### PR TITLE
feat: enable Envoy Gateway / Gateway API CRDs

### DIFF
--- a/infrastructure/clusters/feather-core/base-controllers/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/base-controllers/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
   - metallb
   - ../../../../infrastructure/base/controllers/spegel
   - ../../../../infrastructure/base/controllers/mariadb-operator-crds
-#  - ../../../../infrastructure/base/controllers/envoy-crds
+  - ../../../../infrastructure/base/controllers/envoy-crds


### PR DESCRIPTION
## Summary
This change enables the Envoy Custom Resource Definitions (CRDs) controller in the feather-core cluster configuration by uncommenting the resource reference in the kustomization file.

## Key Changes
- Uncommented the `envoy-crds` controller resource in `infrastructure/clusters/feather-core/base-controllers/kustomization.yaml`
- This enables the Envoy CRDs to be deployed as part of the base controller stack for the feather-core cluster

## Details
The Envoy CRDs controller was previously disabled (commented out) and is now being activated. This will ensure that Envoy-related custom resources are properly defined and available in the cluster.

https://claude.ai/code/session_011nYkhRAzVFCNNqnqva6qWN