### PR TITLE
Add TLS certificates for gateway domains via cert-manager

### DIFF
--- a/infrastructure/clusters/feather-core/configs/gateway/certificates.yaml
+++ b/infrastructure/clusters/feather-core/configs/gateway/certificates.yaml
@@ -1,0 +1,70 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-onelitefeather-dev
+  namespace: envoy
+spec:
+  secretName: wildcard-onelitefeather-dev-tls
+  issuerRef:
+    name: letsencrypt-prod-dns
+    kind: ClusterIssuer
+  privateKey:
+    algorithm: RSA
+    size: 2048
+    rotationPolicy: Always
+  dnsNames:
+    - "*.onelitefeather.dev"
+    - "onelitefeather.dev"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-onelitefeather-net
+  namespace: envoy
+spec:
+  secretName: wildcard-onelitefeather-net-tls
+  issuerRef:
+    name: letsencrypt-prod-dns
+    kind: ClusterIssuer
+  privateKey:
+    algorithm: RSA
+    size: 2048
+    rotationPolicy: Always
+  dnsNames:
+    - "*.onelitefeather.net"
+    - "onelitefeather.net"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: s3-onelitefeather-net
+  namespace: envoy
+spec:
+  secretName: s3-onelitefeather-net-tls
+  issuerRef:
+    name: letsencrypt-prod-dns
+    kind: ClusterIssuer
+  privateKey:
+    algorithm: RSA
+    size: 2048
+    rotationPolicy: Always
+  dnsNames:
+    - "s3.onelitefeather.net"
+    - "*.s3.onelitefeather.net"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: onelitefeather-1lf-link
+  namespace: envoy
+spec:
+  secretName: 1lf-link-tls
+  issuerRef:
+    name: letsencrypt-prod-dns
+    kind: ClusterIssuer
+  privateKey:
+    algorithm: RSA
+    size: 2048
+    rotationPolicy: Always
+  dnsNames:
+    - "1lf.link"

--- a/infrastructure/clusters/feather-core/configs/gateway/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/configs/gateway/kustomization.yaml
@@ -2,4 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - gateway-class.yaml
-  - gateway.yaml
+  - certificates.yaml
+  # gateway.yaml is intentionally deferred to the nginx->Envoy cutover:
+  # creating the Gateway provisions an Envoy data-plane LoadBalancer
+  # (MetalLB IP) and must land together with the ingress-nginx removal
+  # to avoid a 10.200.90.1 conflict (hard cutover).
+  # - gateway.yaml

--- a/infrastructure/clusters/feather-core/configs/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/configs/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
   - postgresql
   - mariadb-galera
-#  - gateway
+  - gateway


### PR DESCRIPTION
## Summary
This PR adds TLS certificate management for the Envoy gateway infrastructure by creating cert-manager Certificate resources for multiple domains and enabling the gateway configuration in the cluster kustomization.

## Key Changes
- **New certificates.yaml**: Added four Certificate resources managed by cert-manager with Let's Encrypt DNS validation:
  - Wildcard certificates for `onelitefeather.dev` and `onelitefeather.net` domains
  - S3 subdomain certificate for `s3.onelitefeather.net`
  - Short URL certificate for `1lf.link`
  
- **Updated gateway kustomization**: Included the new certificates.yaml in the gateway resources and deferred gateway.yaml deployment with detailed comments explaining the nginx→Envoy cutover strategy to avoid IP conflicts

- **Enabled gateway in cluster kustomization**: Uncommented the gateway resource to activate the gateway configuration in the feather-core cluster

## Implementation Details
- All certificates use RSA 2048-bit keys with automatic rotation enabled
- Certificates are deployed to the `envoy` namespace
- TLS secrets are stored with descriptive names matching their domains
- The gateway.yaml deployment is intentionally deferred pending the removal of ingress-nginx to prevent MetalLB IP address conflicts (10.200.90.1)

https://claude.ai/code/session_011nYkhRAzVFCNNqnqva6qWN