### PR TITLE
Disable internal-certificates in gateway kustomization

### DIFF
--- a/infrastructure/clusters/feather-core/configs/gateway/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/configs/gateway/kustomization.yaml
@@ -3,7 +3,11 @@ kind: Kustomization
 resources:
   - gateway-class.yaml
   - certificates.yaml
-  - internal-certificates.yaml
+  # internal-certificates.yaml is intentionally NOT applied here: the
+  # configs Kustomization has wait:true, so failing step-ca HTTP01
+  # certs would block configs -> base-apps -> apps (whole cutover).
+  # Internal-host certs are handled by a separate non-blocking
+  # Kustomization once the ACME-over-Gateway path is fixed.
   - envoyproxy.yaml
   - gateway.yaml
   - redirect-route.yaml


### PR DESCRIPTION
## Summary
Removed the application of `internal-certificates.yaml` from the gateway kustomization to prevent blocking the entire cluster cutover when ACME certificate provisioning fails.

## Key Changes
- Commented out `internal-certificates.yaml` resource from `infrastructure/clusters/feather-core/configs/gateway/kustomization.yaml`
- Added detailed explanation of why this resource is being skipped:
  - The configs Kustomization has `wait:true` enabled, which means any failures in HTTP01 certificate provisioning would block the entire deployment chain (configs → base-apps → apps)
  - Internal host certificates will be handled separately by a dedicated non-blocking Kustomization once the ACME-over-Gateway path is fixed

## Implementation Details
This is a temporary measure to unblock the cluster cutover process. The internal certificate handling will be restored through a separate, non-blocking Kustomization once the underlying ACME certificate provisioning issue is resolved.

https://claude.ai/code/session_011nYkhRAzVFCNNqnqva6qWN