### PR TITLE
Fix TLS certificate references and improve Loki deployment reliability

### DIFF
--- a/apps/base/loki/release.yaml
+++ b/apps/base/loki/release.yaml
@@ -14,7 +14,13 @@ spec:
         namespace: flux-system
   install:
     remediation:
-      retries: 0
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  # Loki SingleBinary + chunk/result caches need more than the
+  # default 5m; the cutover upgrade timed out at ~5m12s.
+  timeout: 20m0s
   interval: 1m0s
   # Default values
   # https://github.com/grafana/helm-charts/blob/main/charts/loki-stack/values.yaml

--- a/infrastructure/clusters/feather-core/base-configs/s3-proxy.yaml
+++ b/infrastructure/clusters/feather-core/base-configs/s3-proxy.yaml
@@ -35,6 +35,8 @@ endpoints:
     - "10.200.1.3"
     - "10.200.1.4"
     - "10.200.1.5"
+    conditions:
+      ready: true
 ---
 apiVersion: v1
 kind: Service

--- a/infrastructure/clusters/feather-core/configs/gateway/gateway.yaml
+++ b/infrastructure/clusters/feather-core/configs/gateway/gateway.yaml
@@ -21,7 +21,12 @@ spec:
       tls:
         mode: Terminate
         certificateRefs:
-          # Public domains - cert-manager DNS01 wildcards (prestaged)
+          # Only secrets that actually exist may be listed: a missing
+          # certificateRef makes the whole HTTPS listener
+          # ResolvedRefs=False (PartiallyInvalidCertificateRef) and
+          # breaks TLS for ALL hosts (incl. s3/public). The internal
+          # *.apps.onelite.feather step-ca secrets are added back here
+          # once they are actually issued.
           - kind: Secret
             name: wildcard-onelitefeather-dev-tls
           - kind: Secret
@@ -30,14 +35,3 @@ spec:
             name: s3-onelitefeather-net-tls
           - kind: Secret
             name: 1lf-link-tls
-          # Internal hosts - step-ca via HTTP01-over-Gateway (issued at cutover)
-          - kind: Secret
-            name: grafana-apps-onelite-feather-tls
-          - kind: Secret
-            name: loki-apps-onelite-feather-tls
-          - kind: Secret
-            name: mimir-apps-onelite-feather-tls
-          - kind: Secret
-            name: node-red-apps-onelite-feather-tls
-          - kind: Secret
-            name: otis-apps-onelite-feather-tls


### PR DESCRIPTION
## Summary
This PR addresses TLS configuration issues in the gateway and improves the reliability of Loki deployments by adjusting timeouts and retry policies.

## Key Changes

- **Gateway TLS Configuration**: Removed references to internal `*.apps.onelite.feather` certificates that don't yet exist. Added detailed comments explaining that missing certificate references cause the entire HTTPS listener to fail with `ResolvedRefs=False`. These internal certificates will be added back once they are issued by step-ca.

- **Loki Helm Release**: 
  - Increased install and upgrade retry attempts from 0 to 3 to handle transient failures
  - Extended deployment timeout from the default 5 minutes to 20 minutes to accommodate Loki SingleBinary startup with chunk/result caches (previous cutover upgrade timed out at ~5m12s)

- **S3 Proxy Endpoints**: Added `ready: true` condition to the S3 endpoint configuration to ensure endpoints are only considered when ready.

## Implementation Details

The gateway change prevents a critical issue where referencing non-existent secrets causes the entire TLS listener to fail, affecting all hosts including public domains. The comment documents this behavior for future reference when internal certificates become available.

The Loki timeout increase is based on observed behavior during cutover, where the deployment legitimately requires more than 5 minutes to fully initialize.

https://claude.ai/code/session_011nYkhRAzVFCNNqnqva6qWN