### PR TITLE
Enable Envoy DaemonSet deployment for gateway

### DIFF
--- a/infrastructure/clusters/feather-core/configs/gateway/envoyproxy.yaml
+++ b/infrastructure/clusters/feather-core/configs/gateway/envoyproxy.yaml
@@ -7,8 +7,13 @@ spec:
   provider:
     type: Kubernetes
     kubernetes:
+      # Run the Envoy data plane as a DaemonSet (one pod per node) -
+      # parity with the replaced ingress-nginx DaemonSet. With
+      # externalTrafficPolicy: Local + MetalLB BGP this makes every
+      # node announce 10.200.90.1, so the external reverse-proxy path
+      # reaches the gateway on any node (and client source IP is kept).
+      envoyDaemonSet: {}
       envoyService:
-        # Drop-in: take over the ingress-nginx LoadBalancer IP + BGP label
         externalTrafficPolicy: Local
         annotations:
           metallb.io/loadBalancerIPs: "10.200.90.1"


### PR DESCRIPTION
## Summary
Configure Envoy proxy to run as a DaemonSet instead of a standard Deployment, achieving feature parity with the replaced ingress-nginx controller and enabling proper traffic distribution across cluster nodes.

## Key Changes
- Added `envoyDaemonSet: {}` configuration to deploy Envoy as a DaemonSet (one pod per node)
- Maintained `externalTrafficPolicy: Local` to preserve client source IP
- Retained MetalLB BGP configuration with fixed LoadBalancer IP (10.200.90.1)

## Implementation Details
With this configuration, every node in the cluster announces the gateway IP (10.200.90.1) via BGP. This ensures that external reverse-proxy traffic can reach the gateway on any node, while the `externalTrafficPolicy: Local` setting preserves the original client source IP without requiring additional NAT hops. This matches the behavior of the previous ingress-nginx DaemonSet setup.

https://claude.ai/code/session_011nYkhRAzVFCNNqnqva6qWN