### PR TITLE
Decouple Loki deployment with dedicated wait:false Kustomization

### DIFF
--- a/apps/clusters/feathre-core/base-apps/kustomization.yaml
+++ b/apps/clusters/feathre-core/base-apps/kustomization.yaml
@@ -12,5 +12,7 @@ resources:
   - leantime
   - mimir
   - grafana
-  - loki
+  # loki is managed by a dedicated wait:false Kustomization
+  # (clusters/feather-core/loki.yaml) so its Ceph-RGW S3 quota
+  # issue does not block base-apps -> apps.
   - alloy

--- a/clusters/feather-core/loki.yaml
+++ b/clusters/feather-core/loki.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: loki
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: configs
+  interval: 1m0s
+  retryInterval: 30s
+  timeout: 20m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./apps/clusters/feathre-core/base-apps/loki
+  prune: true
+  # wait:false on purpose: loki depends on the external Ceph RGW S3
+  # backend whose bucket quota can be exceeded. Health-gating here
+  # must NOT block base-apps -> apps (the rest of the platform).
+  wait: false
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg
+  postBuild:
+    substitute:
+      ALLOWED_CIDRS: "172.16.0.0/16,10.200.0.0/16,192.168.0.0/16"


### PR DESCRIPTION
## Summary
Refactored Loki deployment to use a dedicated Kustomization resource with `wait: false` to prevent its Ceph RGW S3 quota issues from blocking the base-apps to apps deployment pipeline.

## Key Changes
- Created new `clusters/feather-core/loki.yaml` Kustomization resource that manages Loki deployment independently
  - Configured with `wait: false` to allow non-blocking deployment
  - Set dependency on `configs` Kustomization
  - Configured SOPS decryption for secrets management
  - Added ALLOWED_CIDRS substitution for network access control
- Removed Loki from `apps/clusters/feathre-core/base-apps/kustomization.yaml` resources list
  - Added explanatory comments documenting why Loki is managed separately

## Implementation Details
- The dedicated Kustomization allows Loki's external Ceph RGW S3 backend quota issues to be isolated and not cascade to the rest of the platform deployment
- Loki maintains its own deployment lifecycle while the base-apps to apps pipeline remains unblocked
- SOPS GPG decryption is configured for secure secret management
- Network access is restricted to specific CIDR ranges (172.16.0.0/16, 10.200.0.0/16, 192.168.0.0/16)

https://claude.ai/code/session_011nYkhRAzVFCNNqnqva6qWN