### PR TITLE
Bump Helm chart versions for leantime, micronaut, outline, and shlink

### DIFF
--- a/helm/leantime/Chart.yaml
+++ b/helm/leantime/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/micronaut/Chart.yaml
+++ b/helm/micronaut/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/outline/Chart.yaml
+++ b/helm/outline/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/shlink/Chart.yaml
+++ b/helm/shlink/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## Summary
This PR updates the Helm chart versions across multiple application charts to reflect recent changes and improvements to their respective chart templates and configurations.

## Key Changes
- **leantime**: Chart version bumped from 0.1.0 to 0.2.0
- **micronaut**: Chart version bumped from 0.1.0 to 0.2.0
- **outline**: Chart version bumped from 0.2.0 to 0.3.0
- **shlink**: Chart version bumped from 0.1.0 to 0.2.0

## Details
All version updates follow semantic versioning conventions and indicate minor version increments, suggesting new features or non-breaking changes have been introduced to the respective Helm charts. These version bumps should be accompanied by corresponding updates to the chart templates and documentation (not shown in this diff).

https://claude.ai/code/session_011nYkhRAzVFCNNqnqva6qWN