### PR TITLE
Add Redis Sentinel support to Shlink deployment

### DIFF
--- a/apps/clusters/feathre-core/base-apps/shlink/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/shlink/release.yaml
@@ -92,3 +92,9 @@ spec:
           # REDIS_SERVERS as KEY
           secretName: 'shlink-secret'
           enabled: true
+          # Redis is Bitnami replication + Sentinel (masterSet
+          # "mymaster"). shlink must resolve the master via Sentinel,
+          # otherwise lock writes hit a read-only replica (READONLY).
+          # NOTE: the shlink-secret REDIS_SERVERS value must point at
+          # the Sentinel endpoint tcp://redis.redis.svc.cluster.local:26379
+          sentinelService: mymaster

--- a/helm/shlink/Chart.yaml
+++ b/helm/shlink/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/shlink/templates/deployment.yaml
+++ b/helm/shlink/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
               {{- else }}
               value: {{ .Values.shlink.realtime.redis.servers | quote }}
               {{- end }}
+            {{- with .Values.shlink.realtime.redis.sentinelService }}
+            - name: REDIS_SENTINEL_SERVICE
+              value: {{ . | quote }}
+            {{- end }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/helm/shlink/values.yaml
+++ b/helm/shlink/values.yaml
@@ -40,6 +40,10 @@ shlink:
       # REDIS_SERVERS as KEY
       secretName: ''
       enabled: true
+      # Set to the Redis Sentinel master set name to make shlink
+      # resolve the current master via Sentinel (REDIS_SERVERS must
+      # then point at the Sentinel endpoint(s), port 26379).
+      sentinelService: ''
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
## Summary
This PR adds support for Redis Sentinel in the Shlink Helm chart and deployment configuration, enabling automatic master discovery in Redis replication setups.

## Key Changes
- **Helm Chart Version**: Bumped from 0.1.0 to 0.3.0
- **New Configuration Parameter**: Added `sentinelService` field to Redis configuration in `values.yaml` to specify the Redis Sentinel master set name
- **Environment Variable**: Added `REDIS_SENTINEL_SERVICE` environment variable to the Shlink deployment template, conditionally set when `sentinelService` is configured
- **Release Configuration**: Updated the base release manifest with Sentinel configuration for the feathre-core cluster, pointing to the "mymaster" sentinel master set

## Implementation Details
- The `sentinelService` parameter is optional (defaults to empty string) and only adds the environment variable when explicitly set
- When configured, Shlink will resolve the current Redis master via Sentinel instead of connecting directly to a single Redis instance
- The `REDIS_SERVERS` configuration must point to the Sentinel endpoint (port 26379) rather than the Redis instance directly
- This prevents write failures that occur when Shlink attempts to write to a read-only replica in a replication setup
- Includes documentation comments explaining the Sentinel setup requirements and configuration

https://claude.ai/code/session_011nYkhRAzVFCNNqnqva6qWN