### PR TITLE
Disable Sentinel authentication in Redis release config

### DIFF
--- a/infrastructure/clusters/feather-core/controllers/redis/release.yaml
+++ b/infrastructure/clusters/feather-core/controllers/redis/release.yaml
@@ -153,8 +153,9 @@ spec:
       ##
       enabled: true
       ## @param auth.sentinel Enable authentication on sentinels too
-      ##
-      sentinel: true
+      ## Disabled: Predis (shlink) cannot authenticate to Sentinel, so
+      ## master discovery failed. Data-node AUTH (auth.enabled) stays on.
+      sentinel: false
       ## @param auth.password Redis&reg; password
       ## Defaults to a random 10-character alphanumeric string if not set
       ##


### PR DESCRIPTION
## Summary
Disabled authentication on Redis Sentinel nodes in the feather-core cluster configuration due to compatibility issues with the Predis client used by Shlink.

## Key Changes
- Changed `auth.sentinel` from `true` to `false` in the Redis Helm release configuration
- Added explanatory comment documenting that Predis (used by Shlink) cannot authenticate to Sentinel, causing master discovery failures
- Clarified that data-node authentication (`auth.enabled`) remains enabled for security

## Implementation Details
This change resolves a master discovery failure in the Redis cluster where Predis was unable to authenticate against Sentinel nodes. By disabling Sentinel authentication while keeping data-node authentication enabled, the cluster maintains security for actual data access while allowing Shlink to properly discover and connect to Redis master nodes.

https://claude.ai/code/session_011nYkhRAzVFCNNqnqva6qWN