### PR TITLE
Configure Redis Sentinel for Shlink with explicit node list

### DIFF
--- a/apps/clusters/feathre-core/base-apps/shlink/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/shlink/release.yaml
@@ -106,19 +106,23 @@ spec:
             key: GEOLITE_LICENSE_KEY
       - name: REDIS_PUB_SUB_ENABLED
         value: "true"
+      # IMPORTANT: list ALL Bitnami sentinel nodes (port 26379).
+      # shlink-common (RedisFactory::resolveServers) collapses a
+      # single REDIS_SERVERS entry to a non-list, which disables
+      # Predis sentinel mode -> commands hit the sentinel directly
+      # ("unknown command 'EVALSHA'"). With >=2 entries Predis enters
+      # sentinel replication and resolves the master correctly.
+      # Hostnames are not secret; the data-node password comes from
+      # REDIS_SERVERS_PASSWORD. Sentinel URIs carry no password
+      # because redis is deployed with auth.sentinel: false.
+      - name: REDIS_SERVERS
+        value: "tcp://redis-node-0.redis-headless.redis.svc.cluster.local:26379,tcp://redis-node-1.redis-headless.redis.svc.cluster.local:26379,tcp://redis-node-2.redis-headless.redis.svc.cluster.local:26379"
+      - name: REDIS_SENTINEL_SERVICE
+        value: "mymaster"
       - name: REDIS_SERVERS_PASSWORD
         valueFrom:
           secretKeyRef:
             name: shlink-secret
             key: REDIS_SERVERS_PASSWORD
-      - name: REDIS_SERVERS
-        valueFrom:
-          secretKeyRef:
-            name: shlink-secret
-            key: REDIS_SERVERS
-      - name: REDIS_SENTINEL_SERVICE
-        value: "mymaster"
-      - name: REDIS_PUB_SUB_ENABLED
-        value: "true"
       - name: SKIP_INITIAL_GEOLITE_DOWNLOAD
         value: "true"


### PR DESCRIPTION
## Summary
Updated the Shlink Redis configuration to properly support Sentinel mode by explicitly listing all Bitnami Sentinel nodes and moving sensitive credentials to the appropriate configuration layer.

## Key Changes
- **Added explicit Redis Sentinel node list**: Configured `REDIS_SERVERS` with all three Sentinel nodes (redis-node-0, redis-node-1, redis-node-2) on port 26379
- **Added Sentinel service name**: Set `REDIS_SENTINEL_SERVICE` to "mymaster" for proper Sentinel discovery
- **Moved password configuration**: Kept `REDIS_SERVERS_PASSWORD` as a secret reference while making hostnames non-secret
- **Removed secret reference for REDIS_SERVERS**: Changed from secret-based configuration to explicit plaintext hostnames
- **Added comprehensive documentation**: Included detailed comments explaining why multiple Sentinel nodes are required and how Predis handles the configuration

## Implementation Details
The change addresses a critical issue where Predis (the Redis client library used by shlink-common) collapses a single `REDIS_SERVERS` entry into a non-list value, which disables Sentinel mode and causes commands to hit the Sentinel directly instead of the Redis master. By providing at least 2 entries, Predis correctly enters sentinel replication mode and resolves the master node.

Sentinel URIs don't require passwords since Redis is deployed with `auth.sentinel: false`, while the actual data node password is provided separately via `REDIS_SERVERS_PASSWORD`.

https://claude.ai/code/session_011nYkhRAzVFCNNqnqva6qWN