### PR TITLE
feat(feather-core): deploy Ollama CPU inference for n8n classification

### DIFF
--- a/apps/base/ollama/kustomization.yaml
+++ b/apps/base/ollama/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ollama
+resources:
+  - namespace.yaml
+  - release.yaml

--- a/apps/base/ollama/namespace.yaml
+++ b/apps/base/ollama/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ollama

--- a/apps/base/ollama/release.yaml
+++ b/apps/base/ollama/release.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ollama
+  namespace: ollama
+spec:
+  releaseName: ollama
+  chart:
+    spec:
+      chart: ollama
+      sourceRef:
+        kind: HelmRepository
+        name: ollama
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  interval: 1m0s
+  # Default values
+  # https://github.com/otwld/ollama-helm/blob/main/values.yaml
+  values: {}

--- a/apps/clusters/feathre-core/base-apps/kustomization.yaml
+++ b/apps/clusters/feathre-core/base-apps/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - leantime
   - grafana
   - n8n
+  - ollama
   # loki + mimir (later tempo) are managed by the dedicated
   # wait:false monitoring Kustomization
   # (clusters/feather-core/monitoring.yaml) so their external

--- a/apps/clusters/feathre-core/base-apps/ollama/kustomization.yaml
+++ b/apps/clusters/feathre-core/base-apps/ollama/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ollama
+resources:
+  - ../../../../../apps/base/ollama/
+patches:
+  - path: release.yaml

--- a/apps/clusters/feathre-core/base-apps/ollama/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/ollama/release.yaml
@@ -1,0 +1,56 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ollama
+  namespace: ollama
+spec:
+  values:
+    # CPU-only inference. No GPU on these nodes, so keep the GPU integration
+    # off — this also pins the plain (non-rocm/non-cuda) image tag.
+    ollama:
+      gpu:
+        enabled: false
+      models:
+        # Pulled once at container startup, then cached on the PVC below.
+        # qwen2.5:3b-instruct is small enough for responsive CPU inference and
+        # strong at structured classification / JSON output (the n8n use case).
+        # Swap/extend here; every entry adds to first-boot startup time.
+        pull:
+          - qwen2.5:3b-instruct
+
+    # Persist model blobs so a pod restart does not re-download gigabytes.
+    persistentVolume:
+      enabled: true
+      size: 30Gi
+      storageClass: ceph-rbd-fr01
+
+    # CPU inference is compute-bound: more cores ≈ more tokens/sec. Memory must
+    # hold the model (~3-5Gi for a 3B Q4) plus the KV-cache headroom. Tune to
+    # the node's real core count. No CPU limit on purpose — a hard cap would
+    # throttle generation; requests + region pin keep scheduling sane.
+    resources:
+      requests:
+        cpu: "4"
+        memory: 8Gi
+      limits:
+        memory: 16Gi
+
+    # Region pin (matches the other stateful apps).
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+                - key: topology.kubernetes.io/region
+                  operator: In
+                  values:
+                    - fr-rosenau
+
+    # No Ingress / HTTPRoute: Ollama ships NO authentication. It is reached
+    # cluster-internally at http://ollama.ollama.svc.cluster.local:11434 (e.g.
+    # by n8n). Do NOT expose this Service publicly without an auth proxy in
+    # front (Envoy + JWT/basic-auth/SecurityPolicy).
+    service:
+      type: ClusterIP
+      port: 11434

--- a/infrastructure/clusters/feather-core/base-sources/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
   - grafana.yml
   - rook.yaml
   - n8n.yml
+  - ollama.yml

--- a/infrastructure/clusters/feather-core/base-sources/ollama.yml
+++ b/infrastructure/clusters/feather-core/base-sources/ollama.yml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ollama
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: https://otwld.github.io/ollama-helm/


### PR DESCRIPTION
## Was

Deployt **Ollama** (`otwld/ollama-helm`) als cluster-internen, CPU-only LLM-Endpoint für n8n — gedacht für die automatische Moderation/Klassifizierung von Forenbeiträgen.

## Änderungen

- HelmRepository-Source `ollama` + Base-HelmRelease (Default-Values)
- Cluster-Overlay: GPU aus, Modell `qwen2.5:3b-instruct` (Pull beim Start), 30Gi RBD-PVC als Modell-Cache, Region-Pin `fr-rosenau`
- **Nur ClusterIP, keine HTTPRoute** — Ollama hat keine Auth. Erreichbar in-cluster unter `http://ollama.ollama.svc.cluster.local:11434`

## n8n

OpenAI-kompatibel: Base URL `…:11434/v1`, Model `qwen2.5:3b-instruct`, API-Key beliebig. Structured-Output-Parser für saubere Labels.

## Hinweise

- Erster Pod-Start dauert (~2 GB Modell-Pull, danach auf PVC gecached)
- CPU-Inferenz ~5–15 Tok/s — gut für Async/Batch, nicht für Live-Chat
- Personen-Bewertung: nur als Vorschlag, Mensch im Loop (DSGVO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)