### PR TITLE
feat(feather-core): structured otis logging via Alloy

### DIFF
--- a/apps/clusters/feathre-core/apps/otis/release.yaml
+++ b/apps/clusters/feathre-core/apps/otis/release.yaml
@@ -45,16 +45,21 @@ spec:
                 value: /
     profiles: [ "prod" ]
 
+    # Opt in to Alloy's JSON log pipeline (LOG_JSON=true emits structured logs).
+    # Alloy maps this to the "format" stream label -> level/logger/timestamp parsing.
+    podLabels:
+      logs.onelitefeather.net/format: json
+
     config:
       base: |-
         micronaut:
           application:
             name: Otis Backend
-            server:
-              port: 8080
+          server:
+            port: 8080
             netty:
               access-logger:
-                enabled: false
+                enabled: true
       profiles:
         prod: |-
           router:
@@ -81,6 +86,9 @@ spec:
           logger:
             levels:
               root: WARN
+              # Per-request access logs (micronaut.server.netty.access-logger).
+              # root is WARN, so the access logger must be raised explicitly.
+              HTTP_ACCESS_LOGGER: INFO
               "org.hibernate.SQL": WARN
               "org.hibernate.type.descriptor.sql": WARN
               "org.hibernate.orm.connections.pooling": WARN

--- a/apps/clusters/feathre-core/base-apps/alloy/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/alloy/release.yaml
@@ -57,6 +57,14 @@ spec:
               target_label = "part_of"
             }
 
+            // instance distinguishes Helm releases that share a chart name
+            // (e.g. the micronaut chart): app stays "micronaut", instance = release.
+            rule {
+              source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+              action = "replace"
+              target_label = "instance"
+            }
+
             // --- Custom policy labels (onelitefeather.net) ---
             rule {
               source_labels = ["__meta_kubernetes_pod_label_logs_onelitefeather_net_tenant"]
@@ -68,6 +76,16 @@ spec:
               source_labels = ["__meta_kubernetes_pod_label_onelitefeather_net_team"]
               action = "replace"
               target_label = "team"
+            }
+
+            // Log-format opt-in: pods labeled logs.onelitefeather.net/format="json"
+            // get their JSON parsed in loki.process below (level -> label,
+            // logger -> structured metadata, embedded timestamp honoured).
+            // Absent -> label dropped -> stage.match skips them (plain-text default).
+            rule {
+              source_labels = ["__meta_kubernetes_pod_label_logs_onelitefeather_net_format"]
+              action = "replace"
+              target_label = "format"
             }
 
             // --- Identification (higher cardinality, but k8s standard) ---
@@ -102,6 +120,40 @@ spec:
             stage.static_labels {
               values = {
                 cluster = "feather-core",
+              }
+            }
+
+            // Only applied to streams that opted in via logs.onelitefeather.net/format="json".
+            // Plain-text apps fall through untouched (no parse-error spam, no wasted CPU).
+            stage.match {
+              selector = "{format=\"json\"}"
+
+              stage.json {
+                expressions = {
+                  level  = "level",
+                  logger = "logger",
+                  log_ts = "timestamp",
+                }
+              }
+
+              // Use the application's own timestamp instead of the ingest time.
+              stage.timestamp {
+                source = "log_ts"
+                format = "RFC3339Nano"
+              }
+
+              // level is low-cardinality -> a real index label for fast {level="ERROR"} filtering.
+              stage.labels {
+                values = {
+                  level = "level",
+                }
+              }
+
+              // logger is higher-cardinality -> structured metadata, not an index label.
+              stage.structured_metadata {
+                values = {
+                  logger = "logger",
+                }
               }
             }
 


### PR DESCRIPTION
## Problem

Otis logs were already collected by Alloy (verified live: `opened log stream … target=otis/…:app`), but were effectively invisible in Grafana:

1. **Otis is near-silent** — `root: WARN` plus the Netty access logger disabled → 0 log lines after startup (`kubectl logs --since=1h` → 0).
2. **Wrong label to search by** — the micronaut chart hardcodes `app.kubernetes.io/name: micronaut`, so `{app="otis"}` matches nothing; Otis hides in `{app="micronaut"}` and the standard `app.kubernetes.io/instance=otis` was never mapped by Alloy.
3. **JSON never parsed** — Otis emits clean JSON (`LOG_JSON=true`), but the pipeline only set a static `cluster` label, so `level`/`logger` weren't queryable.

## Changes

### Alloy (`base-apps/alloy/release.yaml`) — global, additive
- Map `app.kubernetes.io/instance` → **`instance`** so releases sharing a chart name (micronaut et al.) are distinguishable. Purely additive; existing queries keep working.
- Opt-in label `logs.onelitefeather.net/format` → **`format`** label gates a `stage.match { selector = "{format=\"json\"}" }` block that:
  - parses JSON,
  - promotes **`level`** to an index label (low cardinality → fast `{level="ERROR"}`),
  - stores **`logger`** as structured metadata (higher cardinality),
  - honours the application's own timestamp.
  - Plain-text apps fall through untouched (no parse-error spam, no wasted CPU).

### Otis (`apps/otis/release.yaml`)
- Enable the Netty access logger at the **correct** `micronaut.server.netty.access-logger` path. It was previously mis-nested under `micronaut.application.*` and therefore inert → per-request logs now emitted.
- Raise `HTTP_ACCESS_LOGGER` to `INFO` (root stays `WARN`), otherwise the access logs get swallowed.
- Add podLabel `logs.onelitefeather.net/format: json` to opt into the Alloy JSON pipeline.

## Verification
- Both HelmReleases parse; `helm template` renders cleanly — pod labels include `instance: otis` + `format: json`, and `micronaut.server.netty.access-logger.enabled: true` is correctly nested.
- Loki supports the new pipeline: `schema: v13`, `store: tsdb`, `allow_structured_metadata: true`.
- River syntax reviewed manually (`alloy fmt` CLI not available in this environment).

## After merge (Flux)
1. Alloy DaemonSet picks up the new ConfigMap → reload.
2. Otis Deployment rolls (config checksum changes) → access logger active.
3. In Grafana: `{instance="otis"}`, filter by `{instance="otis", level="WARN"}`, and per-request access logs appear via `HTTP_ACCESS_LOGGER`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)