### PR TITLE
feat: add Kubernetes service discovery RBAC for otis & vulpes

### DIFF
--- a/apps/clusters/feathre-core/apps/otis/release.yaml
+++ b/apps/clusters/feathre-core/apps/otis/release.yaml
@@ -56,7 +56,13 @@ spec:
             - path:
                 type: PathPrefix
                 value: /
-    profiles: [ "prod" ]
+    # "k8s" activates the Micronaut Kubernetes environment so the discovery
+    # client beans (micronaut-kubernetes-discovery-client) come up in-cluster.
+    profiles: [ "prod", "k8s" ]
+
+    # RBAC for in-namespace service discovery (read services/endpoints).
+    rbac:
+      create: true
 
     # Opt in to Alloy's JSON log pipeline (LOG_JSON=true emits structured logs).
     # Alloy maps this to the "format" stream label -> level/logger/timestamp parsing.

--- a/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
+++ b/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
@@ -55,7 +55,13 @@ spec:
             - path:
                 type: PathPrefix
                 value: /
-    profiles: [ "prod" ]
+    # "k8s" activates the Micronaut Kubernetes environment so the discovery
+    # client beans (micronaut-kubernetes-discovery-client) come up in-cluster.
+    profiles: [ "prod", "k8s" ]
+
+    # RBAC for in-namespace service discovery (read services/endpoints).
+    rbac:
+      create: true
 
     # Alloy log pipeline: JSON parsing + per-env stream label.
     podLabels:

--- a/helm/micronaut/Chart.yaml
+++ b/helm/micronaut/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/micronaut/templates/rbac.yaml
+++ b/helm/micronaut/templates/rbac.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.rbac.create -}}
+{{- /*
+  Namespace-scoped read access required by micronaut-kubernetes-discovery-client
+  to discover services in this namespace. Scoped to the release namespace only
+  (own-namespace discovery), so it grants no cross-namespace access.
+*/ -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "micronaut.fullname" . }}-discovery
+  labels:
+    {{- include "micronaut.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "micronaut.fullname" . }}-discovery
+  labels:
+    {{- include "micronaut.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "micronaut.fullname" . }}-discovery
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "micronaut.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/micronaut/values.yaml
+++ b/helm/micronaut/values.yaml
@@ -49,6 +49,13 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# RBAC for Micronaut Kubernetes service discovery.
+# When enabled, creates a namespace-scoped Role + RoleBinding granting the
+# ServiceAccount read access to services and endpoints in the release namespace,
+# as required by micronaut-kubernetes-discovery-client. Off by default.
+rbac:
+  create: false
+
 # This is for setting Kubernetes Annotations to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 podAnnotations: {}


### PR DESCRIPTION
## Why

The backends now ship `micronaut-kubernetes-discovery-client`, but in-cluster the discovery client found nothing — `/health` showed `compositeDiscoveryClient` with an empty `services: {}`. The ServiceAccount had no permission to read `services`/`endpoints`, and the `k8s` Micronaut environment wasn't active.

## What

**Chart `helm/micronaut` (→ 0.4.0)**
- New opt-in `templates/rbac.yaml`: namespace-scoped `Role` + `RoleBinding` granting `get/list/watch` on `services` and `endpoints`, bound to the chart's ServiceAccount. Gated by `rbac.create` (default **false**, so other chart users are unaffected).

**Releases (otis + vulpes-backend)**
- `rbac.create: true`
- `profiles: ["prod", "k8s"]` — the `k8s` environment activates the Micronaut Kubernetes discovery beans in-cluster.

Scope is **own-namespace only** (Role/RoleBinding, not Cluster*), so no cross-namespace access is granted.

## Verification

- `helm lint` ✅
- `helm template … --set rbac.create=true` renders the Role/RoleBinding bound to the correct SA + namespace ✅
- Default render (no override) emits no RBAC ✅
- Both edited release manifests parse as valid YAML ✅

## Rollout note

Requires the backend images that include `micronaut-kubernetes-discovery-client` (Otis & Vulpes PRs). After rollout, `/health` `compositeDiscoveryClient` should list the namespace's services.