### PR TITLE
fix(harbor): single-replica registry + minAvailable PDB

### DIFF
--- a/apps/clusters/feathre-core/base-apps/harbor/pdb.yaml
+++ b/apps/clusters/feathre-core/base-apps/harbor/pdb.yaml
@@ -17,7 +17,11 @@ metadata:
   name: harbor-registry
   namespace: harbor
 spec:
-  maxUnavailable: 1
+  # The registry runs as a single replica (chunked uploads are session-bound to
+  # one pod). minAvailable: 1 keeps that pod up across voluntary disruptions, so
+  # node drains/updates don't silently take the registry down mid-push; draining
+  # its node needs a deliberate cordon/force.
+  minAvailable: 1
   selector:
     matchLabels:
       app: harbor

--- a/apps/clusters/feathre-core/base-apps/harbor/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/harbor/release.yaml
@@ -766,7 +766,12 @@ spec:
       serviceAccountName: ""
       # mount the service account token
       automountServiceAccountToken: false
-      replicas: 2
+      # Single replica on purpose: chunked blob uploads are session-bound to one
+      # registry pod (POST starts the upload, PATCH chunks resume it). With >1
+      # replica the chunk PATCH can land on a different pod that doesn't know the
+      # upload session -> intermittent "failed to send blob (chunk) ... 404".
+      # The harbor-registry PDB (minAvailable: 1) keeps this single pod up.
+      replicas: 1
       revisionHistoryLimit: 10
       nodeSelector: { }
       tolerations: [ ]


### PR DESCRIPTION
## Problem

The Otis `1.15.1-SNAPSHOT` release failed on the chunked image push:
```
failed to send blob (chunk), ref .../onelitefeather/otis:1.15.1-SNAPSHOT: http status: not found [http 404]
```
The release `1.15.0` (same workflow/registry) pushed fine — the failure is **intermittent**.

## Root cause

Chunked blob uploads are **session-bound to one registry pod**: the `POST` opens the upload session, the chunk `PATCH`es resume it. The Harbor registry ran with `replicas: 2`, so a chunk `PATCH` could be routed to a different pod that doesn't know the upload UUID → `404`. The S3/Ceph-RGW `_uploads` state isn't read-after-write consistent enough to make cross-pod resumes reliable. The new snapshot flow doubled push frequency and surfaced it.

## Fix

- **`registry.replicas: 1`** — keeps all chunks of an upload on one pod. Removes HA for the registry component, so:
- **`harbor-registry` PDB → `minAvailable: 1`** — the previous `maxUnavailable: 1` is a no-op for a singleton. `minAvailable: 1` keeps the one registry pod up across voluntary disruptions (node drains during updates) instead of letting it be evicted mid-push.

## Trade-off

Draining the registry's node now requires a deliberate cordon/force (the PDB blocks automatic eviction of the sole pod). Registry **image** updates are unaffected (Deployment rolling update surges a new pod; PDB only governs the eviction API).

## Verification

- Both manifests parse as valid YAML ✅
- Only the registry component changed 2→1; other components' replicas untouched ✅