### PR TITLE
chore: bump otis to 1.16.0 and vulpes to 2.4.1

### DIFF
--- a/apps/clusters/feathre-core/apps/otis/release.yaml
+++ b/apps/clusters/feathre-core/apps/otis/release.yaml
@@ -31,7 +31,7 @@ spec:
     image:
       repository: harbor.onelitefeather.dev/onelitefeather/otis
       pullPolicy: IfNotPresent
-      tag: "1.15.0"
+      tag: "1.16.0"
     imagePullSecrets:
       - name: harbor-pull
     service:

--- a/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
+++ b/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
@@ -30,7 +30,7 @@ spec:
     image:
       repository: harbor.onelitefeather.dev/onelitefeather/vulpes-backend
       pullPolicy: IfNotPresent
-      tag: "2.3.0"
+      tag: "2.4.1"
     imagePullSecrets:
       - name: harbor-pull
     service:


### PR DESCRIPTION
## Why

otis `1.16.0` and vulpes-backend `2.4.1` are the first images built with `micronaut-kubernetes-discovery-client` (PRs Otis#142 / Vulpes#144). With the discovery RBAC + `k8s` profile already on `main` (FLUX#60), rolling these images out makes service discovery actually work — `/health` `compositeDiscoveryClient` should list the namespace's services instead of being empty.

## What

- otis: `1.15.0` → `1.16.0`
- vulpes-backend: `2.3.0` → `2.4.1`

## Verification

- Both release manifests parse as valid YAML ✅
- Only the `image.tag` changed in each ✅

## Note

Vulpes `2.4.1` shows 97 vulnerabilities (34 fixable, incl. High) in the Harbor scan — unrelated to this change; worth a follow-up dependency bump.