### PR TITLE
fix: add application-k8s.yml so otis/vulpes start with the k8s profile

### DIFF
--- a/apps/clusters/feathre-core/apps/otis/release.yaml
+++ b/apps/clusters/feathre-core/apps/otis/release.yaml
@@ -151,6 +151,15 @@ spec:
               registerMbeans: true
               leakDetectionThreshold: 20000
               transactionIsolation: TRANSACTION_READ_COMMITTED
+        # Loaded only in the Kubernetes (k8s) environment. k8s is listed in
+        # profiles so the micronaut-kubernetes discovery beans activate (explicit
+        # MICRONAUT_ENVIRONMENTS disables auto-deduction). The chart requires one
+        # config file per profile, so this file must exist.
+        k8s: |-
+          kubernetes:
+            client:
+              discovery:
+                mode: endpoint
     envFrom:
       - secretRef:
           name: otis-app-db

--- a/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
+++ b/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
@@ -141,6 +141,15 @@ spec:
               registerMbeans: true
               leakDetectionThreshold: 20000
               transactionIsolation: TRANSACTION_READ_COMMITTED
+        # Loaded only in the Kubernetes (k8s) environment. k8s is listed in
+        # profiles so the micronaut-kubernetes discovery beans activate (explicit
+        # MICRONAUT_ENVIRONMENTS disables auto-deduction). The chart requires one
+        # config file per profile, so this file must exist.
+        k8s: |-
+          kubernetes:
+            client:
+              discovery:
+                mode: endpoint
     envFrom:
       - secretRef:
           name: vulpes-app-db


### PR DESCRIPTION
## Incident

After rolling out otis `1.16.0` / vulpes `2.4.1` (with the `k8s` profile), the pods crash-looped on startup:
```
Established active environments: [prod, k8s]
Error starting Micronaut server: Failed to read configuration file: /config/application-k8s.yml
```
(Rollout stuck; `maxUnavailable: 0` kept the old pods serving, so no hard outage.)

## Root cause

The `helm/micronaut` chart derives **both** env vars from `.Values.profiles`:
- `MICRONAUT_ENVIRONMENTS = prod,k8s`
- `MICRONAUT_CONFIG_FILES = …/application.yml,…/application-prod.yml,…/application-k8s.yml`

`MICRONAUT_CONFIG_FILES` entries are mandatory, but the configmap only generates a file for each key in `.Values.config.profiles` — and there was no `k8s` entry → `application-k8s.yml` missing → startup abort.

## Fix

Add a `config.profiles.k8s` entry to both releases so the configmap generates `application-k8s.yml`. `k8s` must remain an explicit profile: an explicit `MICRONAUT_ENVIRONMENTS` disables Micronaut's environment auto-deduction, so the `micronaut-kubernetes` discovery beans (`@Requires(env=KUBERNETES)`) only activate when `k8s` is listed. The new file also carries the k8s-only discovery config.

## Verification

- `helm template` for both releases now renders `application-k8s.yml` in the configmap, and `MICRONAUT_CONFIG_FILES` references only files that exist ✅
- Rendered `application-k8s.yml` is valid YAML ✅
- Both release manifests parse as valid YAML ✅

## Follow-up (chart hardening)

The chart could emit an (empty) `application-<p>.yml` for every profile, or only list existing files in `MICRONAUT_CONFIG_FILES`, so a profile without config can't crash a service again. Out of scope for this hotfix.