### PR TITLE
fix: grant pods read in micronaut discovery RBAC

### DIFF
--- a/helm/micronaut/templates/rbac.yaml
+++ b/helm/micronaut/templates/rbac.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.rbac.create -}}
 {{- /*
-  Namespace-scoped read access required by micronaut-kubernetes-discovery-client
-  to discover services in this namespace. Scoped to the release namespace only
-  (own-namespace discovery), so it grants no cross-namespace access.
+  Namespace-scoped read access for micronaut-kubernetes. services/endpoints are
+  used by the discovery client; pods is read by the KubernetesHealthIndicator
+  (it looks up its own pod for /health). Scoped to the release namespace only,
+  so it grants no cross-namespace access.
 */ -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -12,7 +13,7 @@ metadata:
     {{- include "micronaut.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
-    resources: ["services", "endpoints"]
+    resources: ["services", "endpoints", "pods"]
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Why

otis/vulpes recovered after the discovery rollout, but their logs spam 403s:
```
pods "…" is forbidden: serviceaccount …:…-micronaut cannot get resource "pods" … (KubernetesHealthIndicator)
```
`micronaut-kubernetes` registers a `KubernetesHealthIndicator` that reads the app's own pod for `/health`. The discovery Role (PR #60) only granted `services`/`endpoints`, so the indicator can't read `pods`.

Discovery itself is fine — only `pods` is denied; `services`/`endpoints` work (verified: no 403s for those, discovery client active).

## What

Add `pods` to the namespace-scoped read Role in `helm/micronaut/templates/rbac.yaml`:
`resources: ["services", "endpoints", "pods"]`.

## Verification

- `helm lint` ✅; rendered Role shows `services, endpoints, pods` / `get, list, watch` ✅
- Still namespace-scoped (Role/RoleBinding), no cross-namespace access.

## Alternative (not taken)

Could instead disable the `KubernetesHealthIndicator` to avoid the pods grant and the per-probe API call. Granting read is the simpler, documented option; happy to switch to disabling it if you prefer least-privilege.