### PR TITLE
chore: bump micronaut chart to 0.4.1 to roll out the RBAC pods fix

### DIFF
--- a/helm/micronaut/Chart.yaml
+++ b/helm/micronaut/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## Why

PR #64 added `pods` to the discovery Role but did **not** bump the chart version (left at `0.4.0`). The otis/vulpes HelmReleases use `reconcileStrategy: ChartVersion`, so Flux only re-upgrades when the chart **version** changes. As a result #64's template change never rolled out — the live Role still lacks `pods` and the `KubernetesHealthIndicator` keeps logging 403s.

## What

- `helm/micronaut` chart `0.4.0` → `0.4.1`.

This triggers Flux to re-upgrade both HelmReleases with the updated chart, applying the `pods` read permission.

## Verification

- `helm lint` ✅

## Follow-up

Chart template changes need a version bump to take effect under `ChartVersion` strategy. Alternatively the HelmReleases could switch to `reconcileStrategy: Revision` (upgrade on any source change) — worth considering to avoid this footgun.