### PR TITLE
fix: disable broken KubernetesHealthIndicator for otis and vulpes

### DIFF
--- a/apps/clusters/feathre-core/apps/otis/release.yaml
+++ b/apps/clusters/feathre-core/apps/otis/release.yaml
@@ -156,6 +156,14 @@ spec:
         # MICRONAUT_ENVIRONMENTS disables auto-deduction). The chart requires one
         # config file per profile, so this file must exist.
         k8s: |-
+          # Disable the KubernetesHealthIndicator: the client-java bundled with
+          # micronaut-kubernetes 7.1.1 can't deserialize newer API-server pod
+          # fields (observedGeneration / PodReadyToStartContainers), so every
+          # /health probe logs an ERROR+WARN. Service discovery is unaffected.
+          endpoints:
+            health:
+              kubernetes:
+                enabled: false
           kubernetes:
             client:
               discovery:

--- a/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
+++ b/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
@@ -146,6 +146,14 @@ spec:
         # MICRONAUT_ENVIRONMENTS disables auto-deduction). The chart requires one
         # config file per profile, so this file must exist.
         k8s: |-
+          # Disable the KubernetesHealthIndicator: the client-java bundled with
+          # micronaut-kubernetes 7.1.1 can't deserialize newer API-server pod
+          # fields (observedGeneration / PodReadyToStartContainers), so every
+          # /health probe logs an ERROR+WARN. Service discovery is unaffected.
+          endpoints:
+            health:
+              kubernetes:
+                enabled: false
           kubernetes:
             client:
               discovery:


### PR DESCRIPTION
## Problem

Both `otis` and `vulpes-backend` flood their logs with an ERROR + WARN line every ~5 seconds from `io.micronaut.kubernetes.health.KubernetesHealthIndicator`:

```
ERROR Failed to read Pod [...] from namespace [...]: null
WARN  Error while getting Pod information
  java.lang.IllegalArgumentException: The field 'observedGeneration' in the
  JSON string is not defined in the 'V1PodStatus' properties.
```

## Root cause

The `io.kubernetes:client-java` bundled in **micronaut-kubernetes 7.1.1** uses strict GSON validation (`V1PodStatus.validateJsonElement`) and cannot deserialize the newer fields the ~1.33 API server returns (`observedGeneration`, the `PodReadyToStartContainers` condition). The indicator reads the pod's own status on every `/health` probe, so it throws every time the kubelet probes.

Only the pod-reading health indicator is affected — **service discovery (services/endpoints) keeps working**.

## Fix

Disable the indicator via `endpoints.health.kubernetes.enabled: false` in the `k8s` profile of both HelmReleases. This lives in `spec.values`, so it applies on merge with **no chart-version bump** required.

- `apps/clusters/feathre-core/apps/otis/release.yaml`
- `apps/clusters/feathre-core/apps/vulpes-backend/release.yaml`