### PR TITLE
fix(cloudflare-tunnel): raise proxy keepalive timeout past origin idle gaps

### DIFF
--- a/infrastructure/clusters/feather-core/base-controllers/cloudflare-tunnel-ingress-controller/release.yaml
+++ b/infrastructure/clusters/feather-core/base-controllers/cloudflare-tunnel-ingress-controller/release.yaml
@@ -45,6 +45,14 @@ spec:
         limits:
           cpu: 200m
           memory: 256Mi
+      # Default keepalive on the connector->origin connection is 90s
+      # (cloudflared default). Bursty/gappy origins (e.g. S3 tile uploads
+      # from BlueMap) fall idle past that and pay a full TCP+TLS reconnect
+      # (~700ms observed) on the next request. Raise it well past typical
+      # gaps between uploads. Applies to ALL hosts behind this shared
+      # connector, not just s3.onelitefeather.net.
+      extraArgs:
+        - "--proxy-keepalive-timeout=10m"
     # cloudflared already runs its Prometheus /metrics endpoint on :44483
     # (the controller sets --metrics itself, not configurable via Helm) --
     # this just wires up scraping for it. No tracing equivalent exists:


### PR DESCRIPTION
## Summary
- The Cloudflare Tunnel connector's default origin keepalive is 90s (cloudflared default). Clients with gaps between requests longer than that (e.g. BlueMap tile uploads to s3.onelitefeather.net from an external Helsinki host) pay a full TCP+TLS reconnect on the next request.
- Measured via curl from the affected host: a cold request had a 670ms gap between TLS handshake completion and first byte, while back-to-back requests over a reused connection completed in ~70-100ms total.
- Raises `--proxy-keepalive-timeout` to 10m via `cloudflared.extraArgs` on the shared HelmRelease. This affects all apps behind this tunnel (leantime, uptime-kuma, reposilite, dependency-track, shlink, bluemap, outline, harbor), not just S3 — raising the idle timeout should only help, not hurt, any of them.

## Test plan
- [x] `kubectl kustomize infrastructure/clusters/feather-core/base-controllers/cloudflare-tunnel-ingress-controller` renders `extraArgs` correctly
- [x] `./scripts/validate.sh` passes for all layers
- [ ] After merge + Flux reconcile, repeat the curl idle-gap test against `s3.onelitefeather.net` and confirm TTFB stays low after a >90s gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)