### PR TITLE
fix(rook-fr01): raise RGW beast request_timeout_ms past origin idle gaps

### DIFF
--- a/infrastructure/clusters/feather-core/rook-fr01/cluster/objectstore.yaml
+++ b/infrastructure/clusters/feather-core/rook-fr01/cluster/objectstore.yaml
@@ -38,6 +38,16 @@ spec:
   gateway:
     port: 80
     instances: 3
+    # Beast's own idle-keepalive default (request_timeout_ms) is 65s. In-cluster
+    # clients that talk to the RGW Service directly (bypassing the Cloudflare
+    # Tunnel entirely, e.g. reposilite) can hit the same cold-reconnect pattern
+    # observed on the tunnel path once their pooled connection sits idle past
+    # that. Raised to 10m to match the tunnel-side fix (PR #67).
+    # NOTE: rgwCommandFlags replaces the whole --rgw-frontends value and
+    # restarts all RGW pods on change — port=80 must stay in sync with
+    # spec.gateway.port above.
+    rgwCommandFlags:
+      rgw_frontends: "beast port=80 request_timeout_ms=650000"
     placement:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary
- The Beast frontend's default idle-keepalive (`request_timeout_ms`) is 65s. In-cluster clients that talk to the RGW Service directly (bypassing the Cloudflare Tunnel, e.g. reposilite's `HeadObject` calls) can hit the same cold-reconnect pattern already found on the tunnel path (#67) once a pooled connection sits idle past that.
- Raises it to 10m via `spec.gateway.rgwCommandFlags` on the `CephObjectStore` CR, mirroring the tunnel-side fix.

## Investigation before this change (read-only, live cluster)
- **Bucket sharding (already fine):** `bluemap0` has 23 shards for 2.2M objects (~95k objects/shard), and `rgw_dynamic_resharding` is enabled — no manual resharding needed.
- **Thread pool / concurrency (already fine):** `rgw_thread_pool_size=512` and `rgw_max_concurrent_requests=1024` are already at/above commonly recommended values for small-object workloads.
- **CPU/disk ruled out:** RGW pods use 15-80m CPU with no limit set, nodes sit at 6-8% load, and `ceph osd perf` shows 1ms commit/apply latency on all 12 (SSD) OSDs. `rgw_op` perf counters show `put_obj_lat` averaging ~54ms — consistent with Ceph's well-documented per-PUT bucket-index roundtrip cost, not a resource bottleneck.
- This left the RGW-side idle-connection timeout as the one remaining, actionable lever for the in-cluster (non-tunnel) path.

## ⚠️ Risk / blast radius
`rgwCommandFlags` replaces the **entire** `--rgw-frontends` value and, per Rook's own CRD docs, restarts all 3 RGW pods when applied ("intended for advanced users... use with caution"). A malformed value could crash-loop all RGW pods simultaneously, taking down S3 for every consumer (BlueMap, reposilite, harbor, outline, Loki/Mimir/Tempo storage, Velero and PostgreSQL backups).

Mitigations taken:
- `port=80` kept in sync with `spec.gateway.port`
- Verified `kubectl kustomize` render + `scripts/validate.sh` pass
- Verified `kubectl apply --dry-run=server` accepts the CR against the live CRD schema with no errors

## Test plan
- [x] `kubectl kustomize infrastructure/clusters/feather-core/rook-fr01` renders correctly
- [x] `./scripts/validate.sh` passes
- [x] `kubectl apply --dry-run=server` accepts the schema against the live cluster
- [ ] After merge + Flux reconcile, watch `kubectl get pods -n rook-ceph-fr01 -l app=rook-ceph-rgw` through the restart and confirm all 3 come back healthy
- [ ] Repeat the reposilite `HeadObject` trace check in Tempo after a >65s idle gap to confirm latency improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)