### PR TITLE
feat(harbor): enable OTel tracing via alloy-receiver

### DIFF
--- a/apps/clusters/feathre-core/base-apps/harbor/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/harbor/release.yaml
@@ -447,10 +447,13 @@ spec:
         #   action: replace
 
     trace:
-      enabled: false
+      # Same alloy-receiver OTLP gateway reposilite uses (see its release.yaml),
+      # via the HTTP port instead of gRPC since Harbor's otel provider only
+      # speaks OTLP/HTTP.
+      enabled: true
       # trace provider: jaeger or otel
       # jaeger should be 1.26+
-      provider: jaeger
+      provider: otel
       # set sample_rate to 1 if you wanna sampling 100% of trace data; set 0.5 if you wanna sampling 50% of trace data, and so forth
       sample_rate: 1
       # namespace used to differentiate different harbor services
@@ -469,7 +472,7 @@ spec:
         # export trace data by jaeger.thrift in compact mode
         # agent_port: 6831
       otel:
-        endpoint: hostname:4318
+        endpoint: alloy-receiver.grafana.svc.cluster.local:4318
         url_path: /v1/traces
         compression: false
         insecure: true


### PR DESCRIPTION
## Summary
- Harbor's Helm chart already ships a `trace` block, disabled by default, defaulting to a standalone Jaeger collector config.
- Switches it on with `provider: otel`, pointed at the same `alloy-receiver` OTLP gateway `reposilite` already uses (`apps/clusters/feathre-core/base-apps/reposilite/release.yaml`), over the HTTP port (`:4318`) since Harbor's `otel` exporter only speaks OTLP/HTTP (`url_path: /v1/traces`), not gRPC like reposilite's `:4317`.
- No agent/sidecar needed — this is native support already built into the Harbor chart, just switched on.

## Context
Part of a broader look at where tracing coverage is missing across the cluster (see prior PRs #67, #68 on S3/RGW latency). Harbor was flagged as the easiest win: request-serving (registry push/pull, UI, vuln scans), and the trace config already exists in the chart's values, just needs pointing at our OTLP intake instead of a placeholder hostname.

## Test plan
- [x] `kubectl kustomize apps/clusters/feathre-core/base-apps` renders the `trace` block correctly (`enabled: true`, `provider: otel`, correct endpoint)
- [x] `./scripts/validate.sh` passes
- [ ] After merge + Flux reconcile, confirm Harbor traces show up in Tempo (search by `service.name` for harbor-core/jobservice/registry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)