### PR TITLE
fix(rook): bump operator chart to 1.19.x

### DIFF
--- a/infrastructure/clusters/feather-core/rook/release.yaml
+++ b/infrastructure/clusters/feather-core/rook/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph
-      version: ">=1.18.0 <1.19.0"
+      version: ">=1.19.5 <1.20.0"
       sourceRef:
         kind: HelmRepository
         name: rook-ceph


### PR DESCRIPTION
## Summary
- Stage 1 of the Rook 1.18 -> 1.20 upgrade (docs/superpowers/specs/2026-07-18-rook-operator-upgrade-design.md)
- Bumps the rook-ceph HelmRelease chart constraint to >=1.19.5 <1.20.0, no CSI value changes

## Test plan
- [x] ./scripts/validate.sh passes
- [ ] Merge, reconcile once, confirm `rook` Kustomization Ready and `ceph status` HEALTH_OK before opening the 1.20 PR