### PR TITLE
fix(rook-fr01): bump ceph image to v19.2.5

### DIFF
--- a/infrastructure/clusters/feather-core/rook-fr01/cluster/cluster.yaml
+++ b/infrastructure/clusters/feather-core/rook-fr01/cluster/cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: rook-ceph-fr01
 spec:
   cephVersion:
-    image: quay.io/ceph/ceph:v19.2.3
+    image: quay.io/ceph/ceph:v19.2.5
     allowUnsupported: false
   dataDirHostPath: /var/lib/rook
   skipUpgradeChecks: false


### PR DESCRIPTION
## Summary
- Bumps the CephCluster image tag from v19.2.3 to v19.2.5 (two Squid patch releases behind), same major line
- No breaking changes, independent of the Rook operator upgrade in #72/#73

## Test plan
- [x] ./scripts/validate.sh passes