### PR TITLE
fix(plane): re-revert /silo ingress rule after concurrent merge reintroduced it

### DIFF
--- a/apps/clusters/feathre-core/base-apps/plane/ingress.yaml
+++ b/apps/clusters/feathre-core/base-apps/plane/ingress.yaml
@@ -44,15 +44,6 @@ spec:
                 name: plane-live
                 port:
                   number: 3000
-          # Integrations backend. The chart's SILO_BASE_PATH/SILO_API_BASE_URL
-          # env vars (plane-silo-vars ConfigMap) already assume this exact path.
-          - path: /silo
-            pathType: Prefix
-            backend:
-              service:
-                name: plane-silo
-                port:
-                  number: 3000
           - path: /api
             pathType: Prefix
             backend:


### PR DESCRIPTION
## Summary
- #83 reverted the `/silo` ingress rule to fix the `tasks.onelitefeather.net` DNS-deletion outage (headless Service, see #83 for full root cause).
- A concurrent merge from another branch (unrelated monitoring/grafana work), reconciled against `main` before #83 landed, silently brought the `/silo` rule back when it merged with `origin/main` — undoing #83 and re-triggering the same outage.
- Re-applies the same revert on top of current `main`.

## Test plan
- [x] `./scripts/validate.sh` passes
- [ ] After merge + Flux reconcile, confirm DNS record for tasks.onelitefeather.net exists and the site is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)