### PR TITLE
feat(plane): expose Silo via a dedicated non-headless ClusterIP Service

### DIFF
--- a/apps/clusters/feathre-core/base-apps/plane/ingress.yaml
+++ b/apps/clusters/feathre-core/base-apps/plane/ingress.yaml
@@ -44,6 +44,19 @@ spec:
                 name: plane-live
                 port:
                   number: 3000
+          # Integrations backend. The chart's SILO_BASE_PATH/SILO_API_BASE_URL
+          # env vars (plane-silo-vars ConfigMap) already assume this exact path.
+          # Routed to plane-silo-ingress (silo-service.yaml), NOT the chart's
+          # own "plane-silo" Service — that one is headless (clusterIP: None),
+          # which cloudflare-tunnel-ingress-controller can't parse a backend
+          # for; referencing it here previously took down the whole domain.
+          - path: /silo
+            pathType: Prefix
+            backend:
+              service:
+                name: plane-silo-ingress
+                port:
+                  number: 3000
           - path: /api
             pathType: Prefix
             backend:

--- a/apps/clusters/feathre-core/base-apps/plane/kustomization.yaml
+++ b/apps/clusters/feathre-core/base-apps/plane/kustomization.yaml
@@ -6,6 +6,7 @@ generatorOptions:
 resources:
   - ../../../../../apps/base/plane/
   - ingress.yaml
+  - silo-service.yaml
 patches:
   - path: release.yaml
 

--- a/apps/clusters/feathre-core/base-apps/plane/silo-service.yaml
+++ b/apps/clusters/feathre-core/base-apps/plane/silo-service.yaml
@@ -1,0 +1,18 @@
+# The chart's own "plane-silo" Service is headless (clusterIP: None), which
+# cloudflare-tunnel-ingress-controller can't route to (it fails to parse the
+# *entire* Ingress object when a referenced backend is headless — see the
+# tasks.onelitefeather.net outage this caused). This is a plain ClusterIP
+# Service in front of the same pods, used only as the ingress backend for
+# /silo. Selector must stay in lockstep with the chart's plane-silo Service.
+apiVersion: v1
+kind: Service
+metadata:
+  name: plane-silo-ingress
+spec:
+  type: ClusterIP
+  selector:
+    app.name: plane-plane-silo
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000


### PR DESCRIPTION
## Summary
- Two prior attempts (#82, then re-reverted twice via #83/#84) to route `/silo` directly at the chart's own `plane-silo` Service took down `tasks.onelitefeather.net` entirely, because that Service is headless (`clusterIP: None`) and `cloudflare-tunnel-ingress-controller` fails to parse the *whole* Ingress object when a referenced backend is headless — not just the offending rule.
- This time: adds `plane-silo-ingress`, a plain `ClusterIP` Service selecting the same pods (`app.name: plane-plane-silo`), used only as the ingress backend. The chart's own headless Service is untouched.
- `/silo` now routes to `plane-silo-ingress` instead.

## Test plan
- [x] `./scripts/validate.sh` passes
- [x] `kubectl kustomize` confirms `plane-silo-ingress` renders `type: ClusterIP` with **no** `clusterIP: None`
- [x] `kubectl kustomize` confirms `/silo` is ordered ahead of `/api`/`/auth`, consistent with the rest of the file
- [ ] **Please review before merge** given the history of this exact rule taking the domain down twice
- [ ] After merge + Flux reconcile: confirm `plane-silo-ingress` gets a real ClusterIP allocated in-cluster, `tasks.onelitefeather.net` stays reachable throughout, and `/silo` reaches the plane-silo backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)