### PR TITLE
fix(plane): resolve length-based path collisions in cloudflare-tunnel ingress

### DIFF
--- a/apps/clusters/feathre-core/base-apps/plane/ingress.yaml
+++ b/apps/clusters/feathre-core/base-apps/plane/ingress.yaml
@@ -10,26 +10,60 @@ spec:
     - host: tasks.onelitefeather.net
       http:
         paths:
-          # cloudflare-tunnel-ingress-controller matches path rules by substring,
-          # not path-prefix. Hashed web bundle filenames like auth.service-*.js
-          # and api.service-*.js contain "/auth"/"/api" as a substring (right at
-          # the /assets + filename boundary) and get misrouted to plane-api,
-          # breaking the SPA's auth bootstrap. This rule must stay first so it
-          # wins the match before /api and /auth are ever checked.
-          - path: /assets
-            pathType: Prefix
-            backend:
-              service:
-                name: plane-web
-                port:
-                  number: 3000
-          - path: /spaces
+          # ============================================================
+          # IMPORTANT — how cloudflare-tunnel-ingress-controller actually
+          # matches these paths (verified against its source, v0.0.23,
+          # pkg/cloudflare-controller/tunnel-client.go):
+          #
+          #   1. Rules for one hostname are sorted by len(path) DESCENDING
+          #      before being pushed to Cloudflare. The order they're
+          #      written in below has NO effect on evaluation order.
+          #   2. Each rule's "path" becomes a Cloudflare Tunnel ingress
+          #      `path`, which is an UNANCHORED regex — it matches if the
+          #      text appears ANYWHERE in the request path, not just as a
+          #      leading prefix. cloudflared evaluates the length-sorted
+          #      list top to bottom; first match wins.
+          #   3. Consequence: any two rules of EQUAL path length race in
+          #      an unspecified (non-deterministic sort) order if both
+          #      match the same request. Every rule below MUST have a
+          #      length distinct from any other rule it could plausibly
+          #      collide with. Two known, deliberately-resolved cases:
+          #        - plane-web's hashed bundle "/assets/*.js" vs
+          #          plane-api's "/api/assets/*" upload endpoints — both
+          #          contain "/assets" as a substring.
+          #        - plane-space's own "/spaces/assets/*.js" bundle vs
+          #          the same generic "/assets" rule.
+          #      Both were live outages/breakage before being split out
+          #      into their own longer, more specific rules below.
+          #      /silo, /live, /auth are still tied at 5 chars — left
+          #      alone since no real path has been found that matches
+          #      more than one of them, but treat any future addition of
+          #      an endpoint containing one of those words as a substring
+          #      as a potential silent misroute until re-verified.
+          # ============================================================
+
+          # plane-space's own hashed JS/CSS bundle, e.g.
+          # /spaces/assets/entry.client-*.js — must outrank the generic
+          # /assets rule (both would otherwise tie at 7 chars).
+          - path: /spaces/assets
             pathType: Prefix
             backend:
               service:
                 name: plane-space
                 port:
                   number: 3000
+
+          # Asset upload/attachment API (plane.app.urls, mounted at /api/),
+          # e.g. /api/assets/v2/workspaces/<slug>/ — must outrank the
+          # generic /assets rule (both would otherwise tie at 7 chars).
+          - path: /api/assets
+            pathType: Prefix
+            backend:
+              service:
+                name: plane-api
+                port:
+                  number: 8000
+
           - path: /god-mode
             pathType: Prefix
             backend:
@@ -37,19 +71,35 @@ spec:
                 name: plane-admin
                 port:
                   number: 3000
-          - path: /live
+
+          - path: /spaces
             pathType: Prefix
             backend:
               service:
-                name: plane-live
+                name: plane-space
                 port:
                   number: 3000
+
+          # plane-web's own hashed JS/CSS bundle, e.g. /assets/auth.service-*.js
+          # or /assets/api.service-*.js. Some filenames contain "/auth" or
+          # "/api" as a substring (right at the /assets + filename boundary)
+          # — this rule's length (7) must stay longer than /auth (5) and
+          # /api (4) so it's evaluated first for those.
+          - path: /assets
+            pathType: Prefix
+            backend:
+              service:
+                name: plane-web
+                port:
+                  number: 3000
+
           # Integrations backend. The chart's SILO_BASE_PATH/SILO_API_BASE_URL
-          # env vars (plane-silo-vars ConfigMap) already assume this exact path.
-          # Routed to plane-silo-ingress (silo-service.yaml), NOT the chart's
-          # own "plane-silo" Service — that one is headless (clusterIP: None),
-          # which cloudflare-tunnel-ingress-controller can't parse a backend
-          # for; referencing it here previously took down the whole domain.
+          # env vars (plane-silo-vars ConfigMap) already assume this exact
+          # path. Routed to plane-silo-ingress (silo-service.yaml), NOT the
+          # chart's own "plane-silo" Service — that one is headless
+          # (clusterIP: None), which this controller can't parse a backend
+          # for; referencing it directly previously took down the whole
+          # domain (see git history on this file).
           - path: /silo
             pathType: Prefix
             backend:
@@ -57,13 +107,15 @@ spec:
                 name: plane-silo-ingress
                 port:
                   number: 3000
-          - path: /api
+
+          - path: /live
             pathType: Prefix
             backend:
               service:
-                name: plane-api
+                name: plane-live
                 port:
-                  number: 8000
+                  number: 3000
+
           - path: /auth
             pathType: Prefix
             backend:
@@ -71,6 +123,15 @@ spec:
                 name: plane-api
                 port:
                   number: 8000
+
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: plane-api
+                port:
+                  number: 8000
+
           - path: /
             pathType: Prefix
             backend:


### PR DESCRIPTION
## Root cause (finally found the real mechanism)

Pulled and read the controller's actual source (`STRRL/cloudflare-tunnel-ingress-controller` v0.0.23, `pkg/cloudflare-controller/tunnel-client.go`). It:

1. Sorts all Ingress paths for one hostname by `len(path)` **descending** before pushing them to Cloudflare — YAML declaration order has no effect on evaluation order.
2. Passes each path straight through as a Cloudflare Tunnel `path`, which is an **unanchored regex** matched anywhere in the request path, not just as a prefix.
3. cloudflared evaluates the length-sorted list top to bottom, first match wins. Rules of equal length race in an unspecified order (Go's `slices.SortFunc` isn't stable).

This means every previous fix to this file that reasoned about "declaration order" (mine included) was based on a wrong model that happened to coincidentally work for some cases.

## What was actually broken, live, right now

- `/api/assets/v2/workspaces/<slug>/` (Plane's asset/attachment upload API) — misrouted to `plane-web`, 405. Confirmed via browser + direct in-pod curl. Both `/api/assets/...` and `/assets` tie at 7 characters.
- `/spaces/assets/*.js` (plane-space's own hashed JS/CSS bundle) — also misrouted to `plane-web`, served `index.html` instead of JS (same 7-char tie). This silently broke Plane's public "Spaces" view.

## Fix

Adds two deliberately longer, more specific rules (`/api/assets`, `/spaces/assets`) that always sort ahead of the generic `/assets` rule, regardless of tie-break order. Rewrote the file's comments to document the real mechanism instead of the wrong "must stay first" reasoning from before.

`/silo`, `/live`, `/auth` remain tied at 5 characters — left alone since no real endpoint has been found that collides between them, but flagged in-file as a residual risk for future additions.

## Verification

- `./scripts/validate.sh` passes clean.
- Wrote a routing simulator that models the exact sort+unanchored-regex algorithm from the controller source, ran it against the **actual rendered YAML** (`kubectl kustomize` output parsed and fed through the simulator), covering every currently-known real path (web bundle files, api/assets uploads, god-mode assets, spaces assets, silo, live, auth, catch-all). All pass.
- Confirmed live, currently, that both `/api/assets/...` and `/spaces/assets/...` are broken on the deployed ingress (pre-fix), and that `/god-mode/assets/...` is currently fine (naturally wins by length coincidence, 9 > 7 — no change needed there).

## Test plan
- [x] `./scripts/validate.sh` passes
- [x] Routing simulation against real rendered YAML passes for all known paths
- [ ] **Please review before merge**, per the history of this file
- [ ] After merge + Flux reconcile: confirm `tasks.onelitefeather.net` stays up throughout, `/api/assets/...` upload works, `/spaces/...` public view loads its JS correctly, `/silo` and `/god-mode` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)