### PR TITLE
feat(sops): add scripts/rekey.sh so the re-key list cannot drift

### DIFF
--- a/scripts/rekey.sh
+++ b/scripts/rekey.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Re-encrypt every SOPS-encrypted file in this repo to the recipient set
+# currently listed in .sops.yaml. Run from anywhere; it cd's to the repo root.
+#
+#   ./scripts/rekey.sh          re-key every encrypted file
+#   ./scripts/rekey.sh --list   print the file list and exit (used by verification)
+#
+# Run this after ANY edit to .sops.yaml — adding a recipient, removing one,
+# or rotating a key. `sops updatekeys` is a no-op on a file whose recipients
+# already match, so re-running is always safe.
+#
+# The suffix list below mirrors the path_regex in .sops.yaml. If you add a
+# suffix there, add it here. `.sops.yaml` itself is excluded: it is config,
+# not ciphertext, and `sops updatekeys` on it errors.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+mapfile -t FILES < <(
+  find apps infrastructure clusters -type f \
+    \( -name '*.sops.env' \
+    -o -name '*.sops.yaml' -o -name '*.sops.yml' \
+    -o -name '*.sops.json' \
+    -o -name '*.sops.conf' \
+    -o -name '*.sops.crt' \
+    -o -name '*.sops.key' \
+    -o -name '*.dockerconfigjson' \
+    -o -name '*.s3.conf' \
+    -o -name '*.env' \) \
+    ! -name '.sops.*' \
+    | sort
+)
+
+if [[ "${#FILES[@]}" -eq 0 ]]; then
+  echo "error: no encrypted files found — wrong directory?" >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "--list" ]]; then
+  printf '%s\n' "${FILES[@]}"
+  exit 0
+fi
+
+echo "re-keying ${#FILES[@]} file(s) against $(pwd)/.sops.yaml"
+for f in "${FILES[@]}"; do
+  printf '  %s\n' "$f"
+  sops updatekeys -y "$f"
+done
+echo
+echo "done: ${#FILES[@]} file(s) re-keyed"
+echo "now verify every file carries every recipient:"
+echo "  ./scripts/rekey.sh --list | xargs grep -L <RECIPIENT>   # must print nothing"


### PR DESCRIPTION
Implements Task 2 of `docs/superpowers/plans/2026-08-03-sops-key-custody-and-rotation-hygiene.md` (PR #91).

## Why

`docs/sops.md` tells you to re-key with hand-written `find` invocations after
changing a recipient. Those lists have drifted from the `path_regex` in
`.sops.yaml`. The consequence of an incomplete re-key is not a loud failure —
it is a file that is still encrypted to the *old* recipient set and that
nobody notices until someone needs to decrypt it.

## What

One script that derives its file list from the same suffixes `.sops.yaml`
matches, so the two cannot drift apart without someone editing both.

```console
$ ./scripts/rekey.sh --list | wc -l
72
```

## Verification

| Check | Result |
|---|---|
| `--list` file count | `72` |
| `.sops.yaml` manifests included | `2` (the real encrypted ones) |
| `.sops.yaml` *config* wrongly included | `0` |
| Encrypted files missed by the script | none — diffed `--list` against a `grep -rl 'sops:\|ENC[AES256_GCM'` over `apps/ infrastructure/ clusters/` |
| `./scripts/validate.sh` | exit 0, no errors |

The `! -name '.sops.*'` predicate is load-bearing: `find -name '*.sops.yaml'`
*does* match a leading dot, so without it the config file would be handed to
`sops updatekeys`, which errors out.

Adds a file under `scripts/` only — no manifests, nothing reconciles from this.
Rewriting `docs/sops.md` to point at it is a separate PR (Task 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZ7or95EosGNvwceYV5UA