### PR TITLE
ci: validate against kubernetes 1.36 instead of 1.31

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -6,7 +6,9 @@ set -euo pipefail
 
 KUSTOMIZE_VERSION="${KUSTOMIZE_VERSION:-5.7.1}"
 KUBECONFORM_VERSION="${KUBECONFORM_VERSION:-0.7.0}"
-KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.31.0}"
+# Keep in step with the live cluster (`kubectl get nodes`), otherwise CI
+# validates against APIs the cluster no longer serves.
+KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.36.0}"
 
 BIN_DIR="$(mktemp -d)"
 trap 'rm -rf "${BIN_DIR}"' EXIT


### PR DESCRIPTION
Part of Task 1 of `docs/superpowers/plans/2026-08-03-ci-as-a-merge-gate.md` (PR #91),
split out as its own change because it is provable on its own.

## Why

`scripts/validate.sh` pinned `KUBERNETES_VERSION=1.31.0`. The cluster runs
**v1.36.1** (`kubectl get nodes` → all ten nodes on v1.36.1). CI was validating
against a five-minor-versions-old API surface, so a manifest using something
removed between 1.31 and 1.36 would pass CI and then fail to apply.

## Verification

The tree already validates clean at 1.36.0, so this bump does not paper over
or surface any existing breakage — it only closes the window going forward:

```console
$ KUBERNETES_VERSION=1.36.0 ./scripts/validate.sh
EXIT=0
```

13 kustomize builds, 0 errors, 0 invalid resources. Same result as the 1.31.0
baseline, which is exactly what should happen.

## Scope

Deliberately just the version pin. The rest of that task — checksumming the
tooling downloads and factoring the shared install step out of the workflow —
is separate.

This does **not** address the larger gap: `-ignore-missing-schemas` means CRDs
(HelmRelease, Kustomization, CephCluster, CNPG Cluster, …) are still skipped
entirely. That is Tasks 3–4 of the same plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZ7or95EosGNvwceYV5UA