### PR TITLE
fix(tempo): restore the gateway podantiaffinity

### DIFF
--- a/apps/clusters/feathre-core/monitoring/tempo/release.yaml
+++ b/apps/clusters/feathre-core/monitoring/tempo/release.yaml
@@ -289,6 +289,10 @@ spec:
         limits:
           cpu: 500m
           memory: 128Mi
+      # This block replaces the chart's default affinity wholesale, so the
+      # podAntiAffinity has to be restated here — without it the only spread
+      # signal left is the chart's zone-keyed topologySpreadConstraint, which
+      # is a no-op on a single-zone cluster (all nodes are zone fr01).
       affinity: |
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -299,6 +303,15 @@ spec:
                     operator: In
                     values:
                       - fr01
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: tempo
+                    app.kubernetes.io/component: gateway
+                topologyKey: kubernetes.io/hostname
       ingress:
         enabled: false
     metaMonitoring:


### PR DESCRIPTION
Implements Task 2 of `docs/superpowers/plans/2026-08-03-workload-resilience-and-pod-hardening.md`.

## The problem, live

```console
$ kubectl get pods -n grafana -l app.kubernetes.io/component=gateway -o wide
tempo-gateway-6c5bdf4959-97dmf   fr01-wrk-xl-02
tempo-gateway-6c5bdf4959-qw7fq   fr01-wrk-xl-02
```

Both replicas on one node. The gateway is the sole read **and** write path for
traces, sitting in front of the 3-replica ingester/querier/distributor HA that
ca12af1 deliberately built — so that HA currently terminates at a single-node
choke point.

## Why it happened

The `gateway.affinity` override sets **only** `nodeAffinity`. Helm replaces the
chart's default affinity wholesale rather than merging, so the chart's
`podAntiAffinity` is dropped. Every sibling component — distributor, ingester,
querier, queryFrontend, compactor, metricsGenerator — restates `podAntiAffinity`
in its own override. `gateway` is the only one that does not.

That leaves the chart's `topologySpreadConstraint` as the only spread signal,
and it is inert here:

```console
$ kubectl get nodes -L topology.kubernetes.io/zone   # → one distinct value
fr01
$ kubectl get deploy tempo-gateway -n grafana -o json | jq '.spec.template.spec.topologySpreadConstraints'
[{"topologyKey":"topology.kubernetes.io/zone","maxSkew":1,"whenUnsatisfiable":"ScheduleAnyway", ...}]
```

Every node is in zone `fr01`, so all pods occupy one topology domain and
`maxSkew: 1` is satisfied unconditionally. A guaranteed no-op.

## The fix

Restates `podAntiAffinity` in the same shape the siblings use, keyed on
`kubernetes.io/hostname`. `preferred`, not `required`, so a single schedulable
node still takes both replicas rather than leaving one `Pending`.

## Verification

- Rendered overlay carries both `nodeAffinity` and `podAntiAffinity`.
- The label selector was checked against the running pods — it matches **2 of 2**.
  (A selector that matched nothing would fail exactly as silently as the bug.)
- `./scripts/validate.sh` exits 0.

## Blast radius

A rolling restart of the 2 gateway pods on the next Helm upgrade. Trace ingest
and query go through this Deployment, so expect a brief blip as pods cycle one
at a time. Nothing else is touched. Rollback is reverting this commit.

The replicas will not redistribute on their own — the scheduler only applies
affinity at placement time. The rollout is what moves them; confirm afterwards
with the `get pods -o wide` above showing two different nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZ7or95EosGNvwceYV5UA