### PR TITLE
fix(loki): give the gateway two replicas, anti-affinity and a pdb

### DIFF
--- a/apps/clusters/feathre-core/monitoring/loki/release.yaml
+++ b/apps/clusters/feathre-core/monitoring/loki/release.yaml
@@ -257,6 +257,12 @@ spec:
       nodeSelector:
         topology.kubernetes.io/zone: fr01
     gateway:
+      # 2 replicas: the gateway is the sole read AND write path for all logs,
+      # and it was the only Loki component left at the chart default of 1.
+      # This also switches on the chart's gateway PodDisruptionBudget, which
+      # is templated on `replicas > 1` and has no value of its own — at 1
+      # replica there was no PDB at all, unlike every sibling.
+      replicas: 2
       podLabels:
         logs.onelitefeather.net/env: prod
       resources:
@@ -265,6 +271,10 @@ spec:
           memory: 32Mi
         limits:
           memory: 128Mi
+      # This block replaces the chart's default affinity wholesale. The chart
+      # default is a *hard* podAntiAffinity on hostname; restating it here as
+      # preferred keeps both replicas schedulable if only one node is
+      # available, which for the sole log path beats leaving one Pending.
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -275,6 +285,15 @@ spec:
                     operator: In
                     values:
                       - fr01
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: loki
+                    app.kubernetes.io/component: gateway
+                topologyKey: kubernetes.io/hostname
       ingress:
         enabled: false
     lokiCanary:


### PR DESCRIPTION
Implements Task 3 of `docs/superpowers/plans/2026-08-03-workload-resilience-and-pod-hardening.md`.
Same defect class as #96.

## The problem, live

```console
$ kubectl get deploy loki-gateway -n grafana        # replicas: 1
$ kubectl get pdb -n grafana | grep loki
loki-distributor      N/A  1  1
loki-index-gateway    N/A  1  1
loki-ingester         N/A  1  1
loki-querier          N/A  1  1
loki-query-frontend   N/A  1  1
loki-query-scheduler  N/A  1  1
#   ...no loki-gateway
```

One replica, no PDB — for the component that is the sole read **and** write
path for every log in the cluster. It is the only Loki component still at the
chart default; all six siblings run 2 with a PDB. `mimir-gateway` and
`tempo-gateway` both have PDBs too, so this is an outlier in its own namespace.

## Why `maxUnavailable` is not the fix here

The siblings get their PDB from `maxUnavailable: 1` in values. That does not
work for the gateway — the chart has no `gateway.maxUnavailable` and no
`gateway.podDisruptionBudget`. Checked against the chart actually in use
(`loki` 7.2.0, per `status.history[0].chartVersion`):

```gotemplate
{{- if or
  (and (not .Values.gateway.autoscaling.enabled) (gt (int .Values.gateway.replicas) 1))
  ...
spec:
  ...
  maxUnavailable: 1
```

`templates/gateway/poddisruptionbudget-gateway.yaml` fires on **`replicas > 1`**
alone, with `maxUnavailable` hardcoded. So `replicas: 2` is what creates the PDB.

## Anti-affinity

Identical defect to #96: Helm replaces the chart's `affinity` wholesale, and the
override set only `nodeAffinity`, dropping the chart's default. The chart default
here is a **hard** (`required`) podAntiAffinity on `kubernetes.io/hostname`.

Restated as **preferred**, deliberately. For the sole log path, two replicas
sharing a node still serves traffic; a `Pending` second replica puts you back at
one. Documented in the manifest comment.

## Verification

- Label selector checked against the running pod — matches.
- `logs.onelitefeather.net/env` confirmed absent from the Deployment selector
  (this repo's known immutable-selector trap); this change does not touch labels.
- `./scripts/validate.sh` exits 0.

## Blast radius

Scales 1 → 2 pods (requests 10m CPU / 32Mi each) and creates a PDB. The existing
pod is not disrupted by the scale-up; the affinity change does trigger a rolling
replacement on the next Helm upgrade, so expect a brief blip on the log path.
Rollback is reverting this commit.

Note the new PDB is `maxUnavailable: 1` on 2 replicas, so it permits exactly one
disruption — it will not block node drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZ7or95EosGNvwceYV5UA