### PR TITLE
fix(metallb): add the feather-platform priority class

### DIFF
--- a/infrastructure/clusters/feather-core/base-controllers/metallb/kustomization.yml
+++ b/infrastructure/clusters/feather-core/base-controllers/metallb/kustomization.yml
@@ -3,9 +3,12 @@ namespace: metallb-system
 resources:
   - github.com/metallb/metallb/config/native?ref=v0.16.1
 
-# Upstream MetalLB manifests ship no resource requests/limits, leaving the
-# controller and speakers BestEffort (first to be evicted — would drop BGP
-# announcements). Inject modest requests + memory limits.
+# Upstream MetalLB manifests ship no resource requests/limits and no
+# priorityClassName, leaving the controller and speakers BestEffort at
+# priority 0 — first to be evicted, which would drop BGP announcements and
+# with them every LoadBalancer IP in the cluster. Inject modest requests +
+# memory limits, and feather-platform to match the other edge components
+# (envoyproxy, cloudflare-tunnel).
 patches:
   - patch: |
       apiVersion: apps/v1
@@ -15,6 +18,7 @@ patches:
       spec:
         template:
           spec:
+            priorityClassName: feather-platform
             containers:
               - name: controller
                 resources:
@@ -31,6 +35,7 @@ patches:
       spec:
         template:
           spec:
+            priorityClassName: feather-platform
             containers:
               - name: speaker
                 resources:


### PR DESCRIPTION
Implements Task 6 of `docs/superpowers/plans/2026-08-03-workload-resilience-and-pod-hardening.md`.

## The file already documents the failure it does not fully prevent

`base-controllers/metallb/kustomization.yml` carries this comment:

> Upstream MetalLB manifests ship no resource requests/limits, leaving the
> controller and speakers BestEffort (**first to be evicted — would drop BGP
> announcements**). Inject modest requests + memory limits.

The QoS half was fixed. The priority half was not:

```console
$ kubectl get pods -n metallb-system -o custom-columns='NAME:.metadata.name,PC:.spec.priorityClassName'
controller-5ffb5cd688-xl46m   <none>
speaker-6sh4l                 <none>
…7 speakers, all <none>
```

Priority 0 means they are still first in line when the kubelet evicts under node
pressure — the exact outcome the comment warns about. Losing the speakers drops
the BGP announcements and with them **every LoadBalancer IP in the cluster**:
the Envoy gateway, MaxScale, Dragonfly.

`feather-platform` (900000000) is what the other edge components already use
(`envoyproxy.yaml`, `cloudflare-tunnel-ingress-controller/release.yaml`).

## Verification

`priorityClassName` belongs on `spec.template.spec`, not inside the container
block. Checked against the rendered output rather than assumed — a key in the
wrong place here would be silently dropped, not rejected:

```console
$ kubectl kustomize infrastructure/clusters/feather-core/base-controllers/metallb
Deployment/controller: priorityClassName=feather-platform  requests={'cpu': '25m', 'memory': '64Mi'}
DaemonSet/speaker:     priorityClassName=feather-platform  requests={'cpu': '25m', 'memory': '64Mi'}
```

`./scripts/validate.sh` exits 0.

## Blast radius

A pod-template change, so both roll:

- **controller** — single Deployment, brief restart. It only assigns IPs; existing
  assignments are unaffected.
- **speaker** — DaemonSet across all 10 nodes, `maxSurge: 0, maxUnavailable: 1`,
  so one node at a time. Each speaker withdraws and re-establishes its BGP
  session as it cycles. With the other nine still announcing, traffic should
  reroute rather than drop, but this does touch the BGP path to every
  LoadBalancer IP — worth merging when you can watch it rather than unattended.

Rollback is reverting this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZ7or95EosGNvwceYV5UA