### PR TITLE
fix(flux): pin the base-apps chart versions

### DIFF
--- a/apps/base/alloy-logs/release.yaml
+++ b/apps/base/alloy-logs/release.yaml
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: alloy
+      version: "=1.11.0"
       sourceRef:
         kind: HelmRepository
         name: grafana-labs

--- a/apps/base/alloy-metrics/release.yaml
+++ b/apps/base/alloy-metrics/release.yaml
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: alloy
+      version: "=1.11.0"
       sourceRef:
         kind: HelmRepository
         name: grafana-labs

--- a/apps/base/alloy-receiver/release.yaml
+++ b/apps/base/alloy-receiver/release.yaml
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: alloy
+      version: "=1.11.0"
       sourceRef:
         kind: HelmRepository
         name: grafana-labs

--- a/apps/base/grafana/release.yaml
+++ b/apps/base/grafana/release.yaml
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: grafana
+      version: "=10.5.15"
       sourceRef:
         kind: HelmRepository
         name: grafana-labs

--- a/apps/base/ollama/release.yaml
+++ b/apps/base/ollama/release.yaml
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: ollama
+      version: "=1.71.0"
       sourceRef:
         kind: HelmRepository
         name: ollama

--- a/apps/clusters/feathre-core/base-apps/node-red/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/node-red/release.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "*"
+      version: "=0.40.2"
   values:
     podLabels:
       logs.onelitefeather.net/env: prod

--- a/apps/clusters/feathre-core/base-apps/reposilite/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/reposilite/release.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: ">=1.3.20"
+      version: "=1.3.28"
   postRenderers:
     - kustomize:
         patches:


### PR DESCRIPTION
Implements Task 5 of `docs/superpowers/plans/2026-08-03-flux-release-control-and-convergence.md`.

## Why

22 of 36 HelmReleases in this cluster resolve a floating constraint. Seven of
them are in `base-apps`. The drift this permits is not theoretical — `cert-manager`
is declared `>=1.14.4` and is running **v1.21.1**, seven minor versions on, with
no PR and no commit to revert.

| Release | Was | Now |
|---|---|---|
| grafana | *(none)* | `=10.5.15` |
| alloy-logs / -metrics / -receiver | *(none)* | `=1.11.0` |
| ollama | *(none)* | `=1.71.0` |
| node-red | `"*"` | `=0.40.2` |
| reposilite | `">=1.3.20"` | `=1.3.28` |

## This changes nothing that is running

Every pin is the version **currently deployed**, read from
`status.history[0].chartVersion` — deliberately not upstream latest. The next
Helm reconcile resolves to the same chart it already has.

## Every pin was proven to resolve first

`base-apps` is `wait: true` and the `apps` layer `dependsOn` it, so an
unresolvable constraint here does not break one release — it stalls **every app
deploy**. Checked against the live HelmRepository indices before writing:

```console
grafana-labs/grafana       10.5.15   JA
grafana-labs/alloy         1.11.0    JA
ollamarepo/ollama          1.71.0    JA
nodered/node-red           0.40.2    JA
reposilite/reposilite      1.3.28    JA
```

Rendered `base-apps` overlay confirms all seven carry their pin.
`./scripts/validate.sh` exits 0.

## Scope

Pins go where the single source of truth already is — the base file where there
was no version, the cluster overlay where one existed. Never both.

The in-repo charts (`leantime`, `outline`, `shlink`, and the `micronaut`-based
`otis`/`vulpes`) are **not** touched. They come from the `helmcharts`
GitRepository pointing at this repo, so they are a different problem with a
different answer — the audit explicitly did not recommend the same treatment.

## Blast radius

None expected: same chart version resolves, so Helm should record no upgrade.
If a release does redeploy, the pinned version is what it was already running.
Rollback is reverting this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZ7or95EosGNvwceYV5UA