### PR TITLE
fix(flux): pin the controller-layer chart versions

### DIFF
--- a/infrastructure/base/controllers/mariadb-operator-crds/release.yaml
+++ b/infrastructure/base/controllers/mariadb-operator-crds/release.yaml
@@ -7,6 +7,7 @@ spec:
   chart:
     spec:
       chart: mariadb-operator-crds
+      version: "=26.6.0"
       sourceRef:
         kind: HelmRepository
         name: mariadb-operator

--- a/infrastructure/base/controllers/mariadb-operator/release.yaml
+++ b/infrastructure/base/controllers/mariadb-operator/release.yaml
@@ -7,6 +7,7 @@ spec:
   chart:
     spec:
       chart: mariadb-operator
+      version: "=26.6.0"
       sourceRef:
         kind: HelmRepository
         name: mariadb-operator

--- a/infrastructure/clusters/feather-core/base-controllers/cert-manager/release.yaml
+++ b/infrastructure/clusters/feather-core/base-controllers/cert-manager/release.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: ">=1.14.4"
+      version: "=v1.21.1"
   values:
     affinity:
       nodeAffinity:

--- a/infrastructure/clusters/feather-core/base-controllers/cloudflare-tunnel-ingress-controller/release.yaml
+++ b/infrastructure/clusters/feather-core/base-controllers/cloudflare-tunnel-ingress-controller/release.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: ">=0.0.23"
+      version: "=0.0.24"
   values:
     # HA: two controller replicas in active/standby. Leader election ensures
     # only one reconciles Cloudflare at a time (mandatory with replicaCount > 1,


### PR DESCRIPTION
Implements Tasks 7 and 8 of `docs/superpowers/plans/2026-08-03-flux-release-control-and-convergence.md`,
minus step-ca (see below). Follows #101, which did the `base-apps` layer.

| Release | Was | Now |
|---|---|---|
| mariadb-operator | *(none)* | `=26.6.0` |
| mariadb-operator-crds | *(none)* | `=26.6.0` |
| cert-manager | `">=1.14.4"` | `=v1.21.1` |
| cloudflare-tunnel-ingress-controller | `">=0.0.23"` | `=0.0.24` |

## Why these four

`mariadb-operator-crds` on `*` is the sharpest: an upstream 27.0.0 would rewrite
CRDs cluster-wide against a live Galera cluster, with no PR and nothing to revert.

`cert-manager` is the clearest evidence of what floating constraints already cost.
The repo declares `>=1.14.4`; the cluster is running **v1.21.1** — seven minor
versions on, unreviewed. This writes reality back into git.

## Changes nothing that is running

Every pin is `status.history[0].chartVersion`, i.e. the chart already deployed.
Not upstream latest.

## Proven to resolve first

`base-controllers` and `controllers` are both `wait: true` and `rook`, `configs`,
`base-apps` and `apps` all sit downstream. An unresolvable constraint here stalls
the whole graph, not one release.

```console
mariadbop/mariadb-operator       26.6.0    JA
mariadbop/mariadb-operator-crds  26.6.0    JA
jetstack/cert-manager            v1.21.1   JA
cft/cloudflare-tunnel-ingress-controller 0.0.24  JA
```

cert-manager publishes as `v1.21.1`. Both `=1.21.1` and `=v1.21.1` resolve
(semver normalises the prefix); the v-form is used so the constraint matches the
index literally.

`./scripts/validate.sh` exits 0. Note `kubectl kustomize` on `base-controllers`
fails locally — that is the documented SOPS-patch behaviour from CLAUDE.md, not
this change; `validate.sh` strips those patches exactly as CI does.

## What is NOT in here

**step-ca stays floating (`>=1.28.2`, running `1.30.1`).** Its HelmRelease lives
in `step-certificates/release.sops.yaml` — a whole-file-encrypted manifest holding
the CA key material. Decrypting and re-encrypting that file to change a version
string is a poor trade against the risk of damaging it, especially unattended.
It deserves its own change, made deliberately.

## Blast radius

None expected: the same chart version resolves, so Helm should record no upgrade.
Watch `cert-manager` first after merge — it is the cluster's entire PKI and
`step-issuer`, `internal-certs` and every gateway certificate depend on it.
Rollback is reverting this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZ7or95EosGNvwceYV5UA