### PR TITLE
feat(flux): add upgrade remediation and drift detection

### DIFF
--- a/apps/base/alloy-logs/release.yaml
+++ b/apps/base/alloy-logs/release.yaml
@@ -16,6 +16,10 @@ spec:
   install:
     remediation:
       retries: 0
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   interval: 1m0s
   # Default values
   # https://raw.githubusercontent.com/grafana/alloy/main/operations/helm/charts/alloy/values.yaml

--- a/apps/base/alloy-metrics/release.yaml
+++ b/apps/base/alloy-metrics/release.yaml
@@ -16,6 +16,10 @@ spec:
   install:
     remediation:
       retries: 0
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   interval: 1m0s
   # Default values
   # https://raw.githubusercontent.com/grafana/alloy/main/operations/helm/charts/alloy/values.yaml

--- a/apps/base/alloy-receiver/release.yaml
+++ b/apps/base/alloy-receiver/release.yaml
@@ -16,6 +16,10 @@ spec:
   install:
     remediation:
       retries: 0
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   interval: 1m0s
   # Default values
   # https://raw.githubusercontent.com/grafana/alloy/main/operations/helm/charts/alloy/values.yaml

--- a/apps/base/grafana/release.yaml
+++ b/apps/base/grafana/release.yaml
@@ -16,6 +16,10 @@ spec:
   install:
     remediation:
       retries: 0
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   interval: 1m0s
   # Default values
   # https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml

--- a/apps/base/node-red/release.yaml
+++ b/apps/base/node-red/release.yaml
@@ -15,6 +15,10 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   interval: 1m0s
   # Default values
   # https://github.com/SchwarzIT/node-red-chart/blob/main/charts/node-red/values.yaml

--- a/infrastructure/base/controllers/cert-manager/release.yaml
+++ b/infrastructure/base/controllers/cert-manager/release.yaml
@@ -15,6 +15,14 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  driftDetection:
+    mode: warn
+    ignore:
+      # The documented rollout-restart workflow (CLAUDE.md) mutates this.
+      - paths: ["/spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt"]
   interval: 1m0s
   # Default values
   #

--- a/infrastructure/base/controllers/cloudflare-tunnel-ingress-controller/release.yaml
+++ b/infrastructure/base/controllers/cloudflare-tunnel-ingress-controller/release.yaml
@@ -15,6 +15,10 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   interval: 1m0s
   # Default values
   # https://github.com/STRRL/cloudflare-tunnel-ingress-controller/blob/main/helm/cloudflare-tunnel-ingress-controller/values.yaml

--- a/infrastructure/base/controllers/cnpg-operator/release.yaml
+++ b/infrastructure/base/controllers/cnpg-operator/release.yaml
@@ -15,5 +15,10 @@ spec:
   install:
     remediation:
       retries: 0
+  driftDetection:
+    mode: warn
+    ignore:
+      # The documented rollout-restart workflow (CLAUDE.md) mutates this.
+      - paths: ["/spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt"]
   interval: 1m0s
   values: {}

--- a/infrastructure/base/controllers/envoy/release.yaml
+++ b/infrastructure/base/controllers/envoy/release.yaml
@@ -10,6 +10,15 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  driftDetection:
+    mode: warn
+    ignore:
+      # The documented rollout-restart workflow (CLAUDE.md) mutates this.
+      - paths: ["/spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt"]
   interval: 1m0s
   timeout: 5m
   values: {}

--- a/infrastructure/base/controllers/mariadb-operator/release.yaml
+++ b/infrastructure/base/controllers/mariadb-operator/release.yaml
@@ -15,6 +15,14 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  driftDetection:
+    mode: warn
+    ignore:
+      # The documented rollout-restart workflow (CLAUDE.md) mutates this.
+      - paths: ["/spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt"]
   interval: 1m0s
   # Default values
   #

--- a/infrastructure/base/controllers/spegel/release.yaml
+++ b/infrastructure/base/controllers/spegel/release.yaml
@@ -11,6 +11,15 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  driftDetection:
+    mode: warn
+    ignore:
+      # The documented rollout-restart workflow (CLAUDE.md) mutates this.
+      - paths: ["/spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt"]
   interval: 1m0s
   timeout: 5m
   values:


### PR DESCRIPTION
Implements Task 14 of `docs/superpowers/plans/2026-08-03-flux-release-control-and-convergence.md`.

## Why

26 of 36 HelmReleases have no `spec.upgrade.remediation`, so helm-controller
defaults to `retries: 0` / `remediateLastFailure: false`: **one** failed upgrade
and the release is `Stalled` until its spec changes.

`grafana/mimir` has been in exactly that state for 20 days — all 21 pods
`Running`, workload converged, only Helm's `wait` timed out — and helm-controller
stopped reconciling it entirely.

Separately, `driftDetection.mode` is unset on all 36, so any `kubectl edit` /
`patch` / `scale` on a Helm-owned object persists forever and is invisible to
`flux get helmrelease`.

## What gets what, and why not everything

| Releases | Block |
|---|---|
| cloudflare-tunnel, spegel, envoy, grafana, alloy-logs/-metrics/-receiver, node-red | `retries: 3` + `remediateLastFailure: true` |
| **cert-manager**, **mariadb-operator** | `retries: 3` **only** |

`cert-manager` sets `crds.enabled: true`, so its CRDs are Helm-managed templates
inside that release. `remediateLastFailure: true` makes helm-controller run
`helm rollback` on a failed upgrade — which would revert the CRDs along with
everything else, against a live PKI that `step-issuer`, `internal-certs` and every
gateway certificate depend on. Same reasoning for `mariadb-operator`: an automated
rollback of the operator against a live Galera cluster is not something to automate.

Deliberately untouched: `mimir`, `loki` (already has `retries: 3`),
`mariadb-operator-crds`, `cnpg`, `harbor`, `outline`, `plane`, `dependency-track`,
and every in-repo `./helm/*` release.

## Drift detection

`mode: warn` on five infrastructure controllers (cert-manager, cnpg-operator,
mariadb-operator, envoy, spegel). **`warn` only logs and emits Events — it
corrects nothing.** The `ignore` path for
`kubectl.kubernetes.io/restartedAt` goes in now, *before* anything moves to
`mode: enabled`, so the escape hatch for the `kubectl rollout restart` workflow
CLAUDE.md documents already exists when that decision comes up.

`cnpg-operator` gets drift detection but deliberately **no** upgrade remediation,
so its block sits after `install:` rather than `upgrade:`.

## Verification

```console
base-controllers  "mode: warn"                 3   (cert-manager, cnpg-operator, spegel)
controllers       "mode: warn"                 2   (envoy, mariadb-operator)
base-apps         "remediateLastFailure: true" 6   (5 new + pre-existing plane)
```

The `base-apps` baseline was confirmed as `1` by reading `plane/release.yaml` from
`origin/main` — the plan suggested `git stash` for this, which is unsafe in this
worktree because the stash stack is shared with other checkouts.

`base-controllers` had to be rendered with sops patches stripped; `kubectl
kustomize` cannot read the encrypted `step-certificates` patch. Pre-existing
behaviour documented in CLAUDE.md, not introduced here.

`./scripts/validate.sh` exits 0.

## Blast radius

Spec-only changes, so each affected HelmRelease reconciles once — same chart
version (pinned in #101/#102), so no workload change is expected beyond Helm
recording an upgrade. `mode: warn` emits Events; it does not revert anything.

This does **not** unstick `grafana/mimir` — that needs its own timeout fix, which
is a separate task carrying a decision gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZ7or95EosGNvwceYV5UA