### PR TITLE
ci: pin actions to sha, add concurrency and timeouts

### DIFF
--- a/.github/workflows/flux-validate.yaml
+++ b/.github/workflows/flux-validate.yaml
@@ -2,28 +2,36 @@ name: flux-validate
 
 # Render every Flux Kustomization with kustomize and schema-check the
 # output with kubeconform so broken manifests never reach the cluster.
+
+# No `paths:` filter on pull_request. A filtered-out workflow never reports
+# a result, so once this becomes a required status check a docs-only PR
+# would sit forever on "Expected — waiting for status". It also means every
+# PR exercises the check, including ones that only touch scripts/. The full
+# run is ~30s.
 on:
   pull_request:
-    paths:
-      - 'clusters/**'
-      - 'infrastructure/**'
-      - 'apps/**'
-      - 'helm/**'
-      - 'scripts/validate.sh'
-      - '.github/workflows/flux-validate.yaml'
   push:
     branches: [main]
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Deliberately false on push: a cancelled post-merge run on main would
+  # leave the last line of defence unreported.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate:
     name: kustomize build + kubeconform
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.x'
       - name: Install PyYAML

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -10,12 +10,17 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-title:
     name: Conventional PR title
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -39,11 +44,13 @@ jobs:
   commits:
     name: Conventional commits
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v7
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: Install commitlint

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ]
 }


### PR DESCRIPTION
Implements Task 2 of `docs/superpowers/plans/2026-08-03-ci-as-a-merge-gate.md`.

## SHA pins

Every action was on a mutable tag (`@v6`, `@v7`). A retagged or compromised
upstream would run with this repo's token on every PR.

I resolved all four digests against the GitHub API rather than copying the ones
in the plan — a wrong SHA here breaks CI on every future PR:

| Action | Tag | Digest |
|---|---|---|
| actions/checkout | v7.0.1 | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
| actions/setup-python | v7.0.0 | `5fda3b95a4ea91299a34e894583c3862153e4b97` |
| actions/setup-node | v7.0.0 | `820762786026740c76f36085b0efc47a31fe5020` |
| amannn/action-semantic-pull-request | v6.1.1 | `48f256284bd46cdaab1048c3721360e808335d50` |

Two matched the plan exactly. `setup-node` needed resolving separately — the
workflow used `@v7`, which I confirmed points at the same commit as the `v7.0.0`
release tag.

`renovate.json` gains `helpers:pinGitHubActionDigests`. Without it, pinning to a
digest means the actions are frozen forever and stop receiving security updates —
strictly worse than mutable tags.

## The `paths:` filter is removed

A filtered-out workflow reports **no result at all**, so once `flux-validate`
becomes a required status check, any docs-only PR hangs on
*"Expected — waiting for status"*. This PR is itself an example: under the old
filter it touched `.github/workflows/flux-validate.yaml` and so would have run,
but a PR touching only `scripts/lib/` would not have.

The filter also never covered `scripts/` beyond `validate.sh`, meaning changes to
the validation tooling itself went unvalidated. Full run is ~30s, so the filter
was not buying much.

## Concurrency and timeouts

`concurrency` cancels superseded PR runs, but **deliberately not** `push` runs on
`main` — a cancelled post-merge run would leave the last line of defence
unreported.

`timeout-minutes` on all three jobs. `persist-credentials: false` on both
checkouts, since neither pushes.

## Verification

```console
yaml ok            (both workflows parse)
json ok            (renovate.json parses)
paths filter: NONE
grep 'uses:' | grep -v '@<40-hex> #'   → no output, all pinned
./scripts/validate.sh                  → exit 0
```

Renovate PR #87, which the plan warned would conflict on these files, is already
merged — no conflict.

## Blast radius

CI only. Nothing reconciles from these files. The one thing to watch is the first
run after merge: if a digest were wrong, every subsequent PR would fail at the
action-resolution step. Rollback is reverting this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZ7or95EosGNvwceYV5UA