### PR TITLE
fix(alloy): cap alloy-metrics ephemeral storage for the remote_write wal

### DIFF
--- a/apps/clusters/feathre-core/base-apps/alloy-metrics/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/alloy-metrics/release.yaml
@@ -37,9 +37,17 @@ spec:
         requests:
           cpu: 100m
           memory: 512Mi
+          # The remote_write WAL lives on the container writable layer — this
+          # StatefulSet has no volumeClaimTemplate. Alloy's own
+          # truncate_frequency/max_keepalive_time defaults bound it to ~8h,
+          # but nothing caps it, so a stuck remote_write would eat the node's
+          # root filesystem. 4Gi is roughly 4x the expected footprint: the pod
+          # gets evicted instead.
+          ephemeral-storage: 1Gi
         limits:
           cpu: "1"
           memory: 2Gi
+          ephemeral-storage: 4Gi
       configMap:
         content: |
           // Discovers PodMonitor/ServiceMonitor CRs cluster-wide (all


### PR DESCRIPTION
Implements Task 3 of `docs/superpowers/plans/2026-08-03-alert-coverage-and-escalation.md`.

## The gap

```console
$ kubectl get sts alloy-metrics -n grafana -o jsonpath='{.spec.template.spec.containers[*].resources}'
{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"100m","memory":"512Mi"}}
```

No `ephemeral-storage` request or limit at all. And the `prometheus.remote_write`
WAL has nowhere else to go — verified that the StatefulSet has **no**
`volumeClaimTemplate`, so the WAL sits on the container writable layer:

```console
$ kubectl get sts alloy-metrics -n grafana -o jsonpath='{.spec.volumeClaimTemplates[*].metadata.name}'
(empty)
```

Alloy's own `truncate_frequency` / `max_keepalive_time` defaults bound the WAL to
roughly 8h of series, so this is not a runaway by design. But nothing *enforces*
it: if remote_write to Mimir stays broken, the WAL grows against the node's
228 Gi root filesystem with no ceiling, and the kubelet then evicts by its own
ranking rather than the pod actually responsible.

## The fix

`requests: 1Gi` / `limits: 4Gi` — roughly 4x the expected footprint. A stuck
remote_write now evicts this pod and nothing else.

## Verification

```console
$ kubectl kustomize .../base-apps/alloy-metrics | grep -c ephemeral-storage
2                       # 1Gi under requests, 4Gi under limits
$ ./scripts/validate.sh
exit 0
```

Worker nodes have 228 Gi allocatable ephemeral-storage each, so a 4 Gi limit is
not a scheduling constraint.

## Blast radius

A resources change is a pod-template change, so the 2 alloy-metrics pods roll.
Each restart discards that replica's in-memory WAL — expect a sub-minute gap in
scraped metrics. **Worth merging outside an active incident**, since this is the
component that collects the metrics you would be looking at.

Rollback is reverting this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZ7or95EosGNvwceYV5UA