### PR TITLE
fix(rook): pin ceph-csi-drivers and drop the dead region affinity

### DIFF
--- a/infrastructure/clusters/feather-core/rook/csi-drivers-release.yaml
+++ b/infrastructure/clusters/feather-core/rook/csi-drivers-release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: ceph-csi-drivers
-      version: ">=1.0.4 <2.0.0"
+      version: "=1.0.4"
       sourceRef:
         kind: HelmRepository
         name: ceph-csi-operator

--- a/infrastructure/clusters/feather-core/rook/release.yaml
+++ b/infrastructure/clusters/feather-core/rook/release.yaml
@@ -40,13 +40,3 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
         operator: Exists
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-                - key: topology.kubernetes.io/region
-                  operator: In
-                  values:
-                    - fi-helsinki


### PR DESCRIPTION
Implements Task 10 of `docs/superpowers/plans/2026-08-03-flux-release-control-and-convergence.md`.
Completes the chart-pinning series (#101, #102).

## The pin

`ceph-csi-drivers` was `">=1.0.4 <2.0.0"` — floating across the entire 1.x line.
A published `1.9.0` would be pulled automatically, with no PR and no CI.

This is **the mount path for all 37 PVCs in the cluster**, which makes it the
sharpest instance of the floating-chart problem here. Pinned to `=1.0.4`, the
version already running.

```console
$ helm search repo cephcsi/ceph-csi-drivers --version "=1.0.4"
cephcsi/ceph-csi-drivers   1.0.4   v1.0.4
```

## The dead affinity

`rook/release.yaml` carried a nodeAffinity preference on the rook-ceph operator:

```yaml
- key: topology.kubernetes.io/region
  operator: In
  values: [fi-helsinki]
```

```console
$ kubectl get nodes -L topology.kubernetes.io/region   # distinct values
fr-rosenau
```

Every node is `fr-rosenau`; `fi-helsinki` exists nowhere. Being `preferred`
rather than `required` it was inert, not harmful — but it misleads anyone reading
the file for scheduling intent.

## Verification

```console
$ kubectl kustomize infrastructure/clusters/feather-core/rook
ceph-csi-drivers     chart=ceph-csi-drivers version==1.0.4
rook-ceph            chart=rook-ceph version=>=1.20.0 <1.21.0
$ ... | grep -c fi-helsinki
0
$ ./scripts/validate.sh
exit 0
```

## Blast radius

**This is the storage data path — merge in a window where you can watch it.**

The chart version does not change (`1.0.4` → `=1.0.4`), so no CSI pod should roll.
The affinity removal *is* a pod-template change on the rook-ceph **operator**, so
that single pod restarts; the operator is not in the I/O path, and CSI
provisioner/plugin pods are unaffected.

Rollback is reverting this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZ7or95EosGNvwceYV5UA