### PR TITLE
ci: fail the build on an unencrypted sops-matched file

### DIFF
--- a/.github/workflows/flux-validate.yaml
+++ b/.github/workflows/flux-validate.yaml
@@ -38,3 +38,19 @@ jobs:
         run: pip install --quiet pyyaml
       - name: Validate Flux manifests
         run: ./scripts/validate.sh
+
+  sops-encryption:
+    name: sops encryption
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.x'
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+      - name: Assert sops-matched files are encrypted
+        run: python3 scripts/check-sops-encryption.py

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,10 @@ fabric.properties
 /.idea/misc.xml
 /.idea/modules.xml
 /.idea/vcs.xml
+
+# Decrypted / exported secret material — never commit (see docs/sops.md)
+# *.asc is deliberately not blanket-ignored: clusters/feather-core/.sops.pub.asc
+# is a tracked public key.
+private-key.asc
+*.dec
+*.plain

--- a/scripts/check-sops-encryption.py
+++ b/scripts/check-sops-encryption.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Assert every git-tracked file matched by a whole-file .sops.yaml creation_rule is encrypted.
+
+The file list is derived from .sops.yaml at runtime — never a hardcoded glob — so
+it cannot drift from the rules. Only rules WITHOUT an `encrypted_regex` are
+considered: those encrypt the whole file. A field-level rule legitimately matches
+plaintext manifests that happen to contain no encryptable field, so it is out of
+scope here. (This repo currently has no field-level rule; it was removed in
+eb4ffd9 because it emitted cleartext under a valid-looking sops block.)
+"""
+import re
+import subprocess
+import sys
+
+import yaml
+
+# .sops.yaml self-matches the `sops\.ya?ml$` alternative in the whole-file rule
+# but is configuration, not a secret. `.sops.pub.asc` is a tracked public key and
+# matches no rule, so it needs no entry.
+ALLOWLIST = {".sops.yaml"}
+
+rules = yaml.safe_load(open(".sops.yaml"))["creation_rules"]
+patterns = [
+    re.compile(r["path_regex"])
+    for r in rules
+    if r.get("path_regex") and not r.get("encrypted_regex")
+]
+if not patterns:
+    sys.exit("::error::no whole-file creation_rules found in .sops.yaml")
+
+files = subprocess.run(
+    ["git", "ls-files", "-z"], capture_output=True, text=True, check=True
+).stdout.split("\0")
+
+bad, checked = [], 0
+for f in files:
+    if not f or f in ALLOWLIST or not any(p.search(f) for p in patterns):
+        continue
+    checked += 1
+    blob = open(f, "rb").read()
+    if b"ENC[AES256_GCM" not in blob and b"sops_version" not in blob and b"sops:" not in blob:
+        bad.append(f)
+
+print(f"sops-encryption: checked {checked} matched file(s)", file=sys.stderr)
+for f in bad:
+    print(f"::error file={f}::matched a .sops.yaml creation_rule but contains no sops metadata")
+sys.exit(1 if bad else 0)


### PR DESCRIPTION
Implements Task 7 of `docs/superpowers/plans/2026-08-03-ci-as-a-merge-gate.md`.
Depends on #105, which removed the `paths:` filter so this job always reports.

## Why

Nothing catches a secret committed in plaintext today. `scripts/validate.sh` runs
kubeconform with `-skip Secret`, so an unencrypted Secret manifest is not merely
unvalidated — it is deliberately ignored. This is the CI half of the problem
#92 fixed in the config half.

## The check

The file list is derived from `.sops.yaml` **at runtime**, never a hardcoded
glob, so the check cannot drift from the rules the way `docs/sops.md` had drifted.

Only creation rules **without** an `encrypted_regex` are considered — those
encrypt the whole file. A field-level rule legitimately matches plaintext
manifests containing no encryptable field. This repo has no such rule since
eb4ffd9 removed the one that emitted cleartext under a valid-looking sops block.

## Proven in both directions

A check that never fails is worthless, so I tested the failing path too:

```console
$ python3 scripts/check-sops-encryption.py
sops-encryption: checked 72 matched file(s)
exit=0

# plant an unencrypted .env, git add -N so it is tracked
$ python3 scripts/check-sops-encryption.py
sops-encryption: checked 73 matched file(s)
::error file=infrastructure/clusters/feather-core/rook/negative-test.env::matched a .sops.yaml creation_rule but contains no sops metadata
exit=1

# remove it
$ python3 scripts/check-sops-encryption.py
sops-encryption: checked 72 matched file(s)
exit=0
```

## Details

- `.sops.yaml` is allowlisted: it self-matches the `sops\.ya?ml$` alternative
  while being configuration, not a secret. The plan's allowlist also named
  `clusters/feather-core/.sops.yaml`, which #92 deleted — dropped.
- `.sops.pub.asc` needs no entry; it matches no rule.
- The new job reuses the **exact** action digests from the `validate` job.
  Renovate bumps them together only when they match.
- `.gitignore` gains `private-key.asc`, `*.dec`, `*.plain` — the filenames
  `docs/sops.md` tells people to create. `*.asc` is deliberately **not**
  blanket-ignored, since `.sops.pub.asc` is tracked and a blanket rule plus a
  negation is more fragile than naming the one file.

`./scripts/validate.sh` exits 0. Both workflow jobs parse.

## Blast radius

CI only. Nothing reconciles from these files. The new `sops encryption` check
context is what Task 8 would later mark as required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZ7or95EosGNvwceYV5UA