### PR TITLE
fix(plane): give the components realistic requests and rabbitmq a qos class

### DIFF
--- a/apps/clusters/feathre-core/base-apps/plane/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/plane/release.yaml
@@ -30,6 +30,23 @@ spec:
           # the "-commercial" variant of the same backend image; verify after
           # cutover whether the bug still applies (harmless either way — this pins
           # concurrency to 2 regardless).
+          # services.rabbitmq exposes no resource keys in plane-enterprise 3.0.0,
+          # so the StatefulSet ships with `resources: {}` — BestEffort, and the
+          # first thing the kubelet evicts, despite being the queue every worker
+          # depends on. No CPU limit on purpose: throttling a broker is worse
+          # than letting it burst (observed 453m under normal load).
+          - target:
+              kind: StatefulSet
+              name: plane-rabbitmq-wl
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/resources
+                value:
+                  requests:
+                    cpu: 250m
+                    memory: 256Mi
+                  limits:
+                    memory: 1Gi
           - target:
               kind: Deployment
               name: plane-worker-wl
@@ -61,28 +78,52 @@ spec:
       opensearch:
         local_setup: true
 
+      # Requests were the chart default 50m/50Mi against 1000-2000Mi limits
+      # while `kubectl top` showed 150-483Mi. Floors below are ~real usage
+      # rounded up; there is no LimitRange anywhere in the cluster to correct
+      # them. plane-opensearch-wl is deliberately absent — the chart already
+      # sizes it correctly (500m/2Gi).
       web:
         assign_cluster_ip: true
+        memoryRequest: 64Mi
+        cpuRequest: 25m
       space:
         assign_cluster_ip: true
+        memoryRequest: 256Mi
+        cpuRequest: 50m
       admin:
         assign_cluster_ip: true
+        memoryRequest: 64Mi
+        cpuRequest: 25m
       api:
         assign_cluster_ip: true
+        memoryRequest: 320Mi
+        cpuRequest: 100m
       live:
         assign_cluster_ip: true
+        memoryRequest: 256Mi
+        cpuRequest: 50m
+      monitor:
+        memoryRequest: 64Mi
+        cpuRequest: 25m
 
       # Same reasoning as the CE cutover: chart default (1000Mi) OOMKilled the
       # worker repeatedly under real load. Bump both async components.
       worker:
         memoryLimit: 2000Mi
         cpuLimit: "1"
+        memoryRequest: 512Mi
+        cpuRequest: 100m
       beatworker:
         memoryLimit: 1500Mi
         cpuLimit: 500m
+        memoryRequest: 320Mi
+        cpuRequest: 50m
 
       silo:
         enabled: true
+        memoryRequest: 256Mi
+        cpuRequest: 50m
 
       # Pi (the AI assistant) is left at the chart default (disabled): its
       # migrator job hard-fails without an embedding model configured


### PR DESCRIPTION
Implements Task 10 of `docs/superpowers/plans/2026-08-03-workload-resilience-and-pod-hardening.md`.
**Task 11 (readiness probes) is deliberately excluded — see the bottom.**

## Requests vs. reality

Nine of eleven Plane containers request the chart default `50m/50Mi` against
limits of 1000–2000Mi. Live usage:

```console
$ kubectl top pods -n plane
plane-worker-wl        483Mi
plane-beat-worker-wl   276Mi
plane-api-wl           271Mi
plane-silo-wl          209Mi
plane-live-wl          199Mi
plane-rabbitmq-wl      155Mi / 453m
plane-space-wl         151Mi
```

`kubectl get limitrange -A` returns nothing, so no LimitRange corrects this. The
scheduler has been placing Plane on numbers unrelated to what it uses, and the
kubelet ranks it for eviction on the same basis.

Requests are set to ~real usage rounded up. `plane-opensearch-wl` is **excluded**
— the chart already sizes it at 500m/2Gi.

## RabbitMQ is the sharper half

```console
$ kubectl get sts plane-rabbitmq-wl -n plane -o jsonpath='{...resources}'
{}
$ kubectl get pod plane-rabbitmq-wl-0 -n plane -o jsonpath='{.status.qosClass}'
BestEffort
```

First thing evicted under node pressure — and it is the queue every Plane worker
depends on. `services.rabbitmq` exposes no resource keys in `plane-enterprise`
3.0.0, so this needs a post-render patch. **No CPU limit on purpose**: throttling
a broker is worse than letting it burst (453m observed under normal load).

## Headroom checked before sizing

The plan's abort condition was any worker above 70% of allocatable in memory
*requests*:

```console
fr01-wrk-xl-01   41%
fr01-wrk-xl-02   38%
fr01-wrk-xl-03   40%
fr01-wrk-xl-04   35%
```

This adds roughly +1.9 Gi of requests cluster-wide. Ample room.

## Why the readiness probes are not here

Task 11 adds readiness probes to the nine unprobed containers. I confirmed the
**ports** from the Service `targetPort`s (web/admin/space/live/silo 3000, api
8000, monitor 8080) and confirmed the chart declares no `containerPort`, as the
plan says.

But I did not independently verify the probe **paths**. A path that 404s would
fail readiness, drop those pods out of their Endpoints and take Plane offline —
and this PR would otherwise be merged unattended. Ports being right is not
enough; that change wants eyes on it. It stays open as a separate task.

`./scripts/validate.sh` exits 0.

## Blast radius

A resources change is a pod-template change, so Plane rolls: nine Deployments
plus the RabbitMQ StatefulSet. Plane is user-facing (tasks.onelitefeather.net),
so expect a rolling blip. Nothing outside the `plane` namespace is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZ7or95EosGNvwceYV5UA