### PR TITLE
fix(renovate): shorten the otel depname so bumps pass commitlint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,12 @@
       "description": "Keep chart and image bumps in one PR, otherwise the chart rolls without its matching image tags",
       "matchFileNames": ["apps/**/harbor/**"],
       "groupName": "harbor"
+    },
+    {
+      "description": "commitlint caps the header at 100 chars; the untouched 70-char depName pushes 'chore(deps): update <depName> docker tag to vX.Y.Z' to 112 and makes every bump of this image unmergeable. Only the display name changes.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java"],
+      "overrideDepName": "otel-autoinstrumentation-java"
     }
   ]
 }


### PR DESCRIPTION
Renovate baut den Commit-Header als `chore(deps): update <depName> docker tag to <version>`. Für `ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java` (70 Zeichen depName) ergibt das 112 Zeichen gegen das 100-Zeichen-Limit aus `commitlint.config.mjs`:

```
✖ header must not be longer than 100 characters, current length is 112  [header-max-length]
```

Das hat #89 blockiert; das Image steckt weiterhin in `helm/micronaut/values.yaml` und `apps/.../reposilite/release.yaml`, also trifft es jeden künftigen Bump identisch.

`overrideDepName` ändert nur den Anzeigenamen — Image, Datasource und Versionsauflösung bleiben unberührt:

```
chore(deps): update otel-autoinstrumentation-java docker tag to v2.31.0   # 73 Zeichen
```

Ich habe alle Registry-Image-Referenzen in `apps/`, `infrastructure/` und `helm/` durchgesehen: dieses ist das einzige, das über das Budget von ~57 Zeichen für den depName geht. Eine generische Registry-strippende Regel würde es nicht einmal lösen (ohne `ghcr.io/` bleiben 62 Zeichen), deshalb die gezielte Regel.

Rebased auf `main` — die Regel hängt jetzt an den vorhandenen `packageRules` neben der Harbor-Gruppierung. Der zentrale OLF-Preset, dessen Fehlen die ursprüngliche Beschreibung noch anmerkte, ist inzwischen eingebunden und enthält nichts, was den Header beeinflusst.