### PR TITLE
fix(mariadb): cut physical backup retention to 7 days

### DIFF
--- a/infrastructure/clusters/feather-core/configs/mariadb-galera/phsysical-backup.yaml
+++ b/infrastructure/clusters/feather-core/configs/mariadb-galera/phsysical-backup.yaml
@@ -10,13 +10,14 @@ spec:
     cron: "0 */6 * * *"
     suspend: false
     immediate: true
-  maxRetention: 720h # 30 days
+  # 7 days: 28 backups * 34.6GiB = ~970GiB in S3 (~2.9TiB raw at 3x replication).
+  # 30 days would need 4.15TiB / 12.5TiB raw — more than the whole Ceph cluster.
+  maxRetention: 168h # 7 days
   # No compression, deliberately: the operator's pipeline is sequential
   # (dump -> compress -> upload, not streamed), so compression algorithm was
   # the entire bottleneck. Measured on this cluster: bzip2 ~60-67min/run,
   # gzip 22m12s/6.8GiB, none 4m18s/28.6GiB. "none" was chosen to hit a
-  # 5-15min backup window; trade-off is ~4.2x more S3 storage per backup
-  # than gzip (~3.4TiB vs ~816GiB at 4 backups/day * 30-day maxRetention).
+  # 5-15min backup window; the storage trade-off is paid via maxRetention above.
   compression: none
   storage:
     s3:
@@ -35,7 +36,7 @@ spec:
   # each backup completes, unlike a PVC which keeps accumulating .xb files
   # forever (no built-in cleanup upstream, see mariadb-operator issue #1243).
   # fr01-wrk-xl-01 (where podAffinity pins this Job) has ~244Gi ephemeral-storage
-  # free; measured uncompressed backup size is ~28.6Gi, comfortable margin
+  # free; measured uncompressed backup size is ~34.6Gi, comfortable margin
   # under the 100Gi sizeLimit below.
   stagingStorage:
     volume:


### PR DESCRIPTION
## Problem

Ceph hit **77.86 % raw** (9.3 / 12 TiB) with `feather-s3.rgw.buckets.data` at 87 % and only **411 GiB MAX AVAIL** left. The `mariadb-galera-backup` bucket held **2.09 TiB of the 2.82 TiB** total S3 payload — ~6.1 TiB raw at 3× replication, two thirds of the entire cluster.

## Root cause

At 4 backups/day the 30-day `maxRetention` can never reach a steady state on this cluster:

| | value |
|---|---|
| measured backup size (uncompressed) | **34.6 GiB** (manifest assumed 28.6 GiB) |
| 120 retained backups | 4.15 TiB S3 = **12.5 TiB raw** |
| cluster total | **12 TiB** |

The oldest object in the active prefix was only 22 days old — nothing had ever been pruned while the bucket grew **138 GiB/day**. At 411 GiB free that was ~3 days from a write stop.

## Change

`maxRetention: 720h` → `168h`. Caps the bucket at 28 backups (~970 GiB S3, ~2.9 TiB raw).

- RPO stays at **6h** — `cron` unchanged.
- Backup window stays at **~5 min** — `compression: none` deliberately unchanged, see the comment in the manifest.
- Cost: one week of restore reach instead of four.

Also refreshes two stale 28.6 GiB figures; the 100Gi staging `sizeLimit` still has comfortable margin at 34.6 GiB.

## Out-of-band cleanup (not expressible in GitOps)

- Removed **65 orphaned** `physicalbackup-2025*.xb.bz2` objects (128.8 GiB) under the retired `backups/` prefix — copied in on 2026-06-09 from a previous instance; the operator only prunes its own `feather-core-backups/` prefix, so these would never have expired.
- Aborted **20 incomplete multipart uploads** from 2026-07-23..26 (2 GiB / 149 parts).

Result: **77.86 % → 74.70 % raw**, MAX AVAIL 411 GiB → 553 GiB.

## Verification

`./scripts/validate.sh` passes. After merge the next backup job prunes everything older than 7 days, freeing a further ~1 TiB S3 (~2.9 TiB raw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)