### PR TITLE
feat(reposilite): switch to Ingot 1.0.0

### DIFF
--- a/apps/clusters/feathre-core/base-apps/reposilite/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/reposilite/release.yaml
@@ -18,6 +18,25 @@ spec:
                 path: /spec/template/spec/priorityClassName
                 value: feather-standard
   values:
+    # Ingot instead of Reposilite. The fork is a drop-in replacement: same
+    # entrypoint, same paths, same environment variables, same schema in the
+    # same database. Nothing else in this release changes, and
+    # REPOSILITE_LOCAL_DATABASE below keeps working because Ingot reads the
+    # legacy prefix as a fallback.
+    #
+    # Rehearsed against a full copy of this instance, the database plus 19.7
+    # GiB of artifacts across all five buckets: artifacts came back byte
+    # identical, all six access tokens survived, an upload authenticated with
+    # REPOSILITE_OPTS was accepted, and dzikoysk/reposilite:3.5.28 was then
+    # pointed back at the same data and read everything Ingot had written.
+    #
+    # `tag` is mandatory, not cosmetic. The chart renders
+    # `{{ image.name }}:{{ image.tag | default .Chart.AppVersion }}`, so
+    # leaving it out asks for ghcr.io/onelitefeathernet/ingot:3.5.28, which
+    # does not exist. Bump it together with the chart pin above.
+    image:
+      name: ghcr.io/onelitefeathernet/ingot
+      tag: "1.0.0"
     deployment:
       podLabels:
         logs.onelitefeather.net/env: prod


### PR DESCRIPTION
## What

Points the `reposilite` HelmRelease at `ghcr.io/onelitefeathernet/ingot:1.0.0`.
Two values, nothing else in the release changes.

## Why this is safe

Ingot is a drop-in fork: same entrypoint, same paths (`/app/data`,
`/var/log/reposilite`), same port, same environment variables, and the same
schema in the same database. The persistence and storage code has not received
a single commit since the fork point (`3.5.28-45-g161d9ae8`), so the S3
provider and the Exposed schema are byte for byte the upstream ones.

The switch was rehearsed against a full copy of this instance: the `reposilite`
database plus 19.7 GiB and 17,454 objects across all five Ceph buckets, with
the S3 settings rewritten so the rehearsal could never touch production data.

| Check | Result |
| --- | --- |
| `REPOSILITE_LOCAL_DATABASE` (legacy prefix) | connects, schema adopted with no migration step |
| Repositories loaded from the copied shared config | all 7 |
| Artifact served through Ingot | byte identical to `repo.onelitefeather.dev`, same sha256 |
| Upload authenticated via `REPOSILITE_OPTS` | HTTP 200, read back matches |
| Rollback to `dzikoysk/reposilite:3.5.28` on the same data | reads everything Ingot wrote |
| Access tokens after Ingot touched the database | all 6 intact |
| Production buckets during the whole rehearsal | object counts unchanged |

`-Dreposilite.s3.pathStyleAccessEnabled=true` from `JAVA_OPTS` is read directly
via `System.getProperty` in unchanged code, so the Ceph RGW path is unaffected
by the `INGOT_`/`REPOSILITE_` prefix work.

## Why `image.tag` is not optional

The chart renders `image.name:image.tag | default .Chart.AppVersion`. With only
`image.name` overridden it asks for `ghcr.io/onelitefeathernet/ingot:3.5.28`,
which does not exist. Verified by rendering the chart both ways. Bump the tag
together with the `=1.3.28` chart pin above it.

## Rollout and rollback

`base-apps` reconciles every minute, so merging rolls this out on its own.
The deployment keeps the existing `maxUnavailable: 1` / `maxSurge: 1`, so the
three replicas are replaced one at a time.

Rollback is reverting this commit.

## Worth knowing

The chart keeps stamping `app.kubernetes.io/version: 3.5.28` and
`helm.sh/chart: reposilite-1.3.28` on the pods, because those come from the
chart, not from the image. Cosmetic, but confusing to whoever reads it next.

After the rollout, `kubectl -n reposilite logs deploy/reposilite | grep -i "LOGGER ERROR"`
is worth one look: readiness only proves the port answers, and the regression
the upgrade test was originally written for was an image that started cleanly,
served artifacts, and silently wrote nothing to `/var/log/reposilite`.
