### PR TITLE
feat(grafana): render discord alerts as a table and cut alert noise

### DIFF
--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -27511,8 +27511,9 @@ spec:
             group_by: ['alertname']
             # A full evaluation period, so all instances of a rule land in ONE message.
             group_wait: 1m
-            # Minimum gap between two messages for the same alertname when group membership changes.
-            group_interval: 15m
+            # Membership churn is fixed at the source, so no routing damping is needed here; 5m
+            # halves both the RESOLVED delay and the wait for a newly added object.
+            group_interval: 5m
             # A repeat carries no new information; two people, no on-call rotation.
             repeat_interval: 24h
       rules.yaml:

--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -27521,12 +27521,14 @@ spec:
                 data:
                   - refId: A
                     relativeTimeRange:
-                      from: 600
+                      from: 1200
                       to: 0
                     datasourceUid: mimir
                     model:
                       editorMode: code
-                      expr: gotk_resource_info{customresource_kind="Kustomization", ready="False"}
+                      # Sustain check lives in PromQL instead of `for:`, so short reconcile blips never
+                      # fire; aggregating to exactly 2 labels is a hard requirement of the Discord template.
+                      expr: min_over_time((max by (exported_namespace, name) (gotk_resource_info{customresource_kind="Kustomization", ready!="True"}) or max by (exported_namespace, name) (gotk_resource_info{customresource_kind="Kustomization"}) * 0)[15m:1m])
                       instant: true
                       intervalMs: 1000
                       maxDataPoints: 43200
@@ -27562,9 +27564,15 @@ spec:
                       type: threshold
                 noDataState: OK
                 execErrState: Alerting
-                for: 5m
+                for: 0s
+                keepFiringFor: 15m
                 annotations:
-                  summary: "Flux Kustomization {{ `{{ $labels.name }}` }} (namespace {{ `{{ $labels.exported_namespace }}` }}) is not Ready. Check: flux get kustomization {{ `{{ $labels.name }}` }} -n {{ `{{ $labels.exported_namespace }}` }}"
+                  summary: "Flux Kustomization {{ `{{ $labels.name }}` }} (namespace {{ `{{ $labels.exported_namespace }}` }}) has not been Ready for 15 minutes."
+                  problem: "Kustomization >15 min nicht Ready"
+                  object_label: "Layer"
+                  object: "{{ `{{ $labels.name }}` }}"
+                  location: "{{ `{{ $labels.exported_namespace }}` }}"
+                  check_command: "flux get kustomization -A"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/flux-control-plane"
                 labels:
                   severity: critical
@@ -27574,12 +27582,14 @@ spec:
                 data:
                   - refId: A
                     relativeTimeRange:
-                      from: 600
+                      from: 1200
                       to: 0
                     datasourceUid: mimir
                     model:
                       editorMode: code
-                      expr: gotk_resource_info{customresource_kind="HelmRelease", ready="False", name=~"envoy|cert-manager|rook-ceph|cnpg|mariadb-operator|mimir|loki|tempo|grafana|cloudflare-tunnel-ingress-controller|metallb|dragonfly"}
+                      # Dropped metallb/dragonfly (never existed in 90d retention), added 9 real infra
+                      # releases; descheduler stays out on purpose (optimiser, not a dependency).
+                      expr: min_over_time((max by (exported_namespace, name) (gotk_resource_info{customresource_kind="HelmRelease", ready!="True", name=~"alloy-logs|alloy-metrics|alloy-receiver|ceph-csi-drivers|cert-manager|cloudflare-tunnel-ingress-controller|cnpg|envoy|grafana|kube-prometheus-stack|loki|mariadb-operator|mariadb-operator-crds|mimir|rook-ceph|spegel|step-ca|step-issuer|tempo"}) or max by (exported_namespace, name) (gotk_resource_info{customresource_kind="HelmRelease", name=~"alloy-logs|alloy-metrics|alloy-receiver|ceph-csi-drivers|cert-manager|cloudflare-tunnel-ingress-controller|cnpg|envoy|grafana|kube-prometheus-stack|loki|mariadb-operator|mariadb-operator-crds|mimir|rook-ceph|spegel|step-ca|step-issuer|tempo"}) * 0)[15m:1m])
                       instant: true
                       intervalMs: 1000
                       maxDataPoints: 43200
@@ -27615,9 +27625,15 @@ spec:
                       type: threshold
                 noDataState: OK
                 execErrState: Alerting
-                for: 5m
+                for: 0s
+                keepFiringFor: 15m
                 annotations:
-                  summary: "Flux HelmRelease {{ `{{ $labels.name }}` }} (namespace {{ `{{ $labels.exported_namespace }}` }}) is not Ready. Check: flux get helmrelease {{ `{{ $labels.name }}` }} -n {{ `{{ $labels.exported_namespace }}` }}"
+                  summary: "Flux HelmRelease {{ `{{ $labels.name }}` }} (namespace {{ `{{ $labels.exported_namespace }}` }}) has not been Ready for 15 minutes."
+                  problem: "HelmRelease >15 min nicht Ready"
+                  object_label: "Release"
+                  object: "{{ `{{ $labels.name }}` }}"
+                  location: "{{ `{{ $labels.exported_namespace }}` }}"
+                  check_command: "flux get helmrelease -A"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/flux-control-plane"
                 labels:
                   severity: critical
@@ -27681,6 +27697,9 @@ spec:
                 for: 5m
                 annotations:
                   summary: "No successful CloudNativePG (Postgres) backup in over 24h."
+                  problem: "Kein Backup seit über 24 h"
+                  location: "cnpg-system"
+                  check_command: "kubectl -n cnpg-system get backups.postgresql.cnpg.io"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/cloudnative-pg"
                 labels:
                   severity: warning
@@ -27739,6 +27758,9 @@ spec:
                 for: 5m
                 annotations:
                   summary: "CloudNativePG's most recent backup attempt failed (a failure timestamp is newer than the last successful one)."
+                  problem: "Backup-Versuch fehlgeschlagen"
+                  location: "cnpg-system"
+                  check_command: "kubectl -n cnpg-system get backups.postgresql.cnpg.io"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/cloudnative-pg"
                 labels:
                   severity: warning
@@ -27793,7 +27815,10 @@ spec:
                 annotations:
                   # No dashboard_url: the mariadb-galera dashboard (gnetId 13106) covers
                   # cluster health, not backup jobs, so it wouldn't add useful context here.
-                  summary: "The mariadb-galera-backup CronJob's most recent Job run failed. Check: kubectl get jobs -n mariadb-galera"
+                  summary: "The mariadb-galera-backup CronJob's most recent Job run failed."
+                  problem: "Backup-CronJob fehlgeschlagen"
+                  location: "mariadb-galera"
+                  check_command: "kubectl -n mariadb-galera get jobs"
                 labels:
                   severity: warning
           - orgId: 1
@@ -27812,7 +27837,8 @@ spec:
                     datasourceUid: mimir
                     model:
                       editorMode: code
-                      expr: (kubelet_volume_stats_used_bytes{namespace="mariadb-galera", persistentvolumeclaim=~"storage-mariadb-galera-.*"} / kubelet_volume_stats_capacity_bytes{namespace="mariadb-galera", persistentvolumeclaim=~"storage-mariadb-galera-.*"}) * 100
+                      # Aggregating to (persistentvolumeclaim, node) is what the Discord template needs and keeps a pod reschedule (new instance label) from spawning a second alert instance.
+                      expr: max by (persistentvolumeclaim, node) (kubelet_volume_stats_used_bytes{namespace="mariadb-galera", persistentvolumeclaim=~"storage-mariadb-galera-.*"} / kubelet_volume_stats_capacity_bytes{namespace="mariadb-galera", persistentvolumeclaim=~"storage-mariadb-galera-.*"}) * 100
                       instant: true
                       intervalMs: 1000
                       maxDataPoints: 43200
@@ -27850,7 +27876,12 @@ spec:
                 execErrState: Alerting
                 for: 10m
                 annotations:
-                  summary: "MariaDB Galera PVC {{ `{{ $labels.persistentvolumeclaim }}` }} on node {{ `{{ $labels.node }}` }} is above 80% capacity. Check: kubectl get pvc -n mariadb-galera; kubectl exec -n mariadb-galera <matching pod> -- df -h /var/lib/mysql"
+                  summary: "MariaDB Galera PVC {{ `{{ $labels.persistentvolumeclaim }}` }} on node {{ `{{ $labels.node }}` }} is above 80% capacity."
+                  problem: "PVC über 80 % belegt"
+                  object_label: "PVC"
+                  object: "{{ `{{ $labels.persistentvolumeclaim }}` }}"
+                  location: "{{ `{{ $labels.node }}` }}"
+                  check_command: "kubectl -n mariadb-galera get pvc"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/pXgz0qFGk/galera-mariadb-overview"
                 labels:
                   severity: warning
@@ -27865,7 +27896,7 @@ spec:
                     datasourceUid: mimir
                     model:
                       editorMode: code
-                      expr: (kubelet_volume_stats_used_bytes{namespace="mariadb-galera", persistentvolumeclaim=~"storage-mariadb-galera-.*"} / kubelet_volume_stats_capacity_bytes{namespace="mariadb-galera", persistentvolumeclaim=~"storage-mariadb-galera-.*"}) * 100
+                      expr: max by (persistentvolumeclaim, node) (kubelet_volume_stats_used_bytes{namespace="mariadb-galera", persistentvolumeclaim=~"storage-mariadb-galera-.*"} / kubelet_volume_stats_capacity_bytes{namespace="mariadb-galera", persistentvolumeclaim=~"storage-mariadb-galera-.*"}) * 100
                       instant: true
                       intervalMs: 1000
                       maxDataPoints: 43200
@@ -27903,7 +27934,12 @@ spec:
                 execErrState: Alerting
                 for: 5m
                 annotations:
-                  summary: "MariaDB Galera PVC {{ `{{ $labels.persistentvolumeclaim }}` }} on node {{ `{{ $labels.node }}` }} is above 90% capacity and at risk of filling up. Check: kubectl get pvc -n mariadb-galera; kubectl exec -n mariadb-galera <matching pod> -- df -h /var/lib/mysql"
+                  summary: "MariaDB Galera PVC {{ `{{ $labels.persistentvolumeclaim }}` }} on node {{ `{{ $labels.node }}` }} is above 90% capacity and at risk of filling up."
+                  problem: "PVC über 90 % belegt"
+                  object_label: "PVC"
+                  object: "{{ `{{ $labels.persistentvolumeclaim }}` }}"
+                  location: "{{ `{{ $labels.node }}` }}"
+                  check_command: "kubectl -n mariadb-galera get pvc"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/pXgz0qFGk/galera-mariadb-overview"
                 labels:
                   severity: critical
@@ -27952,11 +27988,16 @@ spec:
                       maxDataPoints: 43200
                       refId: B
                       type: threshold
+                # Only rule kept as the sentinel for "Ceph telemetry is gone": ceph_health_status was
+                # present 40319/40321 min in 28 days (longest gap 1 min), so for: 10m cannot blip-fire.
                 noDataState: Alerting
                 execErrState: Alerting
                 for: 10m
                 annotations:
-                  summary: "Ceph cluster health is not HEALTH_OK (HEALTH_WARN or worse). Check: ceph -s (or kubectl -n rook-ceph-fr01 exec deploy/rook-ceph-tools -- ceph health detail)"
+                  summary: "Ceph cluster health is not HEALTH_OK (HEALTH_WARN or worse)."
+                  problem: "Ceph nicht HEALTH_OK"
+                  location: "rook-ceph-fr01"
+                  check_command: "kubectl -n rook-ceph-fr01 exec deploy/rook-ceph-tools -- ceph health detail"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/tbO9LAiZK/ceph-cluster"
                 labels:
                   severity: warning
@@ -28005,11 +28046,14 @@ spec:
                       maxDataPoints: 43200
                       refId: B
                       type: threshold
-                noDataState: Alerting
+                noDataState: OK
                 execErrState: Alerting
                 for: 5m
                 annotations:
-                  summary: "Ceph cluster health is HEALTH_ERR. Check: ceph -s (or kubectl -n rook-ceph-fr01 exec deploy/rook-ceph-tools -- ceph health detail)"
+                  summary: "Ceph cluster health is HEALTH_ERR."
+                  problem: "Ceph HEALTH_ERR"
+                  location: "rook-ceph-fr01"
+                  check_command: "kubectl -n rook-ceph-fr01 exec deploy/rook-ceph-tools -- ceph health detail"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/tbO9LAiZK/ceph-cluster"
                 labels:
                   severity: critical
@@ -28058,14 +28102,17 @@ spec:
                       maxDataPoints: 43200
                       refId: B
                       type: threshold
-                noDataState: Alerting
+                noDataState: OK
                 execErrState: Alerting
                 for: 10m
                 annotations:
                   # Baseline observed 2026-07-18 was 0.02-0.3 req/s; a real RGW degradation
                   # incident (Rook 1.20 upgrade, S3 access broken for non-owner users) would
                   # show as a sustained multi-request/s error rate, not baseline noise.
-                  summary: "RGW failed request rate is elevated (baseline is <1/s). This is the class of failure that broke S3 access for backups/Loki/Mimir/Postgres WAL during the Rook 1.20 upgrade incident. Check: kubectl -n rook-ceph-fr01 logs -l app=rook-ceph-rgw --tail=200"
+                  summary: "RGW failed request rate is elevated (baseline is <1/s). This is the class of failure that broke S3 access for backups/Loki/Mimir/Postgres WAL during the Rook 1.20 upgrade incident."
+                  problem: "RGW-Fehlerrate erhöht"
+                  location: "rook-ceph-fr01"
+                  check_command: "kubectl -n rook-ceph-fr01 logs -l app=rook-ceph-rgw --tail=200"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/tbO9LAiZK/ceph-cluster"
                 labels:
                   severity: warning
@@ -28119,11 +28166,14 @@ spec:
                       maxDataPoints: 43200
                       refId: B
                       type: threshold
-                noDataState: Alerting
+                noDataState: OK
                 execErrState: Alerting
                 for: 10m
                 annotations:
-                  summary: "The most-full Ceph OSD is above 80% used. Ceph's own nearfull/backfillfull thresholds trip around here and will start rejecting large S3 uploads (InsufficientCapacity) before HEALTH_WARN fires. Check: kubectl -n rook-ceph-fr01 exec deploy/rook-ceph-tools -- ceph osd df"
+                  summary: "The most-full Ceph OSD is above 80% used. Ceph's own nearfull/backfillfull thresholds trip around here and will start rejecting large S3 uploads (InsufficientCapacity) before HEALTH_WARN fires."
+                  problem: "OSD über 80 % belegt"
+                  location: "rook-ceph-fr01"
+                  check_command: "kubectl -n rook-ceph-fr01 exec deploy/rook-ceph-tools -- ceph osd df"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/tbO9LAiZK/ceph-cluster"
                 labels:
                   severity: warning
@@ -28172,11 +28222,14 @@ spec:
                       maxDataPoints: 43200
                       refId: B
                       type: threshold
-                noDataState: Alerting
+                noDataState: OK
                 execErrState: Alerting
                 for: 5m
                 annotations:
-                  summary: "The most-full Ceph OSD is above 90% used -- at or past Ceph's backfillfull threshold, new writes to affected pools (including S3/RGW uploads) will start being rejected. Check: kubectl -n rook-ceph-fr01 exec deploy/rook-ceph-tools -- ceph osd df; ceph health detail"
+                  summary: "The most-full Ceph OSD is above 90% used -- at or past Ceph's backfillfull threshold, new writes to affected pools (including S3/RGW uploads) will start being rejected."
+                  problem: "OSD über 90 % belegt"
+                  location: "rook-ceph-fr01"
+                  check_command: "kubectl -n rook-ceph-fr01 exec deploy/rook-ceph-tools -- ceph osd df"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/tbO9LAiZK/ceph-cluster"
                 labels:
                   severity: critical
@@ -28230,13 +28283,16 @@ spec:
                       maxDataPoints: 43200
                       refId: B
                       type: threshold
-                noDataState: Alerting
+                noDataState: OK
                 execErrState: Alerting
                 for: 10m
                 annotations:
                   # Threshold is against the live max_connections setting (queried dynamically),
                   # not a hardcoded value - stays correct if the setting is changed again.
-                  summary: "CNPG Postgres connections are above 80% of max_connections. Idle pools from Harbor/Dependency-Track have starved other consumers (e.g. outline-collab) before. Check: kubectl -n cnpg-system exec feather-core-cluster-pg-1 -- psql -c \"select datname, state, count(*) from pg_stat_activity group by 1,2 order by 3 desc;\""
+                  summary: "CNPG Postgres connections are above 80% of max_connections. Idle pools from Harbor/Dependency-Track have starved other consumers (e.g. outline-collab) before."
+                  problem: "Postgres-Verbindungen über 80 %"
+                  location: "cnpg-system"
+                  check_command: "kubectl -n cnpg-system exec feather-core-cluster-pg-1 -- psql -Atc \"select datname,count(*) from pg_stat_activity group by 1 order by 2 desc\""
                   dashboard_url: "https://grafana.apps.onelite.feather/d/cloudnative-pg"
                 labels:
                   severity: warning
@@ -28285,11 +28341,14 @@ spec:
                       maxDataPoints: 43200
                       refId: B
                       type: threshold
-                noDataState: Alerting
+                noDataState: OK
                 execErrState: Alerting
                 for: 5m
                 annotations:
-                  summary: "CNPG Postgres connections are above 90% of max_connections - close to exhausting the shared pool. Check: kubectl -n cnpg-system exec feather-core-cluster-pg-1 -- psql -c \"select datname, state, count(*) from pg_stat_activity group by 1,2 order by 3 desc;\""
+                  summary: "CNPG Postgres connections are above 90% of max_connections - close to exhausting the shared pool."
+                  problem: "Postgres-Verbindungen über 90 %"
+                  location: "cnpg-system"
+                  check_command: "kubectl -n cnpg-system exec feather-core-cluster-pg-1 -- psql -Atc \"select datname,count(*) from pg_stat_activity group by 1 order by 2 desc\""
                   dashboard_url: "https://grafana.apps.onelite.feather/d/cloudnative-pg"
                 labels:
                   severity: critical
@@ -28340,13 +28399,18 @@ spec:
                       type: threshold
                 noDataState: Alerting
                 execErrState: Alerting
-                for: 2m
+                # In 28 days wsrep_cluster_size was below 3 for 7 minutes total, in exactly one
+                # episode >=2m and none >=5m - so 2m paged monthly for a rolling restart.
+                for: 5m
                 annotations:
                   # min() across all 3 nodes' own view of cluster size - a node that loses
                   # connectivity to its peers (e.g. the Flannel host-gw/MTU incident) reports a
                   # smaller cluster size on its own, so this catches split-brain, not just a
                   # fully-down node.
-                  summary: "MariaDB Galera cluster size has dropped below 3 - the cluster is degraded or split-brained. Check: kubectl -n mariadb-galera exec mariadb-galera-0 -- mariadb -e \"show status like 'wsrep_cluster%';\""
+                  summary: "MariaDB Galera cluster size has dropped below 3 - the cluster is degraded or split-brained."
+                  problem: "Galera-Cluster unter 3 Knoten"
+                  location: "mariadb-galera"
+                  check_command: "kubectl -n mariadb-galera exec mariadb-galera-0 -- mariadb -e \"show status like 'wsrep_cluster%'\""
                   dashboard_url: "https://grafana.apps.onelite.feather/d/pXgz0qFGk/galera-mariadb-overview"
                 labels:
                   severity: critical
@@ -28366,10 +28430,7 @@ spec:
                     datasourceUid: mimir
                     model:
                       editorMode: code
-                      # kube_pod_deletion_timestamp has NO series at all when nothing is
-                      # terminating (confirmed live) - "OR vector(0)" turns that healthy state
-                      # into a real 0 instead of "no data", which matters because this rule uses
-                      # noDataState: Alerting.
+                      # "OR vector(0)" always yields a series, so the noDataState path is unreachable here.
                       expr: count(time() - kube_pod_deletion_timestamp > 900) OR vector(0)
                       instant: true
                       intervalMs: 1000
@@ -28404,11 +28465,13 @@ spec:
                       maxDataPoints: 43200
                       refId: B
                       type: threshold
-                noDataState: Alerting
+                noDataState: OK
                 execErrState: Alerting
                 for: 5m
                 annotations:
-                  summary: "One or more pods have been stuck in Terminating for over 15 minutes. Matches the containerd shim task.Delete hang on SIGKILL teardown seen before. Check: kubectl get pods -A --field-selector=status.phase!=Running | grep Terminating"
+                  summary: "One or more pods have been stuck in Terminating for over 15 minutes. Matches the containerd shim task.Delete hang on SIGKILL teardown seen before."
+                  problem: "Pods hängen in Terminating"
+                  check_command: "kubectl get pods -A | grep Terminating"
                 labels:
                   severity: warning
           - orgId: 1
@@ -28473,7 +28536,10 @@ spec:
                 execErrState: Alerting
                 for: 5m
                 annotations:
-                  summary: "No kubelet metrics are reaching Mimir at all - the Alloy scrape/remote-write pipeline is likely down. Every other alert in this cluster depends on this pipeline and will read as falsely healthy while this fires. Check: kubectl -n grafana get pods -l app.kubernetes.io/name=alloy-metrics"
+                  summary: "No kubelet metrics are reaching Mimir at all - the Alloy scrape/remote-write pipeline is likely down. Every other alert in this cluster depends on this pipeline and will read as falsely healthy while this fires."
+                  problem: "Keine Kubelet-Metriken in Mimir"
+                  location: "grafana"
+                  check_command: "kubectl -n grafana get pods -l app.kubernetes.io/name=alloy-metrics"
                 labels:
                   severity: critical
           - orgId: 1
@@ -28537,7 +28603,11 @@ spec:
                 execErrState: Alerting
                 for: 5m
                 annotations:
-                  summary: "Node {{ `{{ $labels.node }}` }} is NotReady or Unreachable. Check: kubectl get node {{ `{{ $labels.node }}` }} -o wide; kubectl describe node {{ `{{ $labels.node }}` }} | tail -30"
+                  summary: "Node {{ `{{ $labels.node }}` }} is NotReady or Unreachable."
+                  problem: "Node NotReady/Unreachable"
+                  object_label: "Node"
+                  object: "{{ `{{ $labels.node }}` }}"
+                  check_command: "kubectl get nodes -o wide"
                 labels:
                   severity: critical
               - uid: kubelet-down
@@ -28593,7 +28663,11 @@ spec:
                 execErrState: Alerting
                 for: 5m
                 annotations:
-                  summary: "Kubelet on node {{ `{{ $labels.node }}` }} is not being scraped - the node is down, the kubelet is dead, or its serving cert expired. Check: talosctl -n {{ `{{ $labels.node }}` }} service kubelet status"
+                  summary: "Kubelet on node {{ `{{ $labels.node }}` }} is not being scraped - the node is down, the kubelet is dead, or its serving cert expired."
+                  problem: "Kubelet wird nicht gescrapt"
+                  object_label: "Node"
+                  object: "{{ `{{ $labels.node }}` }}"
+                  check_command: "kubectl get nodes -o wide"
                 labels:
                   severity: critical
               - uid: node-clock-unsynchronised
@@ -28651,7 +28725,11 @@ spec:
                 execErrState: Alerting
                 for: 15m
                 annotations:
-                  summary: "Clock on {{ `{{ $labels.instance }}` }} is not synchronised - /dev/ptp0 is the only time source and there is no NTP fallback. Check: talosctl -n <node> read /sys/class/ptp/ptp0/clock_name; talosctl -n <node> dmesg | grep -i ptp"
+                  summary: "Clock on {{ `{{ $labels.instance }}` }} is not synchronised - /dev/ptp0 is the only time source and there is no NTP fallback."
+                  problem: "Uhr nicht synchronisiert"
+                  object_label: "Node"
+                  object: "{{ `{{ $labels.instance }}` }}"
+                  check_command: "talosctl -n <node> time"
                 labels:
                   severity: warning
               - uid: node-clock-offset-high
@@ -28706,7 +28784,11 @@ spec:
                 execErrState: Alerting
                 for: 15m
                 annotations:
-                  summary: "Clock offset on {{ `{{ $labels.instance }}` }} exceeds 50ms. Galera certification, etcd leases and TLS validity all assume a tight cluster clock. Check: talosctl -n <node> time"
+                  summary: "Clock offset on {{ `{{ $labels.instance }}` }} exceeds 50ms. Galera certification, etcd leases and TLS validity all assume a tight cluster clock."
+                  problem: "Uhr-Offset über 50 ms"
+                  object_label: "Node"
+                  object: "{{ `{{ $labels.instance }}` }}"
+                  check_command: "talosctl -n <node> time"
                 labels:
                   severity: warning
           - orgId: 1
@@ -28769,7 +28851,12 @@ spec:
                 execErrState: Alerting
                 for: 1h
                 annotations:
-                  summary: "Certificate {{ `{{ $labels.name }}` }} in namespace {{ `{{ $labels.exported_namespace }}` }} expires in under 14 days and has not renewed. Check: kubectl describe certificate {{ `{{ $labels.name }}` }} -n {{ `{{ $labels.exported_namespace }}` }}; kubectl get certificaterequest -n {{ `{{ $labels.exported_namespace }}` }}"
+                  summary: "Certificate {{ `{{ $labels.name }}` }} in namespace {{ `{{ $labels.exported_namespace }}` }} expires in under 14 days and has not renewed."
+                  problem: "Zertifikat läuft in <14 Tagen ab"
+                  object_label: "Zertifikat"
+                  object: "{{ `{{ $labels.name }}` }}"
+                  location: "{{ `{{ $labels.exported_namespace }}` }}"
+                  check_command: "kubectl get certificate -A | grep -v True"
                 labels:
                   severity: warning
               - uid: certificate-expiring-critical
@@ -28821,7 +28908,12 @@ spec:
                 execErrState: Alerting
                 for: 15m
                 annotations:
-                  summary: "Certificate {{ `{{ $labels.name }}` }} in namespace {{ `{{ $labels.exported_namespace }}` }} expires in under 3 days. Renewal has failed. Check: kubectl describe certificate {{ `{{ $labels.name }}` }} -n {{ `{{ $labels.exported_namespace }}` }}; kubectl -n cert-manager logs deploy/cert-manager --tail=100"
+                  summary: "Certificate {{ `{{ $labels.name }}` }} in namespace {{ `{{ $labels.exported_namespace }}` }} expires in under 3 days. Renewal has failed."
+                  problem: "Zertifikat läuft in <3 Tagen ab"
+                  object_label: "Zertifikat"
+                  object: "{{ `{{ $labels.name }}` }}"
+                  location: "{{ `{{ $labels.exported_namespace }}` }}"
+                  check_command: "kubectl get certificate -A | grep -v True"
                 labels:
                   severity: critical
     resources:

--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -28550,6 +28550,65 @@ spec:
                   check_command: "kubectl -n grafana get pods -l app.kubernetes.io/name=alloy-metrics"
                 labels:
                   severity: critical
+              - uid: kube-state-metrics-down
+                title: kube-state-metrics producing no data
+                condition: B
+                data:
+                  - refId: A
+                    relativeTimeRange:
+                      from: 600
+                      to: 0
+                    datasourceUid: mimir
+                    model:
+                      editorMode: code
+                      # Same count()/NoData pattern as observability-pipeline-no-data above, not
+                      # absent(): absent() is empty while healthy, which reads as NoData forever.
+                      expr: count(up{job="kube-state-metrics"})
+                      instant: true
+                      intervalMs: 1000
+                      maxDataPoints: 43200
+                      range: false
+                      refId: A
+                  - refId: B
+                    relativeTimeRange:
+                      from: 600
+                      to: 0
+                    datasourceUid: '-100'
+                    model:
+                      conditions:
+                        - evaluator:
+                            params:
+                              - 1
+                            type: lt
+                          operator:
+                            type: and
+                          query:
+                            params:
+                              - B
+                          reducer:
+                            params: []
+                            type: last
+                          type: query
+                      datasource:
+                        type: __expr__
+                        uid: '-100'
+                      expression: A
+                      intervalMs: 1000
+                      maxDataPoints: 43200
+                      refId: B
+                      type: threshold
+                noDataState: Alerting
+                execErrState: Alerting
+                for: 5m
+                annotations:
+                  # No dashboard_url: the Kubernetes Objects dashboard is built from the same
+                  # metrics, so it is empty exactly while this alert fires.
+                  summary: "kube-state-metrics has stopped producing metrics. Both Flux alerts read gotk_resource_info from it, so they report healthy while blind for as long as this fires."
+                  problem: "Keine kube-state-metrics-Daten"
+                  location: "monitoring"
+                  check_command: "kubectl -n monitoring get pods -l app.kubernetes.io/name=kube-state-metrics"
+                labels:
+                  severity: critical
           - orgId: 1
             name: node_health
             folder: Core Services

--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -27479,25 +27479,29 @@ spec:
       templates.yaml:
         apiVersion: 1
         templates:
-          # discord.message prints severity/Rule/Dashboard once per notification group (not once
-          # per instance) via .CommonLabels/.CommonAnnotations, which only stays correct as long as
-          # every alert rule keeps severity and dashboard_url static (not templated per-$labels)
-          # and rule titles stay unique (group_by: ['alertname'] in policies.yaml). Violating either
-          # doesn't error - the affected line is just silently dropped from the notification.
+          # Static annotations (problem/object_label/check_command/location) are read from (index .Alerts 0),
+          # so a rule must never template them per-$labels - a wrong instance would silently supply the value.
+          # The effective template must contain no backtick (it would end the Helm raw string) and no single
+          # quote (toYaml may single-quote a scalar). Discord hard-truncates message at 2000 runes, which would
+          # rip the code fence open - hence the 8-instance cap. printf widths count runes, not bytes.
           - name: discord.title
             template: '{{ `{{ define "discord.title" }}` }}{{ `{{ if eq .Status "firing" }}` }}🔴 FIRING{{ `{{ if gt (len .Alerts.Firing) 1 }}` }} ({{ `{{ len .Alerts.Firing }}` }}x){{ `{{ end }}` }}{{ `{{ else }}` }}✅ RESOLVED{{ `{{ if gt (len .Alerts.Resolved) 1 }}` }} ({{ `{{ len .Alerts.Resolved }}` }}x){{ `{{ end }}` }}{{ `{{ end }}` }} · {{ `{{ .CommonLabels.alertname }}` }}{{ `{{ end }}` }}'
           - name: discord.message
             template: |
-              {{ `{{ define "discord.message" }}` }}{{ `{{ if .CommonLabels.severity }}` }}severity: `{{ `{{ .CommonLabels.severity }}` }}`
-              {{ `{{ end }}` }}🔗 Rule: <{{ `{{ (index .Alerts 0).GeneratorURL }}` }}>
-              {{ `{{ if .CommonAnnotations.dashboard_url }}` }}📊 Dashboard: <{{ `{{ .CommonAnnotations.dashboard_url }}` }}>
-              {{ `{{ end }}` }}
-
-              {{ `{{ if gt (len .Alerts.Firing) 0 }}` }}Firing ({{ `{{ len .Alerts.Firing }}` }}):
-              {{ `{{ range .Alerts.Firing }}` }}• {{ `{{ reReplaceAll "^(.*?\\.) Check:.*$" "$1" .Annotations.summary }}` }}
-              {{ `{{ end }}` }}{{ `{{ end }}` }}{{ `{{ if gt (len .Alerts.Resolved) 0 }}` }}Resolved ({{ `{{ len .Alerts.Resolved }}` }}):
-              {{ `{{ range .Alerts.Resolved }}` }}• {{ `{{ reReplaceAll "^(.*?\\.) Check:.*$" "$1" .Annotations.summary }}` }}
-              {{ `{{ end }}` }}{{ `{{ end }}` }}{{ `{{ end }}` }}
+              {{ `{{ define "discord.message" }}{{ $f := index .Alerts 0 }}{{ $loc := .CommonAnnotations.location }}{{ $age := reReplaceAll "^(([0-9]+h)?([0-9]+m)?).*$" "$1" (printf "%s" (time.Now.Sub $f.StartsAt)) }}` }}```
+              {{ `{{ printf "%-12s" "Problem" }}{{ if $f.Annotations.problem }}{{ $f.Annotations.problem }}{{ else }}{{ $f.Annotations.summary }}{{ end }}` }}
+              {{ `{{ if $f.Labels.severity }}{{ printf "%-12s" "Schwere" }}{{ $f.Labels.severity }}` }}
+              {{ `{{ end }}{{ if eq .Status "firing" }}{{ printf "%-12s" "Seit" }}{{ date "15:04" (tz "Europe/Berlin" $f.StartsAt) }} Uhr  ({{ if $age }}{{ $age }}{{ else }}<1m{{ end }})` }}
+              {{ `{{ else if not $f.EndsAt.IsZero }}{{ printf "%-12s" "Behoben" }}{{ date "15:04" (tz "Europe/Berlin" $f.EndsAt) }} Uhr` }}
+              {{ `{{ end }}{{ if gt (len .Alerts) 1 }}{{ printf "%-12s" "Betroffen" }}{{ if gt (len .Alerts.Firing) 0 }}{{ len .Alerts.Firing }} aktiv{{ if gt (len .Alerts.Resolved) 0 }}, {{ end }}{{ end }}{{ if gt (len .Alerts.Resolved) 0 }}{{ len .Alerts.Resolved }} behoben{{ end }}` }}
+              {{ `{{ end }}{{ if $loc }}{{ printf "%-12s" "Ort" }}{{ $loc }}` }}
+              {{ `{{ end }}{{ if and $f.Annotations.object_label $f.Annotations.object }}────────────────────────────────────────────` }}
+              {{ `{{ range $i, $a := .Alerts }}{{ if lt $i 8 }}{{ if eq $i 0 }}{{ printf "%-12s" $f.Annotations.object_label }}{{ else }}{{ printf "%-12s" "" }}{{ end }}{{ if $loc }}{{ $a.Annotations.object }}{{ else if $a.Annotations.location }}{{ printf "%-23.22s" $a.Annotations.object }}{{ $a.Annotations.location }}{{ else }}{{ $a.Annotations.object }}{{ end }}{{ if eq $a.Status "resolved" }}  (behoben){{ end }}` }}
+              {{ `{{ end }}{{ end }}{{ if gt (len .Alerts) 8 }}{{ printf "%-12s" "" }}… weitere ausgeblendet ({{ len .Alerts }} insgesamt)` }}
+              {{ `{{ end }}{{ end }}{{ if $f.Annotations.check_command }}────────────────────────────────────────────` }}
+              {{ `{{ printf "%-12s" "Prüfen" }}{{ $f.Annotations.check_command }}` }}
+              {{ `{{ end }}` }}```
+              {{ `🔗 [Regel](<{{ $f.GeneratorURL }}>){{ if $f.Annotations.dashboard_url }}  ·  📊 [Dashboard](<{{ $f.Annotations.dashboard_url }}>){{ end }}{{ end }}` }}
       policies.yaml:
         apiVersion: 1
         policies:

--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -27496,7 +27496,7 @@ spec:
               {{ `{{ end }}{{ if gt (len .Alerts) 1 }}{{ printf "%-12s" "Betroffen" }}{{ if gt (len .Alerts.Firing) 0 }}{{ len .Alerts.Firing }} aktiv{{ if gt (len .Alerts.Resolved) 0 }}, {{ end }}{{ end }}{{ if gt (len .Alerts.Resolved) 0 }}{{ len .Alerts.Resolved }} behoben{{ end }}` }}
               {{ `{{ end }}{{ if $loc }}{{ printf "%-12s" "Ort" }}{{ $loc }}` }}
               {{ `{{ end }}{{ if and $f.Annotations.object_label $f.Annotations.object }}────────────────────────────────────────────` }}
-              {{ `{{ range $i, $a := .Alerts }}{{ if lt $i 8 }}{{ if eq $i 0 }}{{ printf "%-12s" $f.Annotations.object_label }}{{ else }}{{ printf "%-12s" "" }}{{ end }}{{ if $loc }}{{ $a.Annotations.object }}{{ else if $a.Annotations.location }}{{ printf "%-23.22s" $a.Annotations.object }}{{ $a.Annotations.location }}{{ else }}{{ $a.Annotations.object }}{{ end }}{{ if eq $a.Status "resolved" }}  (behoben){{ end }}` }}
+              {{ `{{ range $i, $a := .Alerts }}{{ if lt $i 8 }}{{ if eq $i 0 }}{{ printf "%-12s" $f.Annotations.object_label }}{{ else }}{{ printf "%-12s" "" }}{{ end }}{{ if $loc }}{{ $a.Annotations.object }}{{ else if $a.Annotations.location }}{{ printf "%-27.26s" $a.Annotations.object }}{{ $a.Annotations.location }}{{ else }}{{ $a.Annotations.object }}{{ end }}{{ if eq $a.Status "resolved" }}  (behoben){{ end }}` }}
               {{ `{{ end }}{{ end }}{{ if gt (len .Alerts) 8 }}{{ printf "%-12s" "" }}… weitere ausgeblendet ({{ len .Alerts }} insgesamt)` }}
               {{ `{{ end }}{{ end }}{{ if $f.Annotations.check_command }}────────────────────────────────────────────` }}
               {{ `{{ printf "%-12s" "Prüfen" }}{{ $f.Annotations.check_command }}` }}

--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -27479,8 +27479,11 @@ spec:
       templates.yaml:
         apiVersion: 1
         templates:
-          # Static annotations (problem/object_label/check_command/location) are read from (index .Alerts 0),
-          # so a rule must never template them per-$labels - a wrong instance would silently supply the value.
+          # Static annotations (problem/object_label/object_key/location_key/check_command/location) are read
+          # from (index .Alerts 0), so a rule must never template them per-$labels - a wrong instance would
+          # silently supply the value. The per-instance table columns are read from $a.Labels via the *_key
+          # names, never from a $labels-templated annotation: Grafana 12.3 restores the RAW annotation
+          # template after a restart (grafana#114973), while instance labels are persisted correctly.
           # The effective template must contain no backtick (it would end the Helm raw string) and no single
           # quote (toYaml may single-quote a scalar). Discord hard-truncates message at 2000 runes, which would
           # rip the code fence open - hence the 8-instance cap. printf widths count runes, not bytes.
@@ -27488,15 +27491,15 @@ spec:
             template: '{{ `{{ define "discord.title" }}` }}{{ `{{ if eq .Status "firing" }}` }}🔴 FIRING{{ `{{ if gt (len .Alerts.Firing) 1 }}` }} ({{ `{{ len .Alerts.Firing }}` }}x){{ `{{ end }}` }}{{ `{{ else }}` }}✅ RESOLVED{{ `{{ if gt (len .Alerts.Resolved) 1 }}` }} ({{ `{{ len .Alerts.Resolved }}` }}x){{ `{{ end }}` }}{{ `{{ end }}` }} · {{ `{{ .CommonLabels.alertname }}` }}{{ `{{ end }}` }}'
           - name: discord.message
             template: |
-              {{ `{{ define "discord.message" }}{{ $f := index .Alerts 0 }}{{ $loc := .CommonAnnotations.location }}{{ $age := reReplaceAll "^(([0-9]+h)?([0-9]+m)?).*$" "$1" (printf "%s" (time.Now.Sub $f.StartsAt)) }}` }}```
+              {{ `{{ define "discord.message" }}{{ $f := index .Alerts 0 }}{{ $ok := $f.Annotations.object_key }}{{ $lk := $f.Annotations.location_key }}{{ $loc := or (and $lk (index .CommonLabels $lk)) .CommonAnnotations.location }}{{ $age := reReplaceAll "^(([0-9]+h)?([0-9]+m)?).*$" "$1" (printf "%s" (time.Now.Sub $f.StartsAt)) }}` }}```
               {{ `{{ printf "%-12s" "Problem" }}{{ if $f.Annotations.problem }}{{ $f.Annotations.problem }}{{ else }}{{ $f.Annotations.summary }}{{ end }}` }}
               {{ `{{ if $f.Labels.severity }}{{ printf "%-12s" "Schwere" }}{{ $f.Labels.severity }}` }}
               {{ `{{ end }}{{ if eq .Status "firing" }}{{ printf "%-12s" "Seit" }}{{ date "15:04" (tz "Europe/Berlin" $f.StartsAt) }} Uhr  ({{ if $age }}{{ $age }}{{ else }}<1m{{ end }})` }}
               {{ `{{ else if not $f.EndsAt.IsZero }}{{ printf "%-12s" "Behoben" }}{{ date "15:04" (tz "Europe/Berlin" $f.EndsAt) }} Uhr` }}
               {{ `{{ end }}{{ if gt (len .Alerts) 1 }}{{ printf "%-12s" "Betroffen" }}{{ if gt (len .Alerts.Firing) 0 }}{{ len .Alerts.Firing }} aktiv{{ if gt (len .Alerts.Resolved) 0 }}, {{ end }}{{ end }}{{ if gt (len .Alerts.Resolved) 0 }}{{ len .Alerts.Resolved }} behoben{{ end }}` }}
               {{ `{{ end }}{{ if $loc }}{{ printf "%-12s" "Ort" }}{{ $loc }}` }}
-              {{ `{{ end }}{{ if and $f.Annotations.object_label $f.Annotations.object }}────────────────────────────────────────────` }}
-              {{ `{{ range $i, $a := .Alerts }}{{ if lt $i 8 }}{{ if eq $i 0 }}{{ printf "%-12s" $f.Annotations.object_label }}{{ else }}{{ printf "%-12s" "" }}{{ end }}{{ if $loc }}{{ $a.Annotations.object }}{{ else if $a.Annotations.location }}{{ printf "%-27.26s" $a.Annotations.object }}{{ $a.Annotations.location }}{{ else }}{{ $a.Annotations.object }}{{ end }}{{ if eq $a.Status "resolved" }}  (behoben){{ end }}` }}
+              {{ `{{ end }}{{ if and $f.Annotations.object_label $ok }}────────────────────────────────────────────` }}
+              {{ `{{ range $i, $a := .Alerts }}{{ if lt $i 8 }}{{ if eq $i 0 }}{{ printf "%-12s" $f.Annotations.object_label }}{{ else }}{{ printf "%-12s" "" }}{{ end }}{{ $o := index $a.Labels $ok }}{{ if $loc }}{{ $o }}{{ else if $lk }}{{ printf "%-27.26s" $o }}{{ index $a.Labels $lk }}{{ else }}{{ $o }}{{ end }}{{ if eq $a.Status "resolved" }}  (behoben){{ end }}` }}
               {{ `{{ end }}{{ end }}{{ if gt (len .Alerts) 8 }}{{ printf "%-12s" "" }}… weitere ausgeblendet ({{ len .Alerts }} insgesamt)` }}
               {{ `{{ end }}{{ end }}{{ if $f.Annotations.check_command }}────────────────────────────────────────────` }}
               {{ `{{ printf "%-12s" "Prüfen" }}{{ $f.Annotations.check_command }}` }}
@@ -27579,8 +27582,8 @@ spec:
                   summary: "Flux Kustomization {{ `{{ $labels.name }}` }} (namespace {{ `{{ $labels.exported_namespace }}` }}) has not been Ready for 15 minutes."
                   problem: "Kustomization >15 min nicht Ready"
                   object_label: "Layer"
-                  object: "{{ `{{ $labels.name }}` }}"
-                  location: "{{ `{{ $labels.exported_namespace }}` }}"
+                  object_key: "name"
+                  location_key: "exported_namespace"
                   check_command: "flux get kustomization -A"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/flux-control-plane"
                 labels:
@@ -27640,8 +27643,8 @@ spec:
                   summary: "Flux HelmRelease {{ `{{ $labels.name }}` }} (namespace {{ `{{ $labels.exported_namespace }}` }}) has not been Ready for 15 minutes."
                   problem: "HelmRelease >15 min nicht Ready"
                   object_label: "Release"
-                  object: "{{ `{{ $labels.name }}` }}"
-                  location: "{{ `{{ $labels.exported_namespace }}` }}"
+                  object_key: "name"
+                  location_key: "exported_namespace"
                   check_command: "flux get helmrelease -A"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/flux-control-plane"
                 labels:
@@ -27888,8 +27891,8 @@ spec:
                   summary: "MariaDB Galera PVC {{ `{{ $labels.persistentvolumeclaim }}` }} on node {{ `{{ $labels.node }}` }} is above 80% capacity."
                   problem: "PVC über 80 % belegt"
                   object_label: "PVC"
-                  object: "{{ `{{ $labels.persistentvolumeclaim }}` }}"
-                  location: "{{ `{{ $labels.node }}` }}"
+                  object_key: "persistentvolumeclaim"
+                  location_key: "node"
                   check_command: "kubectl -n mariadb-galera get pvc"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/pXgz0qFGk/galera-mariadb-overview"
                 labels:
@@ -27946,8 +27949,8 @@ spec:
                   summary: "MariaDB Galera PVC {{ `{{ $labels.persistentvolumeclaim }}` }} on node {{ `{{ $labels.node }}` }} is above 90% capacity and at risk of filling up."
                   problem: "PVC über 90 % belegt"
                   object_label: "PVC"
-                  object: "{{ `{{ $labels.persistentvolumeclaim }}` }}"
-                  location: "{{ `{{ $labels.node }}` }}"
+                  object_key: "persistentvolumeclaim"
+                  location_key: "node"
                   check_command: "kubectl -n mariadb-galera get pvc"
                   dashboard_url: "https://grafana.apps.onelite.feather/d/pXgz0qFGk/galera-mariadb-overview"
                 labels:
@@ -28674,7 +28677,7 @@ spec:
                   summary: "Node {{ `{{ $labels.node }}` }} is NotReady or Unreachable."
                   problem: "Node NotReady/Unreachable"
                   object_label: "Node"
-                  object: "{{ `{{ $labels.node }}` }}"
+                  object_key: "node"
                   check_command: "kubectl get nodes -o wide"
                 labels:
                   severity: critical
@@ -28734,7 +28737,7 @@ spec:
                   summary: "Kubelet on node {{ `{{ $labels.node }}` }} is not being scraped - the node is down, the kubelet is dead, or its serving cert expired."
                   problem: "Kubelet wird nicht gescrapt"
                   object_label: "Node"
-                  object: "{{ `{{ $labels.node }}` }}"
+                  object_key: "node"
                   check_command: "kubectl get nodes -o wide"
                 labels:
                   severity: critical
@@ -28796,7 +28799,7 @@ spec:
                   summary: "Clock on {{ `{{ $labels.instance }}` }} is not synchronised - /dev/ptp0 is the only time source and there is no NTP fallback."
                   problem: "Uhr nicht synchronisiert"
                   object_label: "Node"
-                  object: "{{ `{{ $labels.instance }}` }}"
+                  object_key: "instance"
                   check_command: "talosctl -n <node> time"
                 labels:
                   severity: warning
@@ -28855,7 +28858,7 @@ spec:
                   summary: "Clock offset on {{ `{{ $labels.instance }}` }} exceeds 50ms. Galera certification, etcd leases and TLS validity all assume a tight cluster clock."
                   problem: "Uhr-Offset über 50 ms"
                   object_label: "Node"
-                  object: "{{ `{{ $labels.instance }}` }}"
+                  object_key: "instance"
                   check_command: "talosctl -n <node> time"
                 labels:
                   severity: warning
@@ -28922,8 +28925,8 @@ spec:
                   summary: "Certificate {{ `{{ $labels.name }}` }} in namespace {{ `{{ $labels.exported_namespace }}` }} expires in under 14 days and has not renewed."
                   problem: "Zertifikat läuft in <14 Tagen ab"
                   object_label: "Zertifikat"
-                  object: "{{ `{{ $labels.name }}` }}"
-                  location: "{{ `{{ $labels.exported_namespace }}` }}"
+                  object_key: "name"
+                  location_key: "exported_namespace"
                   check_command: "kubectl get certificate -A | grep -v True"
                 labels:
                   severity: warning
@@ -28979,8 +28982,8 @@ spec:
                   summary: "Certificate {{ `{{ $labels.name }}` }} in namespace {{ `{{ $labels.exported_namespace }}` }} expires in under 3 days. Renewal has failed."
                   problem: "Zertifikat läuft in <3 Tagen ab"
                   object_label: "Zertifikat"
-                  object: "{{ `{{ $labels.name }}` }}"
-                  location: "{{ `{{ $labels.exported_namespace }}` }}"
+                  object_key: "name"
+                  location_key: "exported_namespace"
                   check_command: "kubectl get certificate -A | grep -v True"
                 labels:
                   severity: critical

--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -27507,10 +27507,14 @@ spec:
         policies:
           - orgId: 1
             receiver: discord
+            # Do NOT change: discord.message assumes one group == the instances of exactly one rule.
             group_by: ['alertname']
-            group_wait: 30s
-            group_interval: 5m
-            repeat_interval: 4h
+            # A full evaluation period, so all instances of a rule land in ONE message.
+            group_wait: 1m
+            # Minimum gap between two messages for the same alertname when group membership changes.
+            group_interval: 15m
+            # A repeat carries no new information; two people, no on-call rotation.
+            repeat_interval: 24h
       rules.yaml:
         apiVersion: 1
         groups:

--- a/docs/superpowers/plans/2026-08-03-alert-coverage-and-escalation.md
+++ b/docs/superpowers/plans/2026-08-03-alert-coverage-and-escalation.md
@@ -273,8 +273,25 @@ git commit -m "feat(flux): add discord notification provider and error alert"
 
 ### Task 2: Add a `severity=critical` child route and a second contact point
 
+> **Decision 2026-08-12: not now.** Deliberately deferred, not forgotten — see rationale below.
+
 > **Requires a credential** (DG-2): a second Discord webhook URL, ideally to a different channel.
 > **Loud warning:** a syntax error in `policies.yaml` can drop **all** Grafana alert routing silently. Step 4's render check is not optional.
+
+**Why deferred:** three reasons, together. (1) It's blocked on a new credential — a second Discord
+webhook — plus the plumbing that comes with it: a new `*.sops.env` file, a `secretGenerator` entry,
+and a fourth `valuesFrom` targetPath. (2) It doubles the blast radius of `policies.yaml`: a syntax
+error there already silently drops *all* Grafana alert routing (see the loud warning above), and a
+second route is a second place to get that wrong. (3) Its measurable benefit dropped to
+approximately zero after the `feat/grafana-alert-noise-reduction` noise-reduction work
+(`docs/superpowers/specs/2026-08-12-discord-alert-noise-reduction-design.md`): expected volume is
+now ~13 messages/week, and at that rate there is nothing left to meaningfully escalate away from.
+The real value in DG-2 was always option (b) — an ntfy.sh push, which actually wakes someone at
+03:00 — not a second Discord channel that two people both already read.
+
+**Recommendation:** re-evaluate after ~2 weeks of the noise-reduction change running in production
+(around 2026-08-26). If the volume estimate holds, do the ntfy.sh push and this Discord child route
+together as one PR, rather than shipping the lower-value half alone.
 
 **Files:**
 - Create: `apps/clusters/feathre-core/base-apps/grafana/grafana-discord-critical.sops.env`

--- a/docs/superpowers/specs/2026-07-18-discord-alert-notification-design.md
+++ b/docs/superpowers/specs/2026-07-18-discord-alert-notification-design.md
@@ -1,7 +1,16 @@
 # Discord alert notification redesign
 
+> **Superseded 2026-08-12:** this bullet-list layout and its `reReplaceAll`-over-`summary`
+> approach were replaced by a structured-annotation, monospace-table layout (commits `1c0ed60`,
+> `8eee395`, `d7ea580`, `55ee41c`). The "no instance cap" decision under Out of scope below was
+> also reversed — Discord's 2000-rune hard truncation risked leaving the new code-fenced table
+> unclosed, so the current design caps the list at 8 instances. See
+> `docs/superpowers/specs/2026-08-12-discord-alert-noise-reduction-design.md` for the current
+> design, including a more precise version of the `.CommonLabels`/`.CommonAnnotations` invariant
+> noted below. Kept here for history only — do not implement against this document.
+
 **Date:** 2026-07-18
-**Status:** Approved for planning
+**Status:** Superseded — see note above
 
 ## Summary
 

--- a/docs/superpowers/specs/2026-07-18-monitoring-alerting-gaps-design.md
+++ b/docs/superpowers/specs/2026-07-18-monitoring-alerting-gaps-design.md
@@ -2,7 +2,7 @@
 
 > **Partially stale as of 2026-08-12:** the rule count and the `noDataState` cross-cutting decision
 > below no longer match the live rule set. The 5 rules this document was scoped against have grown
-> to **23 rules across 8 groups** (`core_services`, `backups`, `storage`, `databases`,
+> to **24 rules across 8 groups** (`core_services`, `backups`, `storage`, `databases`,
 > `cluster_health`, `observability`, `node_health`, `certificates`), covering most of the P0/P1
 > items below (implemented outside the commits this note is attached to). More directly: the
 > "every P0/P1 rule uses `noDataState: Alerting`" decision was **revised** for 6 of those rules

--- a/docs/superpowers/specs/2026-07-18-monitoring-alerting-gaps-design.md
+++ b/docs/superpowers/specs/2026-07-18-monitoring-alerting-gaps-design.md
@@ -1,7 +1,19 @@
 # Monitoring/alerting gaps — prioritized backlog
 
+> **Partially stale as of 2026-08-12:** the rule count and the `noDataState` cross-cutting decision
+> below no longer match the live rule set. The 5 rules this document was scoped against have grown
+> to **23 rules across 8 groups** (`core_services`, `backups`, `storage`, `databases`,
+> `cluster_health`, `observability`, `node_health`, `certificates`), covering most of the P0/P1
+> items below (implemented outside the commits this note is attached to). More directly: the
+> "every P0/P1 rule uses `noDataState: Alerting`" decision was **revised** for 6 of those rules
+> (plus `pods-stuck-terminating`) back to `OK`, based on 28-day data showing their backing metrics
+> are continuously present — see
+> `docs/superpowers/specs/2026-08-12-discord-alert-noise-reduction-design.md` ("`noDataState`
+> revision") for the measurements and the 3 rules that deliberately keep `Alerting` as sentinels.
+> The backlog table's per-item prioritization is otherwise not re-verified here.
+
 **Date:** 2026-07-18
-**Status:** Approved for planning
+**Status:** Approved for planning (see staleness note above)
 
 ## Summary
 

--- a/docs/superpowers/specs/2026-08-12-discord-alert-noise-reduction-design.md
+++ b/docs/superpowers/specs/2026-08-12-discord-alert-noise-reduction-design.md
@@ -1,0 +1,279 @@
+# Discord alert noise reduction & table layout — design
+
+**Date:** 2026-08-12
+**Status:** Shipped — commits `1c0ed60`, `8eee395`, `d7ea580`, `55ee41c` on
+`apps/clusters/feathre-core/base-apps/grafana/release.yaml` (branch
+`feat/grafana-alert-noise-reduction`).
+
+**Supersedes:** `docs/superpowers/specs/2026-07-18-discord-alert-notification-design.md` (bullet
+list, `reReplaceAll` over `summary`, no instance cap — all replaced by what's below). Also revises
+the `noDataState` cross-cutting decision and rule/group counts in
+`docs/superpowers/specs/2026-07-18-monitoring-alerting-gaps-design.md`.
+
+## Summary
+
+Two problems, one change set: (1) Discord notification volume was dominated by two Flux rules
+whose `for:` timer restarted on every ordinary reconcile blip, and (2) the per-instance bullet-list
+message layout repeated shared fields and had no cap, risking a truncated code fence on a large
+group. Both are fixed together because the fix for (1) — aggregating labels down to a stable
+identity — is also the hard prerequisite the new table layout in (2) depends on.
+
+## Part 1 — Notification volume
+
+### Baseline (measured over 7 days, alert state history)
+
+- 74,562 total state transitions; 1,568 `Pending → Alerting` crossings, both concentrated on
+  `flux-core-layer-not-ready`.
+- ~630 Discord messages/week at the old `for: 5m` / `group_interval: 5m` / `repeat_interval: 4h`
+  settings.
+- 22,102 not-ready episodes of `gotk_resource_info{ready!="True"}`: 87.9% lasted exactly 1 minute,
+  94.3% lasted under 3 minutes, none lasted longer than 20 minutes.
+
+### Root cause
+
+`gotk_resource_info` goes `ready="False"` for a single scrape during every ordinary Flux
+reconcile. The query wasn't aggregating, so `revision` (changes on every commit to `main`), `pod`,
+`instance`, and `ready` were all part of the alert-instance identity — every new label combination
+started a fresh `for:` timer and could produce a new notification, even though `for: 5m` should in
+principle have filtered 1-minute blips. A 15-minute sustain window cleanly separates the 20-minute
+worst case from real breakage (nothing in the measured history reached it).
+
+### Fix: sustain check moves from `for:` into PromQL
+
+```
+min_over_time((max by (exported_namespace, name) (gotk_resource_info{..., ready!="True"}) or
+               max by (exported_namespace, name) (gotk_resource_info{...}) * 0)[15m:1m])
+```
+
+`for:` becomes `0s`; `keepFiringFor: 15m` holds the alert open past a brief recovery. Aggregating
+to exactly `(exported_namespace, name)` — 17 labels down to 2 — is not just cleanup: it is a hard
+requirement of the Discord template (below), which builds its instance table from those two
+labels, and it's what makes the alert instance identity stable across a reconcile instead of
+changing on every `revision` bump.
+
+Replayed against the recorded 7-day history, the new query fires **3 times** instead of 1,568.
+Expected load: **~13 Discord messages/week instead of ~630** (~98% reduction, combines with the
+grouping-interval changes in Part 3). This is an estimate from replaying historical data against
+the new query — **check it against real traffic around 2026-08-19** (one week after shipping).
+
+The same `max by (...)` aggregation was applied to the two Galera PVC rules, so a pod reschedule
+(which changes the `instance` label) no longer spawns a second alert instance for the same PVC.
+
+### The `or … * 0` anchor
+
+The second term of the `or` keeps a same-labelled series alive for every object at every minute,
+purely so the alert instance doesn't disappear and trigger a MissingSeries/NoData transition (58
+of the last 100 recorded state changes were MissingSeries/NoData — nearly as much churn as real
+`for:` crossings). The anchor term must fall **inside** the `[15m:1m]` subquery window, or the
+`min_over_time` has nothing to average outside of real not-ready samples and the anchor does
+nothing.
+
+### `keepFiringFor` — the expensive trap
+
+**`keepFiringFor` must be written in camelCase in the provisioning-format YAML** — it maps to the
+Go struct field `AlertRuleV1` with `yaml:"keepFiringFor"`. Writing `keep_firing_for` (the style
+every other key in this file uses) is an **unknown key that is silently dropped — no validation
+error, no Grafana error, nothing.** The rule looks correct, applies cleanly, and simply doesn't
+keep firing.
+
+Verify it actually took by reading back the *exported* rule, not the source YAML:
+
+```
+GET /api/v1/provisioning/alert-rules/<uid>/export?format=yaml
+```
+
+If `keepFiringFor` is missing from the export, the key was dropped on ingest.
+
+### HelmRelease matcher cleanup
+
+The old regex included `metallb` and `dragonfly`, which have **zero series** in 90 days of Mimir
+retention (dead matchers — nothing to alert on). Both dropped; 9 real infra HelmReleases that were
+missing from the list were added (`alloy-logs`, `alloy-metrics`, `alloy-receiver`,
+`ceph-csi-drivers`, `kube-prometheus-stack`, `mariadb-operator-crds`, `spegel`, `step-ca`,
+`step-issuer`). `descheduler` is deliberately **not** included — it's an optimiser, not a
+dependency; nothing else in the cluster needs it Ready to function.
+
+### `noDataState` revision
+
+Six rules whose backing metrics are continuously present move `noDataState: Alerting → OK`
+(the two Ceph OSD-usage rules, the RGW error-rate rule, Ceph HEALTH_ERR, and the two CNPG
+connection-saturation rules). `pods-stuck-terminating` also moves to `OK`, for a different reason:
+its query already ends in `OR vector(0)`, so it always returns a series and the no-data path was
+unreachable dead configuration regardless of the setting.
+
+Three rules deliberately keep `noDataState: Alerting` as sentinels for missing telemetry:
+`ceph-cluster-health-warning`, `mariadb-galera-cluster-degraded`, `observability-pipeline-no-data`.
+
+### `mariadb-galera-cluster-degraded`: `for: 2m → 5m`
+
+Over 28 days, `wsrep_cluster_size < 3` totalled 7 minutes across exactly one episode of ≥2 minutes
+and zero episodes of ≥5 minutes — `for: 2m` was paging roughly once a month for a routine rolling
+restart, not a real degradation.
+
+## Part 2 — Structured annotations replace regex-sliced `summary`
+
+All 23 rules touched by `1c0ed60` gain five new annotations: `problem`, `object_label`, `object`,
+`location`, `check_command` (`dashboard_url` already existed on most). The Discord template reads
+these directly instead of regex-stripping the trailing `Check: ...` clause out of `summary`, which
+was the old design's approach (see the superseded doc).
+
+**Invariant, more precise than the one it replaces:** `problem`, `object_label`, `check_command`,
+and `dashboard_url` are read via `(index .Alerts 0)` and **must be static per rule** — never
+templated against `$labels`. Violating this produces **no error**; it silently shows instance 0's
+value for the entire notification group. Only `object` and `location` are allowed to use `$labels`,
+and they are read exclusively inside `range .Alerts` (once per instance), never via `index .Alerts
+0`. `.CommonAnnotations.location` is used only as an "all instances agree on location" detector —
+if it's set, the table renders a single shared location line instead of a per-row location column.
+
+**Consequence:** a `check_command` that would need to embed the specific node or namespace of the
+firing instance **cannot do that** — it's static. Where that specific value matters (e.g. the Flux
+rules' `flux get kustomization -A` / `flux get helmrelease -A`), the command stays generic and the
+concrete object is read from the row above it in the rendered table instead.
+
+## Part 3 — Grouping/timing (`d7ea580`)
+
+| Setting | Old | New | Why |
+|---|---|---|---|
+| `group_wait` | 30s | 1m | One full evaluation period, so every instance of a firing rule lands in one message instead of trickling in separately. Costs 30s against a 15-minute detection budget. |
+| `group_interval` | 5m | 15m | Minimum gap between two messages for the same `alertname` when group membership changes. At 5m a single group could re-send up to 12×/hour. |
+| `repeat_interval` | 4h | 24h | A repeat carries no new information. At 4h the (at the time) permanently-Stalled `mimir` HelmRelease alone cost 42 messages/week; at 24h it costs 7. Two people, no on-call rotation — see the related mimir finding below, which is exactly that alert source. |
+
+**`group_by: ['alertname']` is a hard requirement of the message layout and must not change.**
+`discord.message` assumes a notification group holds exactly the instances of one rule; changing
+`group_by` would mix instances of different rules into one table.
+
+## Part 4 — Discord message table layout (`8eee395`, `55ee41c`)
+
+### Layout
+
+A monospace two-column table inside a code fence: a 12-rune label on the left, the value on the
+right. Labels are chosen so `printf "%-12s"` (which counts **runes, not bytes**) aligns the
+multi-byte label `Prüfen` correctly alongside ASCII labels like `Seit`/`Ort`/`Betroffen`. The
+labels themselves live outside the code fence conceptually but render inside it — they are **not
+clickable inside the fence**, which is why the rule/dashboard links are printed as a separate line
+after the closing fence, not as a table row.
+
+The object column is `%-27.26s` — precision 26 plus one guaranteed separator space before the
+location column. It was originally 22 (`%-23.22s`); that truncated the Galera PVC names
+(`storage-mariadb-galera-0/-1/-2`, 24 runes each) right at the part that told the three rows apart
+— all three rendered as a bare `storage-mariadb-galera` above their (differing) node names. This
+isn't a corner case: the two-column form is used whenever `location` differs between instances,
+and for the PVC rules `location` is the node label, which differs by definition — the truncating
+path is the *normal* path for that rule, not an edge case.
+
+### Verified template engine limits
+
+Tested live against Grafana 12.3.1 via the templates-test endpoint (below). **No Sprig functions,
+no `humanizeDuration`, no arithmetic (`math.Sub` does not exist)** — all three fail with "function
+not defined". Available: `printf`, `date`, `tz`, `reReplaceAll`, `time.Now.Sub`, and methods on
+`time.Time`.
+
+Consequence: alert age is derived by regexing `time.Duration.String()` output
+(`^(([0-9]+h)?([0-9]+m)?).*$`), because there's no way to subtract components directly. The
+"instances hidden" overflow line prints the **total** instance count rather than the remainder
+past the cap, for the same reason — there's no subtraction available to compute "N more".
+
+### Escaping constraints
+
+The Grafana Helm chart renders the `alerting:` values block through `tpl`, so every Grafana
+template has to be written as a Helm **raw string** (`{{ \`...\` }}`). Consequence: the effective
+template text must contain **no backtick** (would close the raw string early) and **no single
+quote** (Helm's `toYaml` may render a single-line scalar single-quoted, which would then appear
+inside the raw string and break the surrounding Helm parse).
+
+### Discord's own limits
+
+- `message` → Discord's `content` field: hard-truncated at **2000 runes**, with a marker appended
+  on truncation. A cut landing inside the code fence would leave it unclosed and wreck the
+  rendering of the whole message — this is why the instance list is capped at **8** rows regardless
+  of how many instances are actually firing.
+- `title` → `embeds[0].title`: 256 runes.
+- Measured worst case across the 9 test cases below: **726 runes** (~2.75× headroom under 2000).
+  After the column-width fix in `55ee41c`, the worst observed render (3 full-length Galera PVC rows
+  plus a 36-rune release name cut to 26) was **566 runes**.
+
+### Testability
+
+`POST /api/alertmanager/grafana/config/api/v1/templates/test` renders a template **without writing
+any config and without sending a real message** — body shape: `{"name": "<define-name>",
+"template": "<full template text>", "alerts": [...]}`. This is what both `8eee395` and `55ee41c`
+were verified against, across 9 cases for the initial layout (single instance, 12 instances,
+resolved-only scalar rule, mixed firing/resolved with differing locations, missing
+`dashboard_url`, missing `check_command`, over-long object name, empty object, fresh `startsAt`)
+and again for the column-width fix (3 Galera PVC rows, a 36-rune release name, the single-column
+shared-location form).
+
+**`POST /api/alertmanager/grafana/config/api/v1/receivers/test` is a different endpoint that
+actually posts to the Discord channel** — do not use it for iterating on template text.
+
+The contact point itself is untouched: `discord.title`/`discord.message` are still the names
+referenced from `contactpoints.yaml`, so the existing Flux `valuesFrom` targetPath into
+`contactPoints[0].receivers[0].settings.url` keeps working.
+
+## Accepted blindness
+
+Flux resources that are not-Ready for under 14 continuous minutes are now invisible to alerting —
+that's 98.5% of all recorded episodes, which is normal reconcile noise, not something worth paging
+on. `mariadb-operator` is a known case that stays under this radar: it flaps for a measured 418
+minutes/week with individual streaks up to 14 minutes and will never trigger the new 15-minute
+sustain rule. That belongs on a dashboard, not in an alert.
+
+## Open finding: kube-state-metrics outage is a blind spot for both Flux rules
+
+If `kube-state-metrics` stops producing data, both Flux rules (`flux-core-layer-not-ready`,
+`core-infra-helmrelease-not-ready`) read as healthy — `noDataState: OK`, and the `* 0` anchor
+disappears along with the real data, so there's nothing left to alert on either. This is **not**
+covered by `observability-pipeline-no-data`, which watches `job="kubelet"`, a different scrape
+target. Measured exposure: 1 missing minute in 28 days — small, but not zero.
+
+A candidate follow-up rule (`absent(up{job="kube-state-metrics"})`, or the same
+`count(...) < 1` pattern `observability-pipeline-no-data` uses) is under review but **not yet
+committed** — treat this as an open item, not a shipped mitigation, until it lands.
+
+## Measurement pitfall for future alert-noise analyses
+
+A `[30d:1m]` subquery against Mimir reports roughly 275 missing minutes for **every** metric, not
+because anything is actually down, but because Mimir's retention ends at ~29.81 days — `absent()`
+(or any no-data check) sees the pre-retention edge and reads it as a ~4.5 hour outage. Measure
+against **28 days**, not 30, to avoid this artifact.
+
+## Alert group count correction
+
+The rule set is organised into **8** groups, not 7: `core_services`, `backups`, `storage`,
+`databases`, `cluster_health`, `observability`, `node_health`, `certificates` — all with
+`interval: 60s`.
+
+## Related open finding: `mimir` HelmRelease bookkeeping stall
+
+Separately from this branch, on `fix/mimir-upgrade-remediation` (commit `46000f7`, not yet
+merged): the `mimir` HelmRelease has read `Ready=False`/`Stalled=RetriesExceeded` since
+`2026-07-14T21:23:23Z`. Root cause: a Helm upgrade ran into the default 5-minute timeout while
+mimir-distributed pods were crashlooping during the concurrent S3/RGW `AccessDenied` incident, and
+`apps/base/mimir/release.yaml` carried no `upgrade:` stanza — so the Flux default
+`upgrade.remediation.retries: 0` applied, one attempt was made, and the release has stayed
+`Stalled` for 29 days since, even though every pod has run healthy the whole time. Pure bookkeeping
+debt, not a live outage. `loki` and `tempo` already had the fix (`upgrade.remediation.retries: 3`).
+
+**This interacts directly with the noise-reduction work above:** `mimir` is in the HelmRelease
+matcher regex, so once this branch merges, the persistently-Stalled `mimir` release will keep the
+new sustained `core-infra-helmrelease-not-ready` alert firing continuously until the remediation
+fix lands — at `repeat_interval: 24h` that's one Discord message/day from a condition that isn't a
+real incident. It's the same `mimir` release the `repeat_interval` rationale in Part 3 cited as the
+costly example at the old 4h setting.
+
+**Broader systemic gap, open, not yet actioned:** 12 more HelmReleases have no `upgrade:` stanza
+and carry the identical risk (one failed attempt during a transient outage → permanently `Stalled`
+until someone notices and deletes the failed-release history):
+
+- `apps/base/`: `harbor`, `outline`, `uptime-kuma`, `leantime`, `dependency-track`, `bluemap`,
+  `vulpes-backend`, `shlink`, `otis`, `reposilite` (10 — note: `reposilite`'s file is
+  `release.yml`, not `release.yaml`, which is why a naive glob for `*/release.yaml` misses it).
+- `apps/clusters/feathre-core/apps/`: `otis-dev`, `vulpes-backend-dev` (2).
+
+`harbor` is the riskiest of these: a multi-component chart with PVCs and a Postgres dependency —
+exactly the profile that outgrows a 5-minute default timeout. Its `values:` block does contain a
+`timeout: 5m0s`, but that's a **red herring** — it's under `trivy:` (the vulnerability-scan
+timeout), not `spec.timeout`; `harbor`'s Flux-level timeout is unset just like the other 11.
+
+Recommendation: add `upgrade: {remediation: {retries: 3}, timeout: 20m0s}` (the `loki`/`tempo`/
+`mimir` precedent) across these 12, as its own follow-up — not decided or scheduled here.

--- a/docs/superpowers/specs/2026-08-12-discord-alert-noise-reduction-design.md
+++ b/docs/superpowers/specs/2026-08-12-discord-alert-noise-reduction-design.md
@@ -1,7 +1,7 @@
 # Discord alert noise reduction & table layout — design
 
-**Date:** 2026-08-12
-**Status:** Shipped — commits `1c0ed60`, `8eee395`, `d7ea580`, `55ee41c` on
+**Date:** 2026-08-12 (updated same day after `455edcf`, `959f39a`)
+**Status:** Shipped — commits `1c0ed60`, `8eee395`, `d7ea580`, `55ee41c`, `455edcf`, `959f39a` on
 `apps/clusters/feathre-core/base-apps/grafana/release.yaml` (branch
 `feat/grafana-alert-noise-reduction`).
 
@@ -56,6 +56,12 @@ Expected load: **~13 Discord messages/week instead of ~630** (~98% reduction, co
 grouping-interval changes in Part 3). This is an estimate from replaying historical data against
 the new query — **check it against real traffic around 2026-08-19** (one week after shipping).
 
+**Detection latency: ~15–17 minutes, not 14–16.** `[15m:1m]` is left-open, so it evaluates 15
+points spanning **14 real minutes**, on top of which: `for: 0s` adds nothing; the `interval: 60s`
+evaluation cadence adds up to 60s of jitter; and routing's `group_wait: 1m` adds up to another 60s
+before the message actually sends. Best case ends up ~14–15 minutes, worst case ~16–17 minutes. An
+earlier pass at this number ("14–16 min") missed the `group_wait` contribution.
+
 The same `max by (...)` aggregation was applied to the two Galera PVC rules, so a pod reschedule
 (which changes the `instance` label) no longer spawns a second alert instance for the same PVC.
 
@@ -67,6 +73,35 @@ of the last 100 recorded state changes were MissingSeries/NoData — nearly as m
 `for:` crossings). The anchor term must fall **inside** the `[15m:1m]` subquery window, or the
 `min_over_time` has nothing to average outside of real not-ready samples and the anchor does
 nothing.
+
+### Verified against a real incident: overlapping-series false-alarm concern, cleared
+
+The obvious worry with `max by (exported_namespace, name)`: it collapses *all* series for an
+object, so if a `ready="True"` series and a `ready="False"` series exist for the same object at the
+same instant (e.g. during a kube-state-metrics staleness overlap), `max` returns `1` even though
+the object is healthy — a permanent false positive waiting to happen.
+
+This was checked against a real event, not just reasoned about, and the result clears the design —
+recorded here so the concern doesn't get re-raised from scratch:
+
+- `max_over_time((count by (exported_namespace, name)(gotk_resource_info{customresource_kind="Kustomization"}))[30d:1m])`
+  returns **2** for five objects (`base-apps`, `base-configs`, `base-controllers`, `controllers`,
+  `monitoring`); a 7-day window shows a steady 1 for the same objects — so the overlap event sits
+  between 7 and 30 days back.
+- Localised to **2026-08-04, ~08:30–09:30 UTC**, `revision` label `main@sha1:d50090a7…` —
+  commit `d50090a feat(rook): raise the bakery bucket quota to four`. An ordinary push triggered a
+  cascading reconcile of dependent layers.
+- Raw data for that hour shows exactly the feared pattern: all five objects briefly carried **three
+  co-existing series** (`ready="True"`, `="False"`, `="Unknown"`) with tightly interleaved
+  timestamps.
+- **The production expression, evaluated across 08:00–12:00 (241 points × 13 objects, 60s step):
+  returned 0 for all 13 objects throughout — no firing.** `min_over_time` requires all 15 embedded
+  minutes to be non-`True`; a brief transition overlap doesn't satisfy that.
+- **Open residual risk (suspected, not confirmed):** what was checked was staleness overlap from a
+  *single* kube-state-metrics pod. The other plausible case — two pods running in parallel during a
+  rolling restart, each reporting a contradictory `ready` value at the exact same timestamp — was
+  not resolved down to the second. Over 30 days the maximum concurrent-pod count was 2, but that was
+  never correlated against a concrete `gotk_resource_info` overlap.
 
 ### `keepFiringFor` — the expensive trap
 
@@ -112,8 +147,10 @@ restart, not a real degradation.
 
 ## Part 2 — Structured annotations replace regex-sliced `summary`
 
-All 23 rules touched by `1c0ed60` gain five new annotations: `problem`, `object_label`, `object`,
-`location`, `check_command` (`dashboard_url` already existed on most). The Discord template reads
+All 23 rules that existed at the time of `1c0ed60` gain five new annotations: `problem`,
+`object_label`, `object`, `location`, `check_command` (`dashboard_url` already existed on most).
+The 24th rule (`kube-state-metrics-down`, added later by `455edcf` — see below) was written
+directly against this convention, so all **24** rules now carry it. The Discord template reads
 these directly instead of regex-stripping the trailing `Check: ...` clause out of `summary`, which
 was the old design's approach (see the superseded doc).
 
@@ -130,13 +167,39 @@ firing instance **cannot do that** — it's static. Where that specific value ma
 rules' `flux get kustomization -A` / `flux get helmrelease -A`), the command stays generic and the
 concrete object is read from the row above it in the rendered table instead.
 
-## Part 3 — Grouping/timing (`d7ea580`)
+**Concrete example of what the invariant costs:** the clock-drift rules' `check_command` uses the
+literal placeholder `<node>` rather than `{{ $labels.instance }}`. A reviewer proposed swapping in
+`$labels.instance` for a directly runnable command; that was rejected — `check_command` is read via
+`(index .Alerts 0)`, so templating it against `$labels` would make the whole notification group
+show instance 0's node for every row, silently. `<node>` is the correct static answer; the real
+value per instance is already visible one line up, in the object row.
 
-| Setting | Old | New | Why |
-|---|---|---|---|
-| `group_wait` | 30s | 1m | One full evaluation period, so every instance of a firing rule lands in one message instead of trickling in separately. Costs 30s against a 15-minute detection budget. |
-| `group_interval` | 5m | 15m | Minimum gap between two messages for the same `alertname` when group membership changes. At 5m a single group could re-send up to 12×/hour. |
-| `repeat_interval` | 4h | 24h | A repeat carries no new information. At 4h the (at the time) permanently-Stalled `mimir` HelmRelease alone cost 42 messages/week; at 24h it costs 7. Two people, no on-call rotation — see the related mimir finding below, which is exactly that alert source. |
+## Part 3 — Grouping/timing (`d7ea580`, then corrected by `959f39a`)
+
+Current, final policy: `group_by: ['alertname']`, `group_wait: 1m`, `group_interval: 5m`,
+`repeat_interval: 24h` — ordering `1m ≤ 5m ≤ 24h` holds.
+
+| Setting | Original | `d7ea580` | `959f39a` | Why |
+|---|---|---|---|---|
+| `group_wait` | 30s | **1m** (final) | unchanged | One full evaluation period, so every instance of a firing rule lands in one message instead of trickling in separately. |
+| `group_interval` | 5m | 15m | **5m** (final — reverted) | See below. |
+| `repeat_interval` | 4h | **24h** (final) | unchanged | A repeat carries no new information. At 4h the (at the time) permanently-Stalled `mimir` HelmRelease alone cost 42 messages/week; at 24h it costs 7. Two people, no on-call rotation — see the related mimir finding below, which is exactly that alert source. |
+
+**`group_interval` went to 15m and back to 5m within the same day.** `d7ea580`'s reasoning was
+sound at the time — damp the membership-churn noise the old, non-aggregated Flux queries produced
+(a single group could otherwise re-send up to 12×/hour). But `1c0ed60` fixed that churn at its
+source in the same change set: the sustain check moved into PromQL and the label set went from 17
+labels down to 2, measured at 3 firings/week instead of 1,568. Once the root cause was gone, the
+15m damping was pure cost with no remaining benefit:
+
+- `keepFiringFor: 15m` stacked with `group_interval: 15m` meant a worst case of **~30 minutes**
+  between a real recovery and the RESOLVED message actually going out.
+- Because `group_by: ['alertname']` groups by rule, a newly-affected object (say, a second
+  Kustomization going not-Ready) also waited up to a full `group_interval` for the next flush
+  before being reported **at all** — up to 15 minutes of silence on a brand-new problem.
+
+`959f39a` reverts to 5m, halving both: worst-case RESOLVED delay drops to ~20 minutes, and a new
+object's first report is capped at 5 minutes instead of 15.
 
 **`group_by: ['alertname']` is a hard requirement of the message layout and must not change.**
 `discord.message` assumes a notification group holds exactly the instances of one rule; changing
@@ -160,6 +223,10 @@ location column. It was originally 22 (`%-23.22s`); that truncated the Galera PV
 isn't a corner case: the two-column form is used whenever `location` differs between instances,
 and for the PVC rules `location` is the node label, which differs by definition — the truncating
 path is the *normal* path for that rule, not an edge case.
+
+The separator lines are 44 × U+2500 (`─`, box-drawings light horizontal), and the "instances
+hidden" line uses U+2026 (`…`, horizontal ellipsis) rather than three periods. If Discord ever
+wraps these differently on mobile, `-` and `...` are the two ASCII fallbacks to swap in.
 
 ### Verified template engine limits
 
@@ -218,17 +285,38 @@ on. `mariadb-operator` is a known case that stays under this radar: it flaps for
 minutes/week with individual streaks up to 14 minutes and will never trigger the new 15-minute
 sustain rule. That belongs on a dashboard, not in an alert.
 
-## Open finding: kube-state-metrics outage is a blind spot for both Flux rules
+## Fixed in `455edcf`: kube-state-metrics outage was a blind spot for both Flux rules
 
 If `kube-state-metrics` stops producing data, both Flux rules (`flux-core-layer-not-ready`,
 `core-infra-helmrelease-not-ready`) read as healthy — `noDataState: OK`, and the `* 0` anchor
-disappears along with the real data, so there's nothing left to alert on either. This is **not**
+disappears along with the real data, so there was nothing left to alert on either. This was **not**
 covered by `observability-pipeline-no-data`, which watches `job="kubelet"`, a different scrape
-target. Measured exposure: 1 missing minute in 28 days — small, but not zero.
+target.
 
-A candidate follow-up rule (`absent(up{job="kube-state-metrics"})`, or the same
-`count(...) < 1` pattern `observability-pipeline-no-data` uses) is under review but **not yet
-committed** — treat this as an open item, not a shipped mitigation, until it lands.
+**Closed** by a new rule, `kube-state-metrics-down` (group `observability`, folder `Observability`,
+placed directly after `observability-pipeline-no-data`): `expr: count(up{job="kube-state-metrics"})`
+with a `lt 1` threshold, `for: 5m`, `noDataState: Alerting`, `execErrState: Alerting`,
+`severity: critical`.
+
+**Why `count(...) < 1` and not `absent(up{job="kube-state-metrics"})`:** a reviewer proposed the
+`absent()` form with `noDataState: OK`. Rejected for two reasons. (a) Consistency — the sibling
+rule in the same group, `observability-pipeline-no-data`, already uses the `count()` pattern, and
+its inline comment documents `absent()` as a *past real bug* in this file. (b) Robustness — with
+`absent()`, the rule sits permanently in `NoData` while healthy and depends on `noDataState: OK` to
+stay quiet, which would also swallow a genuine datasource outage or query error instead of
+alerting on it. With `count()`, the rule sits in `Normal` while healthy, and `NoData` stays
+reserved for the failure mode it's actually meant to catch. Both expressions were checked live
+against Mimir: `count(...)` returns `1` in the healthy state (not `< 1`, not firing); `absent(...)`
+returns an empty vector.
+
+Verified facts worth keeping on record: kube-state-metrics runs in namespace **`monitoring`** (not
+`grafana`), single replica, and `job="kube-state-metrics"` is the real label — hence
+`check_command: "kubectl -n monitoring get pods -l app.kubernetes.io/name=kube-state-metrics"`.
+
+**No `dashboard_url`, deliberately:** the kube-state-metrics dashboard exists (uid
+`kubernetes-objects-native`, "Kubernetes Objects"), but isn't linked — it's rendered entirely from
+the same metrics that are missing while this alert fires, so it would just be empty. Same reasoning
+already used for the `mariadb-galera-backup` rule's missing `dashboard_url`.
 
 ## Measurement pitfall for future alert-noise analyses
 
@@ -237,11 +325,11 @@ because anything is actually down, but because Mimir's retention ends at ~29.81 
 (or any no-data check) sees the pre-retention edge and reads it as a ~4.5 hour outage. Measure
 against **28 days**, not 30, to avoid this artifact.
 
-## Alert group count correction
+## Rule and group count correction
 
-The rule set is organised into **8** groups, not 7: `core_services`, `backups`, `storage`,
-`databases`, `cluster_health`, `observability`, `node_health`, `certificates` — all with
-`interval: 60s`.
+The rule set is now **24** rules (not 23 — `455edcf` added `kube-state-metrics-down`), organised
+into **8** groups, not 7: `core_services`, `backups`, `storage`, `databases`, `cluster_health`,
+`observability`, `node_health`, `certificates` — all with `interval: 60s`.
 
 ## Related open finding: `mimir` HelmRelease bookkeeping stall
 


### PR DESCRIPTION
## Why

Grafana alerting was firing on normal Flux reconcile churn and had become unactionable. Measured over 7 days against Mimir:

- `flux-core-layer-not-ready`: **74,562 state transitions**, 1,568 `Pending → Alerting` (~224/day) — 99% of all alert-state churn in the instance
- **~630 Discord notifications / week** (~90/day)
- 22,102 not-Ready episodes across 13 Kustomizations. **87.9% lasted exactly 1 minute**, 94.3% under 3 minutes, and **not a single one exceeded 20 minutes**

The existing `for: 5m` did not help, and raising it would not have either. The root cause was alert *identity*, not duration: the queries were unaggregated, so `revision` (which changes on every commit to `main`), `pod`, `instance` and `ready` were part of each alert instance's label set. Every new label set started a fresh `for` timer and produced a new notification. The permanently-broken `mimir` HelmRelease alone produced 32 Alerting transitions instead of 1.

## What changed

**Sustain check moved from `for` into PromQL.** The two Flux rules now use

```promql
min_over_time((max by (exported_namespace, name) (gotk_resource_info{customresource_kind="Kustomization", ready!="True"})
            or max by (exported_namespace, name) (gotk_resource_info{customresource_kind="Kustomization"}) * 0)[15m:1m])
```

with `for: 0s` and `keepFiringFor: 15m`. The `or … * 0` anchor keeps a series alive for every object at every minute, so the alert instance never disappears and `MissingSeries` churn cannot occur (58 of the last 100 state transitions were MissingSeries/NoData). `ready!="True"` also covers `Unknown` (stuck reconcile) at zero measured cost. Instance label set drops from 17 labels to 2.

Measured with this expression over the same 7 days: **3 firings instead of 1,568.**

**Discord notifications are now an aligned monospace table** — a 12-rune label column on the left, the value on the right; two columns ("what" / "where") when instances differ in location. Values come from structured annotations (`problem`, `object_key`, `location_key`, `check_command`) instead of a regex that sliced `summary` apart. Links sit outside the code fence so they stay clickable.

**A 24th rule closes a blind spot this change introduced.** No rule watched `up{job="kube-state-metrics"}`. If it fails, `gotk_resource_info` disappears — and with `noDataState: OK` plus the anchor gone, both Flux rules would report healthy. Previously there was at least MissingSeries noise; now the failure would be entirely silent. `kube-state-metrics-down` uses `count(...) < 1` with `noDataState: Alerting`, matching the pattern of its sibling `observability-pipeline-no-data` (whose inline comment documents `absent()` as a past bug in this file).

**Dead and wrong configuration removed.** `metallb` and `dragonfly` were in the HelmRelease regex but have never existed in 90 days of Mimir retention. Nine real infrastructure releases were added; `descheduler` deliberately excluded (an optimiser, not a dependency).

**Other tuning**, each backed by 28-day data: `mariadb-galera-cluster-degraded` `for: 2m → 5m` (exactly one ≥2min episode and zero ≥5min episodes in 28 days); seven rules flipped `noDataState: Alerting → OK` where absence of a metric is a measurement failure, not the condition — `ceph-cluster-health-warning`, `mariadb-galera-cluster-degraded` and `observability-pipeline-no-data` deliberately keep `Alerting`; PVC rules aggregated to `by (persistentvolumeclaim, node)`. No threshold was changed.

## Resolved-notification bug, fixed properly

[grafana/grafana#114973](https://github.com/grafana/grafana/issues/114973) makes RESOLVED notifications show raw `{{ $labels.x }}` text. Confirmed in the v12.3.1 source: `warmStateCache` in `pkg/services/ngalert/state/manager.go` restores `ruleForEntry.Annotations` — the rule's *raw template text* — while `Labels` come from the persisted instance. Instance labels are persisted; rendered annotations are not. The trigger is a **Grafana restart** (Helm upgrade, node drain, OOM) followed by a resolve. Fixed upstream in 12.4.x, **no 12.3.x backport**.

Previously cosmetic; with a table layout it would have put raw placeholders into the columns. It also silently broke the "do all instances agree?" check, which compared identical template *strings* and collapsed three PVCs on three different nodes into one row — hiding real information.

Fix: read columns from `.Labels` directly (`index $a.Labels $f.Annotations.object_key`), which is exactly why the queries aggregate to those labels. Labels are never templated. The agreement check uses `index .CommonLabels $key`, empty precisely when instances disagree.

## Verification

- `./scripts/validate.sh` green on every commit — all 13 Flux paths, `Invalid: 0, Errors: 0`
- **26 template renders** against `POST /api/alertmanager/grafana/config/api/v1/templates/test` (render-only; no notification was ever sent). Covered: single instance, 12 instances with overflow cap, resolved, mixed firing+resolved, missing `dashboard_url`, missing `check_command`, 36-rune object names, empty label, fresh alert, and raw-annotation inputs reproducing the restart bug. Every result: fences balanced, label column exactly 12 runes, object column 27 runes, longest output 908 runes against Discord's hard 2000-rune cap
- Both new queries verified read-only against Mimir: exactly **13** and **19** series, carrying only `exported_namespace` and `name`
- The obvious risk — a permanent false alarm when `max by (...)` sees contradictory `ready` values for one object — was tested against a **real incident**: on 2026-08-04 (commit `d50090a`) five Kustomizations had three coexisting series each (`True`/`False`/`Unknown`) during a cascading reconcile. The production expression over that 4-hour window, 241 points × 13 objects: **0 throughout, no firing**

## Expected effect

| | before (measured) | after (projected) |
|---|---|---|
| Discord notifications | ~630 / week | **~13 / week** |
| Flux rule firings | 1,568 / week | **3 / week** |
| Detection latency | 5 min nominal | 15–17 min |

## Rollout notes

1. **Grafana reads alerting provisioning only at startup.** Confirm the pod actually rolled after the reconcile — if it did not, none of this is loaded.
2. **A one-time large RESOLVED batch is expected.** Every existing 17-label instance loses its identity, so Grafana resolves them all on the first evaluation. This is not a failure.
3. **`mimir` will fire immediately** under its new 2-label identity. That is a true positive — see the companion PR for `fix/mimir-upgrade-remediation`.
4. **Verify `keepFiringFor` landed:** `GET /api/v1/provisioning/alert-rules/flux-core-layer-not-ready/export?format=yaml`. The provisioning field is camelCase; `keep_firing_for` would be an unknown key and **silently discarded with no error anywhere**.
5. `mariadb-galera-pvc-usage-high` is live at **76.7%** against an 80% threshold. If it fires soon, that is a real finding, not a regression from this PR.

## Deliberately accepted blindness

Flux resources not-Ready for under 14 contiguous minutes are invisible — 98.5% of all episodes, i.e. normal reconcile churn. `mariadb-operator` genuinely flaps 418 minutes/week with streaks up to 14 minutes and will no longer alert; that belongs on the `flux-control-plane` dashboard, not in a notification.

The `severity=critical` escalation route from `docs/superpowers/plans/2026-08-03-alert-coverage-and-escalation.md` (Task 2) was **not** implemented: it needs a new Discord webhook credential, and it would double the blast radius in `policies.yaml`, where a syntax error silently drops *all* alert routing. At ~13 notifications/week there is nothing to escalate away from. Documented as a decision, to be revisited around 2026-08-26 together with the ntfy.sh push variant.

Full design rationale in `docs/superpowers/specs/2026-08-12-discord-alert-noise-reduction-design.md`.
