### PR TITLE
fix(mimir): add upgrade remediation retries and 20m timeout

### DIFF
--- a/apps/base/mimir/release.yaml
+++ b/apps/base/mimir/release.yaml
@@ -14,7 +14,13 @@ spec:
         namespace: flux-system
   install:
     remediation:
-      retries: 0
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  # Rolling all mimir-distributed components exceeds the default 5m;
+  # the 2026-07-14 upgrade timed out at 5m9s and stalled for 29 days.
+  timeout: 20m0s
   interval: 1m0s
   # Default values
   # https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/values.yaml


### PR DESCRIPTION
## Why

The `mimir` HelmRelease has been `Ready=False` / `Stalled=True (RetriesExceeded)` since **2026-07-14T21:23:23Z** — 29 days. Metric confirms: over 30 days, `gotk_resource_info{name="mimir", ready="False"}` has 40,942 samples against 1,497 `True`.

Nothing is actually broken. Every StatefulSet and Deployment is converged (`GEN == OBSGEN`, `currentRevision == updateRevision`), and the pods have run 28 days with zero restarts. Helm applies manifests and *then* waits — the apply succeeded, only the wait timed out. This is stale bookkeeping on an otherwise healthy component.

## Root cause

Two separate things.

**The trigger, a one-off event long over.** Commit `3d44843` rewrote `${AWS_…}` to `$${AWS_…}` in mimir's values, which changed `mimir-config` and rolled every component at 21:18 UTC. The new pods could not reach S3 — this was during the same day's RGW `AccessDenied` incident:

```
mimir-ruler, 2026-07-14T21:26:32Z:
  caller=sanity_check.go:41 level=error msg="Unable to successfully connect to configured object storage"
  err="2 errors: blocks storage: ... Access Denied.; ruler storage: ... Access Denied."
  → module failed sanity-check → exit 1
```

Six pods crash-looped with 5 restarts each, last terminations 21:26:30–21:26:57 — exactly the set named in Helm's timeout message. Helm's **default 5m wait** expired at 21:23:23 while they were still restarting. No OOMKills; every termination is `Error`/exit 1 from the sanity check. The `bucketOwner` remediation for mimir's OBCs only landed on 2026-07-18 (`f62e16a`). The pods came up clean at ~21:27 and have been fine since.

**Why it never recovered — the actual bug.** `apps/base/mimir/release.yaml` has no `upgrade:` stanza at all, so upgrade remediation defaults to `retries: 0`. helm-controller made exactly one attempt (`upgradeFailures: 1`), set `Stalled=True / RetriesExceeded`, and stopped permanently. With `observedGeneration == lastAttemptedGeneration == 6` and an unchanged config digest, Flux never re-attempts:

```
$ kubectl logs -n flux-system deploy/helm-controller --tail=5000 | grep -ci mimir
0
```

Even a helm-controller restart around 2026-08-03 did not retry — it only re-stamped the `Stalled` timestamp while leaving `Ready`'s at 2026-07-14.

The full condition:

```
Ready = False, reason: UpgradeFailed, lastTransitionTime: 2026-07-14T21:23:23Z
message: Helm upgrade failed for release grafana/mimir with chart mimir-distributed@6.1.0:
  timeout waiting for: [StatefulSet/grafana/mimir-compactor status: 'InProgress',
  StatefulSet/grafana/mimir-store-gateway, StatefulSet/grafana/mimir-ingester,
  Deployment/grafana/mimir-ruler, Deployment/grafana/mimir-querier,
  StatefulSet/grafana/mimir-alertmanager]
lastAttemptedReleaseActionDuration: 5m9.780550722s
```

## The fix

`upgrade.remediation.retries: 3` plus `timeout: 20m0s`, and `install.remediation.retries: 0 → 3`.

This is not a new pattern — the identical failure was already diagnosed and fixed for Loki (`apps/base/loki/release.yaml:18-23`, `retries: 3` + `timeout: 20m0s`, with a comment noting its cutover upgrade timed out at ~5m12s) and Tempo (`apps/base/tempo/release.yaml:18-20`). **Mimir was the only monitoring-layer HelmRelease with no `upgrade:` stanza whatsoever.** This carries that fix over.

`remediateLastFailure` is deliberately **not** set, matching Loki and Tempo. It would make helm-controller run a Helm rollback after the final retry, which for a stateful metrics backend is the wrong failure mode: it re-applies the previous StatefulSet spec, rolling every pod a second time while things are already unhealthy, and can revert config that ingesters and compactors on disk have moved past. It would also not have helped here — the cause was external (S3), so the old revision would have failed identically. A stalled `Ready=False` is loud and safe.

## Verification

`./scripts/validate.sh` green — all 13 Flux paths, `Invalid: 0, Errors: 0`. `kubectl kustomize apps/clusters/feathre-core/monitoring/mimir` renders all three settings, and the existing `postRenderers` priorityClassName patches are unaffected.

## Rollout notes

**Adding the stanza bumps the HelmRelease generation, so helm-controller re-attempts the upgrade automatically** — no manual `flux reconcile` needed. Two consequences:

1. **The re-attempt rolls all Mimir components** → brief ingest gap. The Grafana alerting path evaluates against Mimir, so alert evaluation is degraded during the roll. Merge at a quiet moment.
2. Verify RGW/S3 health before this lands, since that was the original trigger.

## Systemic follow-up (not in this PR)

**12** other HelmReleases have no `upgrade:` stanza and the same silent-permanent-stall risk. In `apps/base/`: `harbor`, `outline`, `uptime-kuma`, `leantime`, `dependency-track`, `bluemap`, `vulpes-backend`, `shlink`, `otis`, `reposilite`. In `apps/clusters/feathre-core/apps/`: `otis-dev`, `vulpes-backend-dev`.

`harbor` is the highest-risk one — a multi-component chart with PVCs and a shared-Postgres dependency, exactly the profile that blows a 5-minute default. Note the `timeout: 5m0s` at `apps/clusters/feathre-core/base-apps/harbor/release.yaml:927` is a red herring: it is the Trivy scan-completion timeout inside `values:`, not `spec.timeout`. Harbor has no Helm-level timeout or upgrade remediation at all.
