### PR TITLE
feat(grafana): send discord alerts as embeds via webhook payload template

### DIFF
--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -27466,29 +27466,73 @@ spec:
         secret:
           apiVersion: 1
           contactPoints:
+            # type: webhook, not discord - only webhook supports settings.payload.template (Grafana 12.0+).
+            # settings.url stays at this exact YAML position so the Flux valuesFrom targetPath keeps resolving.
+            # No username in the payload, so Discord uses the name configured on the webhook itself.
             - orgId: 1
               name: discord
               receivers:
                 - uid: discord_webhook
-                  type: discord
+                  type: webhook
                   settings:
                     url: "placeholder-overwritten-by-valuesFrom"
-                    use_discord_username: true
-                    title: '{{ `{{ template "discord.title" . }}` }}'
-                    message: '{{ `{{ template "discord.message" . }}` }}'
+                    httpMethod: POST
+                    payload:
+                      template: '{{ `{{ template "discord.payload" . }}` }}'
       templates.yaml:
         apiVersion: 1
         templates:
-          # Static annotations (problem/object_label/object_key/location_key/check_command/location) are read
-          # from (index .Alerts 0), so a rule must never template them per-$labels - a wrong instance would
-          # silently supply the value. The per-instance table columns are read from $a.Labels via the *_key
-          # names, never from a $labels-templated annotation: Grafana 12.3 restores the RAW annotation
-          # template after a restart (grafana#114973), while instance labels are persisted correctly.
-          # The effective template must contain no backtick (it would end the Helm raw string) and no single
-          # quote (toYaml may single-quote a scalar). Discord hard-truncates message at 2000 runes, which would
-          # rip the code fence open - hence the 8-instance cap. printf widths count runes, not bytes.
+          # Static annotations come from (index .Alerts 0) and must never be templated per-$labels in
+          # a rule; per-instance values come from index $a.Labels (Labels, never templated annotations):
+          # after a restart warmStateCache hands back the RAW annotation template (grafana#114973,
+          # fixed in 12.4.x), while instance labels survive correctly.
+          # Three escaping layers (Helm raw string -> chart toYaml/tpl -> Go template): the effective
+          # template must contain no backtick (use "\u0060" - Helm ignores \u in a raw string, Go
+          # string literals do not), no single quote (toYaml may single-quote a scalar), and no line
+          # may end in whitespace.
+          # The payload is built via coll.Dict/coll.Slice and serialized by data.ToJSON (= json.Marshal),
+          # never concatenated, so no value can break the JSON. Every printf precision is a Discord
+          # limit guard; the 12-instance cap follows from field.value <= 1024 (worst case 71 runes/line
+          # x 12 + 38 = 890). printf counts runes. No arithmetic is available (no sprig, no math.Sub).
           - name: discord.title
-            template: '{{ `{{ define "discord.title" }}` }}{{ `{{ if eq .Status "firing" }}` }}🔴 FIRING{{ `{{ if gt (len .Alerts.Firing) 1 }}` }} ({{ `{{ len .Alerts.Firing }}` }}x){{ `{{ end }}` }}{{ `{{ else }}` }}✅ RESOLVED{{ `{{ if gt (len .Alerts.Resolved) 1 }}` }} ({{ `{{ len .Alerts.Resolved }}` }}x){{ `{{ end }}` }}{{ `{{ end }}` }} · {{ `{{ .CommonLabels.alertname }}` }}{{ `{{ end }}` }}'
+            template: '{{ `{{ define "discord.title" }}` }}{{ `{{ if eq .Status "firing" }}` }}{{ `{{ if eq (index .CommonLabels "severity") "warning" }}` }}🟠{{ `{{ else }}` }}🔴{{ `{{ end }}` }} FIRING{{ `{{ if gt (len .Alerts.Firing) 1 }}` }} ({{ `{{ len .Alerts.Firing }}` }}x){{ `{{ end }}` }}{{ `{{ else }}` }}✅ RESOLVED{{ `{{ if gt (len .Alerts.Resolved) 1 }}` }} ({{ `{{ len .Alerts.Resolved }}` }}x){{ `{{ end }}` }}{{ `{{ end }}` }} · {{ `{{ index .CommonLabels "alertname" }}` }}{{ `{{ end }}` }}'
+          - name: discord.payload
+            template: |
+              {{ `{{- define "discord.payload" -}}` }}
+              {{ `{{- $f := index .Alerts 0 -}}` }}
+              {{ `{{- $ok := $f.Annotations.object_key -}}` }}
+              {{ `{{- $lk := $f.Annotations.location_key -}}` }}
+              {{ `{{- $loc := or (and $lk (index .CommonLabels $lk)) $f.Annotations.location -}}` }}
+              {{ `{{- $age := reReplaceAll "^(([0-9]+h)?([0-9]+m)?).*$" "$1" (printf "%s" (time.Now.Sub $f.StartsAt)) -}}` }}
+              {{ `{{- $sev := index $f.Labels "severity" -}}` }}
+              {{ `{{- $bt := "\u0060" -}}` }}
+              {{ `{{- $color := 15548997 -}}{{- if eq .Status "resolved" -}}{{- $color = 5763719 -}}{{- else if eq $sev "warning" -}}{{- $color = 16426522 -}}{{- end -}}` }}
+              {{ `{{- $ts := $f.StartsAt -}}{{- if and (eq .Status "resolved") (not $f.EndsAt.IsZero) -}}{{- $ts = $f.EndsAt -}}{{- end -}}` }}
+              {{ `{{- $desc := or $f.Annotations.problem $f.Annotations.summary "(ohne Beschreibung)" -}}` }}
+              {{ `{{- if $f.Annotations.dashboard_url -}}{{- $desc = printf "%s\n\n[📊 Dashboard öffnen](<%s>)" $desc $f.Annotations.dashboard_url -}}{{- end -}}` }}
+              {{ `{{- $fields := coll.Slice -}}` }}
+              {{ `{{- if $sev -}}{{- $fields = coll.Append (coll.Dict "name" "Schwere" "value" $sev "inline" true) $fields -}}{{- end -}}` }}
+              {{ `{{- if $loc -}}{{- $fields = coll.Append (coll.Dict "name" "Ort" "value" (printf "%.60s" $loc) "inline" true) $fields -}}{{- end -}}` }}
+              {{ `{{- if eq .Status "firing" -}}{{- $fields = coll.Append (coll.Dict "name" "Seit" "value" (or $age "<1m") "inline" true) $fields -}}{{- else -}}{{- $fields = coll.Append (coll.Dict "name" "Behoben" "value" (printf "%s Uhr" (date "15:04" (tz "Europe/Berlin" $ts))) "inline" true) $fields -}}{{- end -}}` }}
+              {{ `{{- if and $f.Annotations.object_label $ok -}}` }}
+              {{ `{{- $lines := "" -}}` }}
+              {{ `{{- range $i, $a := .Alerts -}}{{- if lt $i 12 -}}` }}
+              {{ `{{- $o := index $a.Labels $ok -}}{{- if not $o -}}{{- $o = "?" -}}{{- end -}}` }}
+              {{ `{{- $line := printf "%s%.60s%s" $bt $o $bt -}}` }}
+              {{ `{{- if and (not $loc) $lk -}}{{- $line = printf "%s%-27.26s%s %.30s" $bt $o $bt (index $a.Labels $lk) -}}{{- end -}}` }}
+              {{ `{{- if eq $a.Status "resolved" -}}{{- $line = printf "%s  (behoben)" $line -}}{{- end -}}` }}
+              {{ `{{- if eq $i 0 -}}{{- $lines = $line -}}{{- else -}}{{- $lines = printf "%s\n%s" $lines $line -}}{{- end -}}` }}
+              {{ `{{- end -}}{{- end -}}` }}
+              {{ `{{- if gt (len .Alerts) 12 -}}{{- $lines = printf "%s\n… weitere ausgeblendet (%d insgesamt)" $lines (len .Alerts) -}}{{- end -}}` }}
+              {{ `{{- $label := $f.Annotations.object_label -}}{{- if gt (len .Alerts) 1 -}}{{- $label = printf "%s (%d)" $label (len .Alerts) -}}{{- end -}}` }}
+              {{ `{{- $fields = coll.Append (coll.Dict "name" (printf "%.100s" $label) "value" (printf "%.1024s" $lines) "inline" false) $fields -}}` }}
+              {{ `{{- else if gt (len .Alerts) 1 -}}{{- $fields = coll.Append (coll.Dict "name" "Betroffen" "value" (printf "%d Instanzen" (len .Alerts)) "inline" true) $fields -}}{{- end -}}` }}
+              {{ `{{- if $f.Annotations.check_command -}}{{- $fields = coll.Append (coll.Dict "name" "Prüfen" "value" (printf "%.900s" (printf "%s%s%s" $bt $f.Annotations.check_command $bt)) "inline" false) $fields -}}{{- end -}}` }}
+              {{ `{{- $embed := coll.Dict "title" (printf "%.200s" (tmpl.Exec "discord.title" .)) "url" (or $f.GeneratorURL .ExternalURL) "color" $color "description" (printf "%.1000s" $desc) "timestamp" (date "2006-01-02T15:04:05Z07:00" $ts) "fields" $fields "footer" (coll.Dict "text" (printf "%.100s" (or (index $f.Labels "grafana_folder") "Grafana"))) -}}` }}
+              {{ `{{- data.ToJSON (coll.Dict "embeds" (coll.Slice $embed)) }}` }}
+              {{ `{{- end -}}` }}
+          # Unused while the webhook payload template overrides title/message; kept as a rollback
+          # target (type: discord restores it as-is). Delete once the embeds are a week green.
           - name: discord.message
             template: |
               {{ `{{ define "discord.message" }}{{ $f := index .Alerts 0 }}{{ $ok := $f.Annotations.object_key }}{{ $lk := $f.Annotations.location_key }}{{ $loc := or (and $lk (index .CommonLabels $lk)) .CommonAnnotations.location }}{{ $age := reReplaceAll "^(([0-9]+h)?([0-9]+m)?).*$" "$1" (printf "%s" (time.Now.Sub $f.StartsAt)) }}` }}```

--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -27,6 +27,10 @@ spec:
       name: grafana-discord
       valuesKey: webhookUrl
       targetPath: alerting.contactpoints\.yaml.secret.contactPoints[0].receivers[0].settings.url
+    - kind: Secret
+      name: grafana-discord
+      valuesKey: webhookUrl
+      targetPath: alerting.contactpoints\.yaml.secret.contactPoints[1].receivers[0].settings.url
   values:
     podLabels:
       logs.onelitefeather.net/env: prod
@@ -27479,6 +27483,17 @@ spec:
                     httpMethod: POST
                     payload:
                       template: '{{ `{{ template "discord.payload" . }}` }}'
+            # Fault-tolerant path for the meta alarms: Grafana default rendering, deliberately
+            # tied to no template, so a template error cannot take this receiver down with it.
+            # Same Discord channel.
+            - orgId: 1
+              name: discord-fallback
+              receivers:
+                - uid: discord_fallback
+                  type: discord
+                  settings:
+                    url: "placeholder-overwritten-by-valuesFrom"
+                    use_discord_username: true
       templates.yaml:
         apiVersion: 1
         templates:
@@ -27563,6 +27578,15 @@ spec:
             group_interval: 5m
             # A repeat carries no new information; two people, no on-call rotation.
             repeat_interval: 24h
+            # The meta alarm must not travel the path it reports as broken, so it goes to the
+            # fault-tolerant discord contact point. Everything else falls through to discord.
+            # Prometheus-style matchers, NOT object_matchers: the chart re-serializes values with
+            # toYaml, which emits the "=" of an object_matchers triple as a bare scalar that YAML
+            # then resolves to the special value tag instead of the string "=".
+            routes:
+              - receiver: discord-fallback
+                matchers:
+                  - alertname = "Alert notifications failing"
       rules.yaml:
         apiVersion: 1
         groups:
@@ -28655,6 +28679,68 @@ spec:
                   problem: "Keine kube-state-metrics-Daten"
                   location: "monitoring"
                   check_command: "kubectl -n monitoring get pods -l app.kubernetes.io/name=kube-state-metrics"
+                labels:
+                  severity: critical
+              - uid: alert-notifications-failing
+                title: Alert notifications failing
+                condition: B
+                data:
+                  - refId: A
+                    relativeTimeRange:
+                      from: 600
+                      to: 0
+                    datasourceUid: mimir
+                    model:
+                      editorMode: code
+                      # Both counters are registered WithSkipZeroValueMetrics, so they do not exist
+                      # at all until they were once >0 - a bare sum() would read as NoData instead
+                      # of 0. Hence "or vector(0)" per counter. Both are summed because the webhook
+                      # notifier failure path may bump either one.
+                      expr: (sum(increase(grafana_alerting_notification_requests_failed_total[10m])) or vector(0)) + (sum(increase(grafana_alerting_notifications_failed_total[10m])) or vector(0))
+                      instant: true
+                      intervalMs: 1000
+                      maxDataPoints: 43200
+                      range: false
+                      refId: A
+                  - refId: B
+                    relativeTimeRange:
+                      from: 600
+                      to: 0
+                    datasourceUid: '-100'
+                    model:
+                      conditions:
+                        - evaluator:
+                            params:
+                              - 0
+                            type: gt
+                          operator:
+                            type: and
+                          query:
+                            params:
+                              - B
+                          reducer:
+                            params: []
+                            type: last
+                          type: query
+                      datasource:
+                        type: __expr__
+                        uid: '-100'
+                      expression: A
+                      intervalMs: 1000
+                      maxDataPoints: 43200
+                      refId: B
+                      type: threshold
+                # "or vector(0)" always yields a value while Mimir is reachable, so NoData here only
+                # means the datasource itself is down - already covered by observability-pipeline-no-data,
+                # and firing this rule on it would falsely claim notifications are broken.
+                noDataState: OK
+                execErrState: Alerting
+                for: 5m
+                annotations:
+                  summary: "Grafana failed to deliver alert notifications, so Discord messages are being dropped - the webhook notifier does not retry. Alerts themselves keep evaluating and stay visible in the Grafana alerting UI, so use it as the source of truth until this clears."
+                  problem: "Discord-Zustellung schlägt fehl"
+                  location: "grafana"
+                  check_command: "kubectl -n grafana logs -l app.kubernetes.io/name=grafana --tail=200 | grep -i \"Notify for alerts failed\""
                 labels:
                   severity: critical
           - orgId: 1


### PR DESCRIPTION
## Why

Follow-up to #116. That PR replaced the bullet-list Discord notification with an aligned monospace table inside a code fence. This replaces the code fence with **real Discord embeds** — colour-coded, clickable title, timestamp, and structured fields.

The code fence had a structural weakness: Discord hard-truncates `content` at 2000 runes and appends a marker, which would leave the fence unclosed and destroy the rendering. That is why #116 capped the instance list at 8. Embeds remove that cliff.

## How

The `discord` contact point type cannot send a custom body. The `webhook` type can, via `settings.payload.template` (`receivers/webhook/v1/config.go`, "New in 12.0"; confirmed live against this instance's `GET /api/v1/ngalert/notifiers` schema). So the contact point changes type while keeping `uid: discord_webhook` and `name: discord` — the notification policy references the *name*, so routing is unaffected.

**The payload is not string-concatenated JSON.** `coll.Dict` / `coll.Slice` / `coll.Append` build a real Go data structure and `data.ToJSON` serialises it — that function is `encoding/json.Marshal` (`templates/gomplate/data.go`). A quote, backslash, newline or control character in any label or annotation value therefore *cannot* produce invalid JSON. Verified with an annotation value of `He said "hi" and C:\temp & <b>` plus a literal newline and tab: output was `\"`, `\\`, `\n`, `\t`, `\u0026`, `\u003c` — all valid, all decoding back correctly on Discord's side.

`settings.url` stays at the identical YAML position, so the Flux `valuesFrom` targetPath `alerting.contactpoints\.yaml.secret.contactPoints[0].receivers[0].settings.url` is unchanged. The webhook URL exists only in the `grafana-discord` Secret, never in git.

## Layout

```
▌🔴 FIRING (13x) · Flux core layer not ready       ← clickable → rule
▌Kustomization >15 min nicht Ready
▌
▌📊 Dashboard öffnen                                ← link
▌
▌Schwere            Seit                            ← inline fields, one row
▌critical           7h10m
▌
▌Layer (14)
▌`apps                       ` flux-system         ← inline code span, padded
▌`monitoring                 ` flux-system  (behoben)
▌… weitere ausgeblendet (14 insgesamt)
▌
▌Prüfen
▌`flux get kustomization -A`                       ← one click to copy
▌
▌Core Services • Heute um 09:20                    ← footer + timestamp, viewer TZ
└ left border red (#ED4245)
```

Colours: `15548997` red (firing/critical), `16426522` orange (firing/warning, title gets 🟠), `5763719` green (resolved).

The original goal — *left an information, right where exactly it applies* — survives where it matters, in the instance list: Discord renders inline code monospace **and preserves inner spaces**, so padding the object column with `printf "%-27.26s"` inside a code span keeps the location column aligned without a code fence that could be ripped open. Padding only happens when instances actually differ in location; otherwise the location is hoisted into its own inline field and names stay unpadded and copy-pasteable.

Honest limitation: in the header row, Discord renders the field name *above* the value, not left of it. That is how Discord draws fields and cannot be changed.

**Instance cap rises from 8 to 12**, and this time it is calculated rather than guessed. Binding limit is `field.value` = 1024, not the field count: worst-case line is 1 backtick + 27 (padded) + 1 backtick + 1 space + 30 (location) + 11 (` (behoben)`) + 1 LF = 71 runes; 12 × 71 + 38 for the overflow line = **890 ≤ 1024**. Total across all fields, theoretical maximum: 3418 ≤ 6000.

## Two non-obvious mechanics worth knowing about

**Backticks.** A literal backtick in the effective template would terminate the Helm raw string that every alerting value must be wrapped in. Solved with `{{ $bt := "\u0060" }}` — Helm does not process `\u` escapes inside a raw string, but Go template string literals do. The file contains no backtick; the output does.

**`object_matchers` is unusable here.** The child route in `policies.yaml` uses the string form `matchers:`. With `object_matchers:`, the chart's `toYaml` re-emits the `=` operator as a *bare* scalar, which YAML resolves to `tag:yaml.org,2002:value` instead of a string — the rendered `policies.yaml` then **fails to parse entirely**, which would silently disable all alert routing. This was caught in the render round-trip, not in review.

## Regression this introduces, and the mitigation

**The webhook notifier does not forgive.** On a template render error it returns `return false, tmplErr`; on a non-2xx from Discord it returns `retry=false` (`receivers/webhook/v1/webhook.go`, `notify/notify.go`). Either way: **no retry, message lost.** The old `discord` notifier logged a warning, set `tmplErr = nil` and sent anyway. So a typo in a future template edit now costs notifications where it previously cost a crooked table.

The second commit mitigates that:

- **A fallback contact point `discord-fallback`** of the old `type: discord`, pointing at the same channel, deliberately depending on **no template at all** — so a template error cannot take it down with it. It gets its URL from a second `valuesFrom` entry targeting `contactPoints[1]`.
- **A meta alert rule** `alert-notifications-failing` on `(sum(increase(grafana_alerting_notification_requests_failed_total[10m])) or vector(0)) + (sum(increase(grafana_alerting_notifications_failed_total[10m])) or vector(0))`. Both counters are registered `WithSkipZeroValueMetrics` and are therefore *absent* until non-zero — hence the `or vector(0)`. Verified: returns exactly one series with value `0` in the healthy state.
- **A child route** in `policies.yaml` sending that rule to `discord-fallback`. Without this the rule would be mute precisely when it is needed. The root route — `group_by: ['alertname']`, `group_wait: 1m`, `group_interval: 5m`, `repeat_interval: 24h` — is unchanged.

Known limits of the meta rule, stated plainly: `increase()` needs two samples, so a single isolated failure stays silent while persistent breakage accrues and fires; and if nothing is firing, nothing is delivered, so a broken template cannot be detected until some alert actually fires.

## Verification

- **Helm escaping round-trip**: `helm template grafana-labs/grafana --version 10.5.15`, both `--show-only templates/configmap.yaml` and `configSecret.yaml`. `discord.payload` matches its 33-line target text verbatim. Hard asserts: no backtick, no single quote, no trailing whitespace, no surviving raw-string opener in the new templates. Both `contactPoints[0]` and `contactPoints[1]` `settings.url` positions exist for the two Flux targetPaths.
- **14 render cases** through `POST /api/alertmanager/grafana/config/api/v1/templates/test` (render-only, writes nothing, sends nothing), using the real annotation values read out of the file. Each result passed `json.loads` plus every Discord limit. Worst case **723 of 6000** characters, max `field.value` **485 of 1024**, always 1 embed and ≤5 fields. Covered: single instance; 14 instances hitting the cap; resolved; mixed firing+resolved; missing `dashboard_url`; missing `check_command`; scalar rule with a static `location`; instances agreeing on location (detector); a value containing `"` and `\` and `&` and `<b>`; a missing `object_key` label; missing `severity`; `severity: warning`; empty `grafana_folder`; and a 70-rune/72-byte object name — cut at exactly 26 **runes**, proving rune-based counting.
- `./scripts/validate.sh` exit 0, `kubectl kustomize` exit 0, `rules.yaml` at 25 rules with unique uids, the new rule's annotations all static.

## Not verified, deliberately

**That Discord accepts these embeds.** `POST .../receivers/test` posts to the real channel, so it was off-limits during development. Plan agreed with the user: merge, confirm the Grafana pod rolled, then send exactly one test notification and check it. A 400 is visible immediately in the pod log (`msg="Notify for alerts failed" … webhook response status 400`) and the revert path is one `git revert`, effective in 2–4 minutes.

Also unverified: that Grafana accepts the new `policies.yaml` / `contactpoints.yaml` at provisioning time. YAML-parse correctness of the *rendered* output is the closest available proxy.

## Rollout notes

1. Both blocks must land **together**. `checksum/config` hashes `grafana.configData`, i.e. `templates.yaml` — the config **Secret is not hashed**. A change to `contactpoints.yaml` alone would not trigger a rollout and would silently not take effect, since Grafana reads provisioning only at startup.
2. Verify after the reconcile: `GET /api/v1/provisioning/contact-points` → `type == "webhook"`; `grafana_alerting_alertmanager_integrations{type="webhook"} == 1` and `{type="discord"}` for the fallback.
3. `discord.message` is kept, unused, as the rollback target — switching the contact point back to `type: discord` restores the old behaviour without touching the templates. Delete in a follow-up once the embeds have been green for a week.
4. Minor side effect: the nflog key contains the integration name, which changes from `discord[0]` to `webhook[0]`. Any alert firing at cutover loses its `repeat_interval: 24h` state and gets one immediate repeat. Best deployed while nothing is firing.
