### PR TITLE
fix(grafana): drop trim marker so grafana recognises the payload template define

### DIFF
--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -27511,9 +27511,11 @@ spec:
           # x 12 + 38 = 890). printf counts runes. No arithmetic is available (no sprig, no math.Sub).
           - name: discord.title
             template: '{{ `{{ define "discord.title" }}` }}{{ `{{ if eq .Status "firing" }}` }}{{ `{{ if eq (index .CommonLabels "severity") "warning" }}` }}🟠{{ `{{ else }}` }}🔴{{ `{{ end }}` }} FIRING{{ `{{ if gt (len .Alerts.Firing) 1 }}` }} ({{ `{{ len .Alerts.Firing }}` }}x){{ `{{ end }}` }}{{ `{{ else }}` }}✅ RESOLVED{{ `{{ if gt (len .Alerts.Resolved) 1 }}` }} ({{ `{{ len .Alerts.Resolved }}` }}x){{ `{{ end }}` }}{{ `{{ end }}` }} · {{ `{{ index .CommonLabels "alertname" }}` }}{{ `{{ end }}` }}'
+          # Must open with "{{ define", never "{{- define": Grafana validates with \{\{\s*define, so a
+          # trim marker makes it wrap the body in a SECOND define and provisioning crashes the pod.
           - name: discord.payload
             template: |
-              {{ `{{- define "discord.payload" -}}` }}
+              {{ `{{ define "discord.payload" -}}` }}
               {{ `{{- $f := index .Alerts 0 -}}` }}
               {{ `{{- $ok := $f.Annotations.object_key -}}` }}
               {{ `{{- $lk := $f.Annotations.location_key -}}` }}


### PR DESCRIPTION
## Situation

The grafana pod has been in `CrashLoopBackOff` since #118 (`20949ad`):

```
logger=provisioning level=error msg="Failed to provision alerting"
  error="text templates: [alerting.notifications.templates.invalidFormat] Invalid format of the submitted template"
Error: ✗ invalid service state: Failed ... starting module provisioning
```

**Alerting is latently broken right now, and the UI being up hides it.** The two old
pods still run — `maxUnavailable: 25%` of 2 rounds down to 0 — so the dashboard looks
healthy. But they have already loaded the new DB config, in which `discord` is
`type: webhook` with a `payload.template` pointing at `discord.payload` — a template
that **does not exist**, because provisioning aborted before creating it. The webhook
notifier returns `retry=false` on template errors, so **the next real alert is silently
dropped**. Nothing is firing at the moment, so nothing has been lost yet.

The safety nets from #118 are not in place either: the `discord-fallback` child route
and the `alert-notifications-failing` meta rule were never provisioned, since
provisioning died first.

The HelmRelease is also oscillating between upgrade and rollback (`retries: 3`;
helm rev 37 failed → 38 rollback → 39 pending-upgrade), so this fix has to land on a
*starting* pod.

## Cause

`NotificationTemplate.Validate()` in
`pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go` decides
whether a body already declares its template by matching:

```go
found, err := regexp.MatchString(`\{\{\s*define`, content)
```

`\s*` cannot consume a `-`, so `{{- define "discord.payload" -}}` **does not match**.
Grafana concludes the body has no `define` and wraps it in a **second** one:

```go
content = fmt.Sprintf("{{ define \"%s\" }}\n%s\n{{ end }}", t.Name, content)
```

That nested `define` then fails the real `text/template` parse in
`TemplateDefinition.Validate()` (`github.com/grafana/alerting`,
`templates/template_data.go`):

```
template: :2: unexpected <define> in command
```

Provisioning aborts and the service state goes `Failed`. `discord.title` and
`discord.message` survive only because they open with `{{ define` — no trim marker.

## The fix

One character — the leading `-` on the first line of `discord.payload`:

```diff
-              {{ `{{- define "discord.payload" -}}` }}
+              {{ `{{ define "discord.payload" -}}` }}
```

**Output-neutral.** `Validate()` operates on `strings.TrimSpace(template)`, so there is
no preceding whitespace for the marker to trim. The closing `-}}` and every trim marker
*inside* the body are untouched — the regex only ever looks at `define`.

I grepped the whole file (and the Helm-rendered form): `discord.payload` was the only
Grafana notification template using `{{- define`. The other hits are `helm/*/templates/_helpers.tpl`,
which are genuine Helm chart helpers and unrelated.

An inline comment now records the trap at the template.

## Verification

The template test endpoint (`POST .../templates/test`) did **not** catch this, because
it only *renders* and never calls `Validate()`. So the verification reproduces Grafana's
own logic instead.

**Real library, exact version.** A small Go program replicates the two-step logic from
`alertmanager_validation.go` verbatim (regex → wrap), then calls the genuine
`templates.TemplateDefinition.Validate()` from `github.com/grafana/alerting` pinned to
`v0.0.0-20251120161053-ee90fc928c01` — the pseudo-version `grafana v12.3.1` itself pins —
including its `prometheus/alertmanager` → `grafana/prometheus-alertmanager` fork `replace`.

Inputs come from the actual Helm render:
`helm template grafana grafana-labs/grafana --version 10.5.15` over the values extracted
from `kubectl kustomize apps/clusters/feathre-core/base-apps/grafana`, reading each body
out of the rendered `templates.yaml`.

| Template | regex `\{\{\s*define` | wrapped by Grafana | parse |
|---|---|---|---|
| `discord.title` | ✅ true | no | ✅ ok |
| `discord.payload` | ✅ true | no | ✅ ok |
| `discord.message` | ✅ true | no | ✅ ok |

**Control run** — leading `-` re-added, everything else identical:

| Template | regex | wrapped | parse |
|---|---|---|---|
| `discord.payload` | ❌ false | **yes** | ❌ `template: :2: unexpected <define> in command` |

That is the production error exactly, and the *unwrapped* body parses fine on its own —
confirming the wrap is the whole problem and this fix is the whole cure.

**Output unchanged.** Rendered `discord.payload` against the live instance
(`POST /api/alertmanager/grafana/config/api/v1/templates/test`, read-only) with a
two-instance sample alert. No errors; `json.loads` on the rendered text passes:

```json
{"embeds":[{"color":16426522,"title":"🟠 FIRING (2x) · template-render-selftest",
  "fields":[{"name":"Schwere"...},{"name":"Seit"...},{"name":"Knoten (2)"...},{"name":"Prüfen"...}],
  "footer":{"text":"Core Infra"},"timestamp":"2026-08-12T08:00:00Z"}]}
```

`tmpl.Exec "discord.title"` resolved, all fields within Discord's limits
(`value` ≤ 1024, `title` ≤ 256).

**Hygiene** on the effective (post-render) text: no backtick and no single quote in
`discord.title`/`discord.payload`, no leftover Helm raw-string wrapper, no trailing
whitespace, exactly one `define` per template. The 2 backticks in `discord.message` are
its intentional ``` fence and nothing else.

**Repo validation**

- `./scripts/validate.sh` → exit 0
- `kubectl kustomize apps/clusters/feathre-core/base-apps/grafana` → exit 0

Note that neither could have caught this: they validate YAML and kustomize/kubeconform
schema, whereas this is Grafana-side semantic validation of a string value.

## After merge

Once the pod starts, provisioning should complete and pull in what #118 never applied:
the `discord-fallback` child route and the 25th rule (`alert-notifications-failing`), plus
the rest of the policies. Worth confirming the HelmRelease settles out of its
upgrade/rollback oscillation and that rule count and routes match expectations.

Nothing on the cluster was touched while preparing this.
