### PR TITLE
fix(grafana): only set the embed url when it is absolute

### DIFF
--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -27513,6 +27513,8 @@ spec:
             template: '{{ `{{ define "discord.title" }}` }}{{ `{{ if eq .Status "firing" }}` }}{{ `{{ if eq (index .CommonLabels "severity") "warning" }}` }}🟠{{ `{{ else }}` }}🔴{{ `{{ end }}` }} FIRING{{ `{{ if gt (len .Alerts.Firing) 1 }}` }} ({{ `{{ len .Alerts.Firing }}` }}x){{ `{{ end }}` }}{{ `{{ else }}` }}✅ RESOLVED{{ `{{ if gt (len .Alerts.Resolved) 1 }}` }} ({{ `{{ len .Alerts.Resolved }}` }}x){{ `{{ end }}` }}{{ `{{ end }}` }} · {{ `{{ index .CommonLabels "alertname" }}` }}{{ `{{ end }}` }}'
           # Must open with "{{ define", never "{{- define": Grafana validates with \{\{\s*define, so a
           # trim marker makes it wrap the body in a SECOND define and provisioning crashes the pod.
+          # The embed url is only set when absolute: Grafana's own test alert yields a bare "?orgId=1"
+          # (no GeneratorURL base), and Discord rejects an embed with a relative url with HTTP 400.
           - name: discord.payload
             template: |
               {{ `{{ define "discord.payload" -}}` }}
@@ -27545,7 +27547,13 @@ spec:
               {{ `{{- $fields = coll.Append (coll.Dict "name" (printf "%.100s" $label) "value" (printf "%.1024s" $lines) "inline" false) $fields -}}` }}
               {{ `{{- else if gt (len .Alerts) 1 -}}{{- $fields = coll.Append (coll.Dict "name" "Betroffen" "value" (printf "%d Instanzen" (len .Alerts)) "inline" true) $fields -}}{{- end -}}` }}
               {{ `{{- if $f.Annotations.check_command -}}{{- $fields = coll.Append (coll.Dict "name" "Prüfen" "value" (printf "%.900s" (printf "%s%s%s" $bt $f.Annotations.check_command $bt)) "inline" false) $fields -}}{{- end -}}` }}
-              {{ `{{- $embed := coll.Dict "title" (printf "%.200s" (tmpl.Exec "discord.title" .)) "url" (or $f.GeneratorURL .ExternalURL) "color" $color "description" (printf "%.1000s" $desc) "timestamp" (date "2006-01-02T15:04:05Z07:00" $ts) "fields" $fields "footer" (coll.Dict "text" (printf "%.100s" (or (index $f.Labels "grafana_folder") "Grafana"))) -}}` }}
+              {{ `{{- $url := "" -}}{{- if match "^https?://" $f.GeneratorURL -}}{{- $url = $f.GeneratorURL -}}{{- else if match "^https?://" .ExternalURL -}}{{- $url = .ExternalURL -}}{{- end -}}` }}
+              {{ `{{- $title := printf "%.200s" (tmpl.Exec "discord.title" .) -}}` }}
+              {{ `{{- $desc = printf "%.1000s" $desc -}}` }}
+              {{ `{{- $tss := date "2006-01-02T15:04:05Z07:00" $ts -}}` }}
+              {{ `{{- $footer := coll.Dict "text" (printf "%.100s" (or (index $f.Labels "grafana_folder") "Grafana")) -}}` }}
+              {{ `{{- $embed := coll.Dict "title" $title "color" $color "description" $desc "timestamp" $tss "fields" $fields "footer" $footer -}}` }}
+              {{ `{{- if $url -}}{{- $embed = coll.Dict "title" $title "url" $url "color" $color "description" $desc "timestamp" $tss "fields" $fields "footer" $footer -}}{{- end -}}` }}
               {{ `{{- data.ToJSON (coll.Dict "embeds" (coll.Slice $embed)) }}` }}
               {{ `{{- end -}}` }}
           # Unused while the webhook payload template overrides title/message; kept as a rollback


### PR DESCRIPTION
## Befund

Das Embed in `discord.payload` holte seine `url` aus `or $f.GeneratorURL .ExternalURL`. Das sieht wie ein Fallback aus, ist aber keiner: Grafanas synthetischer Test-Alert (der „Test"-Button bzw. `POST .../receivers/test`) hat **keine** GeneratorURL, Grafana hängt aber trotzdem `?orgId=1` an. Der `or`-Ausdruck sieht damit einen nicht-leeren String, der `.ExternalURL`-Zweig greift nie, und das Embed geht mit `"url": "?orgId=1"` raus — eine **relative** URL, die Discord mit **HTTP 400** komplett ablehnt (das ganze Embed, nicht nur das Feld).

Belegt durch Rendern der gespeicherten Vorlage mit und ohne `generatorURL`:

- mit → `"url":"https://grafana.apps.onelite.feather/alerting/grafana/flux-core-layer-not-ready/view?orgId=1"`
- ohne → `"url":"?orgId=1"`
- `.ExternalURL` selbst ist gesund: `https://grafana.apps.onelite.feather/`

Echte Grafana-managed Alerts haben immer eine absolute GeneratorURL — deshalb waren die produktiven Benachrichtigungen nicht betroffen (zwei wurden real von Discord akzeptiert). Der eingebaute Test-Button war aber dauerhaft unbenutzbar, und da der Webhook-Notifier **nicht retryt**, wäre jeder künftige Alert ohne absolute GeneratorURL still verloren gegangen.

## Änderung

Die Embed-`url` wird nur gesetzt, wenn sie absolut ist:

1. `$f.GeneratorURL`, falls sie auf `^https?://` matcht,
2. sonst `.ExternalURL` unter derselben Bedingung,
3. sonst fällt der Key **ganz weg** (Discord akzeptiert ein Embed ohne `url`).

`match` ist der Alertmanager-Regexp-Helper und steht im Grafana-Template-Kontext zur Verfügung (live gegen die Instanz verifiziert: `match "^https?://" "https://x/y"` → `true`, `"?orgId=1"` → `false`, `""` → `false`). Der `coll`-Namespace der Notification-Templates hat **kein** `Merge`/`Omit`/`Has`/`Keys` (alle live geprüft, jeweils `can't evaluate field ... in type interface {}`) — nur `Dict`, `Slice`, `Append`. Der bedingte Key ist deshalb als zwei `coll.Dict`-Varianten über vorher gehobene Variablen (`$title`, `$desc`, `$tss`, `$footer`) ausgedrückt; die Key-Reihenfolge ist irrelevant, weil `data.ToJSON` = `json.Marshal` Map-Keys sortiert.

## Verifikation

**Grafanas `Validate()`-Logik nachgebildet** (der Render-Endpunkt prüft sie nicht) auf dem echten Helm-Render (`grafana-labs/grafana` 10.5.15, `templates/configmap.yaml`): für alle drei Templates `re.search(r"\{\{\s*define", body)` → true, genau ein `define` pro Body, `{{`/`}}` balanciert, kein Helm-Raw-String-Rest, kein Trailing-Whitespace; für `discord.title`/`discord.payload` zusätzlich kein Backtick und kein einfaches Anführungszeichen. Alle drei Bodies parsen zusätzlich fehlerfrei mit Go `text/template`.

**Render-Tests** gegen `POST /api/alertmanager/grafana/config/api/v1/templates/test` (rendert nur, sendet nichts) mit dem effektiven Template und den echten Annotation-Werten der beiden Regeln:

| # | Fall | Ergebnis |
|---|---|---|
| 1 | firing, absolute GeneratorURL | `url` = absolute Regel-URL |
| 2 | GeneratorURL `?orgId=1` | `url` = `https://grafana.apps.onelite.feather/` (`.ExternalURL`) |
| 3 | GeneratorURL leer | `url` = `https://grafana.apps.onelite.feather/` |
| 4 | resolved | `color` 5763719 (grün), Field `Behoben`, `url` absolut |
| 5 | 14 Instanzen | 12 Zeilen + `… weitere ausgeblendet (14 insgesamt)`, `field.value` 541 |
| 6 | Werte mit `"` und `\` | korrekt escaped, `json.loads` erfolgreich |

Jedes Ergebnis wurde per `json.loads` geparst und gegen alle Discord-Limits geprüft (title ≤ 256, description ≤ 4096, ≤ 25 Fields, `field.value` ≤ 1024, Summe ≤ 6000) — alle bestanden, größte Summe 793. In keinem Fall ist eine relative `url` entstanden.

Der Weglass-Zweig (weder GeneratorURL noch `.ExternalURL` absolut) ist auf dieser Instanz nicht erreichbar, weil `.ExternalURL` absolut ist; er wurde separat mit derselben Dict-Konstruktion gerendert und liefert `{"embeds":[{"color":1,"title":"t"}]}` — der Key fehlt vollständig, steht also nicht mit leerem Wert im JSON.

`./scripts/validate.sh` → exit 0, `kubectl kustomize apps/clusters/feathre-core/base-apps/grafana` → exit 0.

Nicht angefasst: `contactpoints.yaml`, `policies.yaml`, `rules.yaml`, `discord.title`, `discord.message`, `spec.valuesFrom`.
