### PR TITLE
feat(grafana): use discord native timestamps for alert times

### DIFF
--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -27522,7 +27522,6 @@ spec:
               {{ `{{- $ok := $f.Annotations.object_key -}}` }}
               {{ `{{- $lk := $f.Annotations.location_key -}}` }}
               {{ `{{- $loc := or (and $lk (index .CommonLabels $lk)) $f.Annotations.location -}}` }}
-              {{ `{{- $age := reReplaceAll "^(([0-9]+h)?([0-9]+m)?).*$" "$1" (printf "%s" (time.Now.Sub $f.StartsAt)) -}}` }}
               {{ `{{- $sev := index $f.Labels "severity" -}}` }}
               {{ `{{- $bt := "\u0060" -}}` }}
               {{ `{{- $color := 15548997 -}}{{- if eq .Status "resolved" -}}{{- $color = 5763719 -}}{{- else if eq $sev "warning" -}}{{- $color = 16426522 -}}{{- end -}}` }}
@@ -27532,7 +27531,7 @@ spec:
               {{ `{{- $fields := coll.Slice -}}` }}
               {{ `{{- if $sev -}}{{- $fields = coll.Append (coll.Dict "name" "Severity" "value" $sev "inline" true) $fields -}}{{- end -}}` }}
               {{ `{{- if $loc -}}{{- $fields = coll.Append (coll.Dict "name" "Location" "value" (printf "%.60s" $loc) "inline" true) $fields -}}{{- end -}}` }}
-              {{ `{{- if eq .Status "firing" -}}{{- $fields = coll.Append (coll.Dict "name" "Since" "value" (or $age "<1m") "inline" true) $fields -}}{{- else -}}{{- $fields = coll.Append (coll.Dict "name" "Resolved" "value" (date "15:04" (tz "Europe/Berlin" $ts)) "inline" true) $fields -}}{{- end -}}` }}
+              {{ `{{- if eq .Status "firing" -}}{{- $fields = coll.Append (coll.Dict "name" "Since" "value" (printf "<t:%d:R>" $f.StartsAt.Unix) "inline" true) $fields -}}{{- else -}}{{- $fields = coll.Append (coll.Dict "name" "Resolved" "value" (printf "<t:%d:t> (<t:%d:R>)" $ts.Unix $ts.Unix) "inline" true) $fields -}}{{- end -}}` }}
               {{ `{{- if and $f.Annotations.object_label $ok -}}` }}
               {{ `{{- $lines := "" -}}` }}
               {{ `{{- range $i, $a := .Alerts -}}{{- if lt $i 12 -}}` }}

--- a/docs/superpowers/specs/2026-08-12-discord-alert-noise-reduction-design.md
+++ b/docs/superpowers/specs/2026-08-12-discord-alert-noise-reduction-design.md
@@ -306,16 +306,30 @@ near the ceiling day-to-day; the cap exists for the pathological case, not the c
   isn't always set).
 - `description`: the `problem` annotation, plus an optional dashboard link line.
 - Up to 3 inline header fields: `Severity`, `Location` (when common across instances),
-  `Since`/`Resolved` (age or resolution time). The resolution time is `HH:MM` in `Europe/Berlin`.
+  `Since`/`Resolved`. Both carry Discord's native timestamp markup instead of a pre-rendered
+  string: `Since` is `<t:<unix>:R>` (relative), `Resolved` is `<t:<unix>:t> (<t:<unix>:R>)` (short
+  time plus relative). Discord re-renders the relative form every time the message is viewed, so
+  the age stays correct instead of being frozen at send time, and the absolute time is shown in
+  each *viewer's* timezone rather than a hardcoded `Europe/Berlin`.
 - The instance list itself: one `inline: false` field, one row per instance (object + location).
 - `Check` (`check_command`, wrapped in the backtick pair above): the last field.
 - `footer.text`: `grafana_folder`. `timestamp` is passed through `date "2006-01-02T15:04:05Z07:00"`
   — Discord renders this in the *viewer's* local timezone, not Grafana's or UTC, and renders it
   **absolutely** ("Today at 09:20"), not as a relative "x minutes ago". That's the reason the
   age/resolution field still exists as its own line — the timestamp alone doesn't convey elapsed
-  time the way a relative-time renderer would.
+  time, which is exactly what the `Since`/`Resolved` fields supply via `<t:…:R>`. This key is a
+  separate, native embed mechanism and is unrelated to the `<t:…>` markup in the fields.
 - Colors: `15548997` (red, firing/critical), `16426522` (orange, firing/warning), `5763719`
   (green, resolved).
+
+**Where `<t:…>` renders:** only in `description` and `field.value`. Discord parses its special
+formatting (mentions, masked links, timestamps) in exactly those two embed parts, and *not* in
+`title`, `field.name`, `footer.text`, or `author.name` — a timestamp placed there shows up as the
+raw `<t:…>` literal. Field values are therefore the supported spot for these two fields, and the
+markup must not be moved into the title or footer. Discord's own docs enumerate the style suffixes
+(`t` short time, `T` long time, `d` short date, `D` long date, `f` short date+time — the default
+when no suffix is given, `F` full date+time, `R` relative) but say nothing about which embed parts
+parse them, so treat the description/field-value restriction as the binding constraint.
 
 **The alignment trick:** Discord renders inline code (`` `...` ``) in a monospace font and
 preserves internal spaces, so the object column is padded with `printf "%-27.26s"` *inside* a
@@ -362,12 +376,16 @@ wraps these differently on mobile, `-` and `...` are the two ASCII fallbacks to 
 Tested live against Grafana 12.3.1 via the templates-test endpoint (below). **No Sprig functions,
 no `humanizeDuration`, no arithmetic (`math.Sub` does not exist)** — all three fail with "function
 not defined". Available: `printf`, `date`, `tz`, `reReplaceAll`, `time.Now.Sub`, and methods on
-`time.Time`.
+`time.Time` — including `.Unix`, verified to render as a plain int64 through `printf "%d"`.
 
-Consequence: alert age is derived by regexing `time.Duration.String()` output
-(`^(([0-9]+h)?([0-9]+m)?).*$`), because there's no way to subtract components directly. The
-"instances hidden" overflow line prints the **total** instance count rather than the remainder
-past the cap, for the same reason — there's no subtraction available to compute "N more".
+Consequence for the time fields: none any longer. Emitting `<t:<unix>:R>` hands the arithmetic to
+the Discord client, so `Since`/`Resolved` need neither a duration subtraction nor the
+`reReplaceAll` over `time.Duration.String()` (`^(([0-9]+h)?([0-9]+m)?).*$`) that the first version
+used to fake one, and no `tz` call for the resolution time.
+
+The limitation still binds elsewhere: the "instances hidden" overflow line prints the **total**
+instance count rather than the remainder past the cap, because there is no subtraction available
+to compute "N more".
 
 #### Escaping constraints
 


### PR DESCRIPTION
## What

The Discord alert embed built the `Since` field by regexing `time.Duration.String()` output, because
the Grafana template context has no arithmetic:

```
{{- $age := reReplaceAll "^(([0-9]+h)?([0-9]+m)?).*$" "$1" (printf "%s" (time.Now.Sub $f.StartsAt)) -}}
...
"name" "Since" "value" (or $age "<1m")
```

Both time fields now use Discord's native timestamp markup instead:

| Field | Before | After |
|---|---|---|
| `Since` | `2h15m` (regex over a duration, `<1m` fallback) | `<t:<unix>:R>` |
| `Resolved` | `date "15:04" (tz "Europe/Berlin" $ts)` | `<t:<unix>:t> (<t:<unix>:R>)` |

## Why

- **The relative time keeps updating.** Discord re-renders `<t:…:R>` on every view, so a firing
  alert's age stays correct instead of being frozen at the moment the webhook fired.
- **No hardcoded timezone.** `Resolved` was `HH:MM` in `Europe/Berlin` for everyone; `<t:…:t>`
  renders in each *viewer's* own timezone and locale.
- **The regex and the `tz` call are gone** from `discord.payload` (both survive only in the unused
  `discord.message` rollback target, which this PR does not touch).

`.Unix` on `time.Time` was not previously known to work in this context — it does, and `printf "%d"`
formats the int64 correctly (verified live, see below).

## Where `<t:…>` works

Discord parses timestamps (like mentions and masked links) **only in `description` and
`field.value`** — not in `title`, `field.name`, `footer.text`, or `author.name`, where the raw
`<t:…>` literal would show. Both fields here are field values, which is the supported case. The
embed's own `timestamp` key is a separate native mechanism and is unchanged.

## Verification

**Grafana's `Validate()` logic, reproduced locally** (the render endpoint does not check it): all
three templates pass — regex `\{\{\s*define` matches, exactly one `define`, balanced braces, no
backtick/single-quote in `discord.title`/`discord.payload`, no Helm raw-string leftovers, no
trailing whitespace. All three also parse cleanly with Go's `text/template`. `discord.payload` still
opens with `{{ define`, never `{{- define`.

**8 render tests** via `POST /api/alertmanager/grafana/config/api/v1/templates/test` (renders only,
sends nothing), using the real annotation values from `rules.yaml`. Every result parses with
`json.loads` and clears all Discord limits (worst case 778 of 6000 total, largest `field.value` 523
of 1024):

| Case | `Since` / `Resolved` | unix vs. supplied time |
|---|---|---|
| firing, 1 instance | `<t:1786601700:R>` | = `startsAt` 2026-08-13T06:15:00Z |
| firing, 14 instances | `<t:1786601700:R>` | = `startsAt`; 12 rows + `… hidden (14 total)`, padding intact |
| resolved | `<t:1786519200:t> (<t:1786519200:R>)` | = `endsAt` 2026-08-12T07:20:00Z |
| mixed firing + resolved | `<t:1786601700:R>` | = `startsAt` |
| scalar rule | `<t:1786601700:R>` | = `startsAt` |
| no `dashboard_url` | `<t:1786601700:R>` | = `startsAt` |
| no `check_command` | `<t:1786601700:R>` | = `startsAt` |
| value with `"` and `\` | `<t:1786601700:R>` | = `startsAt`; JSON stays valid |

Each value was asserted against `^<t:(\d+):R>$` / `^<t:(\d+):t> \(<t:(\d+):R>\)$`, both unix values
in the `Resolved` pair confirmed identical, and every unix compared against the timestamp supplied
in the test alert — no zero values, nothing from 1970.

`./scripts/validate.sh` and `kubectl kustomize apps/clusters/feathre-core/base-apps/grafana` both
exit 0.

Not touched: `contactpoints.yaml`, `policies.yaml`, `rules.yaml`, `discord.title`, `discord.message`,
`spec.valuesFrom`, the colors, the emoji, and the embed `timestamp` key.
