### PR TITLE
feat(grafana): enable the dashboard sidecar for labelled configmaps

### DIFF
--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -250,10 +250,14 @@ spec:
           foldersFromFilesStructure: true
     dashboards:
       kubernetes:
-        kubernetes-dashboard:
-          gnetId: 22523
-          revision: 2
-          datasource: Mimir
+        # kubernetes-dashboard (gnetId 22523) removed: it never worked. It
+        # pinned revision 2, which does not exist (the API lists only
+        # revision 1), so the download 404'd and left a 0-byte file that
+        # Grafana rejected with a permanent error=EOF. Bumping to revision 1
+        # is not the fix either -- that revision carries uid
+        # k8s_views_global, which a manually imported, non-provisioned
+        # dashboard already holds, and provisioning adopts an occupied uid
+        # instead of erroring, so it would silently overwrite and rename it.
         kubernetes-cluster:
           gnetId: 7249
           revision: 1

--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -223,6 +223,31 @@ spec:
             editable: true
             options:
               path: /var/lib/grafana/dashboards/minecraft
+    # Collects ConfigMaps labelled grafana_dashboard=1 into one extra file
+    # provider, which runs *alongside* the dashboardProviders above -- the
+    # inline dashboards keep their own providers and are unaffected.
+    sidecar:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+      dashboards:
+        enabled: true
+        label: grafana_dashboard
+        # ALL, not the default own-namespace: spegel-dashboard is in kube-system.
+        searchNamespace:
+          - ALL
+        # Only ConfigMaps carry dashboards here; avoids watching every Secret
+        # cluster-wide (RBAC still grants both, the chart hardcodes that).
+        resource: configmap
+        # Annotation -> subdirectory, and foldersFromFilesStructure turns those
+        # subdirectories into Grafana folders; needed for the later inline move.
+        folderAnnotation: grafana_folder
+        provider:
+          foldersFromFilesStructure: true
     dashboards:
       kubernetes:
         kubernetes-dashboard:


### PR DESCRIPTION
Stage 1 of moving Grafana dashboards out of `spec.values`: turn on the dashboard sidecar so labelled ConfigMaps are picked up at all. Nothing is migrated yet.

## What this does

Adds a `sidecar:` block to the grafana HelmRelease values. Until now `spec.values` set no `sidecar:` key at all, so the chart default `enabled: false` applied — the pod ran only the `grafana` container plus the `download-dashboards` initContainer, and `clusterrole/grafana-clusterrole` and `role/grafana` sat there with `rules: null`, because the chart only fills them once a sidecar is enabled.

No separate RBAC is needed: `serviceAccount.create` and `rbac.create` are already true with `rbac.namespaced: false`, so the chart populates the ClusterRole itself. Verified in the render — it goes from `rules: null` to:

```yaml
rules:
  - apiGroups: [""]
    resources: ["configmaps", "secrets"]
    verbs: ["get", "watch", "list"]
```

## The 11 dashboards this picks up

Three labelled ConfigMaps already exist in the cluster and were being silently ignored:

| ConfigMap | Namespace | Dashboards |
|---|---|---|
| `spegel-dashboard` | `kube-system` | 1 |
| `loki-dashboards-1` | `grafana` | 5 |
| `loki-dashboards-2` | `grafana` | 5 |

`searchNamespace` is `ALL` because `spegel-dashboard` lives in `kube-system` — with the chart default (own namespace only) the spegel dashboard would still be missed. It has to be passed as a **list**: chart 10.5.15 renders `NAMESPACE` via `join ","`, so a bare string fails to template.

`resource: configmap` rather than the default `both`, since all three are ConfigMaps and nothing here ships dashboards in Secrets — this avoids a cluster-wide WATCH over every Secret. RBAC is identical either way (the chart hardcodes both resources).

`enableUniqueFilenames` stays off: all 11 data keys are already distinct, so nothing can collide in the shared target directory.

## folderAnnotation semantics

`folderAnnotation` + `provider.foldersFromFilesStructure: true` are both configured now, so the later inline migration works without revisiting this block. The two options are complementary: `folderAnnotation` makes the *sidecar* write a resource into a subdirectory, and `foldersFromFilesStructure` makes *Grafana* turn subdirectories into folders. Neither is much use without the other.

ConfigMaps **without** the annotation are not ignored. In `kiwigrid/k8s-sidecar`, `src/resources.py`:

```python
def _get_destination_folder(metadata, default_folder, folder_annotation):
    if metadata.annotations and folder_annotation in metadata.annotations.keys():
        ...
        return dest_folder
    return default_folder
```

So the annotation-less spegel/loki ConfigMaps land at the root of `/tmp/dashboards`. Grafana's `file_reader.go` then resolves a relative path of `.` to an empty folder path, i.e. `folderID = 0` / `folderUID = ""` — **the General folder**. That is the expected landing spot for these three for now.

## The kubernetes-dashboard fix

Second commit removes the `kubernetes-dashboard` entry (`gnetId: 22523`) rather than repairing it.

It pinned `revision: 2`, which does not exist — the API lists only revision 1, and `/revisions/2/download` returns 404. The file in the pod is 0 bytes and Grafana logs a permanent `error=EOF`. It went unnoticed for five months because the generated `download_dashboards.sh` runs `set -euf` **without `-o pipefail`**: the command is `curl -skf <url> | sed ... > file`, so `-f` does make curl fail on the 404, but the pipeline's exit status is `sed`'s, which succeeds — `set -e` never fires and the initContainer reports success. The redirect had already created the file and sed got empty input.

Bumping to `revision: 1` is **not** the fix. That revision carries uid `k8s_views_global`, and Grafana already holds a manually imported, non-provisioned dashboard on exactly that uid ("Kubernetes / Views / Global", version 2, folder Kubernetes, created 2026-06-12, last edited 2026-07-12). Provisioning onto an occupied uid neither errors nor skips — it **adopts**: `file_reader.go` forces the incoming ID to 0, so `ValidateDashboardBeforeSave` takes the `!dashWithIdExists && dashWithUidExists` branch and calls `SetID(existingByUid.ID)`. `ErrDashboardWithSameUIDExists` only fires when a dashboard is found by both ID *and* UID and the two differ, which provisioning cannot reach. `createDashboardJSON` also sets `Overwrite = true`, so the version check (revision 1 ships version 12 vs. the existing 2) is bypassed too.

Revision 1 would therefore silently overwrite the hand-curated dashboard, rename it to "Kubernetes Dashboard", and put it under provisioning control with `allowUiUpdates: false` — read-only in the UI. An explicit uid override isn't available either: with `gnetId` the JSON is fetched by curl at runtime and only `datasource` is rewritten.

So the entry goes. Nothing is lost — the import never produced a dashboard, and the working manual one on that uid is left alone. It was never provisioned, so the provider's missing-file cleanup does not touch it.

## Deliberately NOT in this PR

- **The 16 inline dashboards stay in `spec.values`.** Moving them to labelled ConfigMaps is a separate stage. Both mechanisms coexist: the sidecar provider is mounted *in addition to* `dashboardProviders`, and all seven existing file providers plus every inline dashboard mount are unchanged in the render.
- **No alerting sidecar.** `sidecar.alerts` stays disabled; the `alerting:` block and `grafana.ini` are byte-identical to `main`.
- No cluster changes and no Grafana writes were made while preparing this.

## Rollout expectation

A new container in the pod spec means the Deployment rolls both replicas. After that the 11 dashboards appear in Grafana's **General** folder (the sidecar provider's default, since none of the three ConfigMaps carries a `grafana_folder` annotation). Each replica runs its own sidecar reloading its own `localhost` Grafana — duplicated but idempotent work.

The reload call keeps working under the new Entra ID OAuth setup: `grafana.ini` configures no `[auth.basic]` section, so basic auth stays at its enabled default, and `REQ_USERNAME`/`REQ_PASSWORD` are wired to `secret/grafana` keys `admin-user`/`admin-password` (both present).

## Validation

- `./scripts/validate.sh` — clean, 0 invalid / 0 errors across all 12 Flux paths
- `kubectl kustomize apps/clusters/feathre-core/base-apps/grafana` — exit 0
- `helm template ... --show-only templates/deployment.yaml` — container `grafana-sc-dashboard` present with `LABEL=grafana_dashboard`, `FOLDER=/tmp/dashboards`, `RESOURCE=configmap`, `NAMESPACE=ALL`, `FOLDER_ANNOTATION=grafana_folder`, `METHOD=WATCH`, `REQ_URL=http://localhost:3000/api/admin/provisioning/dashboards/reload`, `REQ_METHOD=POST`; grafana container mounts the same `sc-dashboard-volume` at `/tmp/dashboards` and receives `sc-dashboardproviders.yaml`
- `--show-only templates/clusterrole.yaml` — real rules instead of `rules: null`
