### PR TITLE
fix(grafana): run the dashboard sidecar as a native sidecar to stop provisioning churn

### DIFF
--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -243,15 +243,22 @@ spec:
         # subdirectories into Grafana folders, reusing an existing folder of the
         # same title -- that is what keeps the moved dashboards in place.
         folderAnnotation: grafana_folder
+        # Native sidecar: the startupProbe holds Grafana back until the initial
+        # LIST wrote every file, so provisioning no longer unprovisions all of
+        # them and churns versions; the watch loop keeps ConfigMap edits live.
+        initDashboards: true
+        restartPolicy: Always
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8084 # chart default here, and templated into HEALTH_PORT
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 60
         provider:
           foldersFromFilesStructure: true
-          # The sidecar populates /tmp/dashboards only after it has started, so
-          # Grafana's first provisioning pass sees an empty folder. Without this
-          # it deletes every sidecar dashboard and they stay gone until the
-          # sidecar's reload call (~2min on 2026-08-13); unprovisioning instead
-          # keeps them visible. Trade-off: a removed ConfigMap leaves its
-          # dashboard behind as an unmanaged one.
-          disableDelete: true
+          # disableDelete dropped: the directory is complete before Grafana
+          # provisions, so a missing file really is a removed ConfigMap.
     dashboards:
       kubernetes:
         # kubernetes-dashboard (gnetId 22523) removed: it never worked. It


### PR DESCRIPTION
## Problem

The dashboard sidecar populates `/tmp/dashboards` only *after* it has started, so Grafana's first provisioning pass sees an empty directory. `handleMissingDashboardFiles` (`file_reader.go:246`) then runs the `disableDelete: true` branch into `UnprovisionDashboard`, which drops the `dashboard_provisioning` rows **including the checksums**. The sidecar writes the files, the reload runs, and every dashboard is re-saved as new — one extra version each. With two replicas this happens twice and overlapping, so both writers compute the same version N+1 and one violates the unique index:

```
level=error msg="failed to save dashboard" file=/tmp/dashboards/Databases/dragonfly.json
  error="pq: duplicate key value violates unique constraint UQE_dashboard_version_dashboard_id_version"
```

**Measurements**

| | duplicate-key errors | `dashboard.version` |
|---|---|---|
| chart file providers | 0 in 31 days (36 pod starts on 2026-08-12 alone) | 1–3 after months |
| sidecar (since today) | 2 over 6 pod starts | 3–12 after ~3 hours |

The error is harmless in itself — the transaction rolls back cleanly and all 43 dashboards are correct — but the cause repeats on every rollout, and Renovate rolls Grafana regularly.

## Fix

Native sidecar (`initDashboards: true` + `restartPolicy: Always` + `startupProbe`), which the chart documents in its own `values.yaml`. Native sidecars are stable since k8s 1.33; this cluster runs **1.36.1**.

1. `initDashboards` moves the container into `initContainers`; `restartPolicy: Always` keeps it running.
2. The kubelet starts the next container only once the sidecar's **`startupProbe`** succeeds.
3. k8s-sidecar 2.5.0 does a full LIST sync and calls `mark_ready()` only afterwards (`Initial sync complete, sidecar is ready.`); `/healthz` answers **503** until then.
4. The watch loop keeps running, so ConfigMap edits still apply live without a pod roll — which plain `initDashboards` alone would have lost.

Result: Grafana's first pass sees the complete set, checksums match, nothing is unprovisioned, nothing re-saved. No churn, no collisions.

### Chart mechanics verified against grafana 10.5.15

- `sidecar.dashboards.restartPolicy` and `sidecar.dashboards.startupProbe` both exist (commented) in `values.yaml`.
- `_pod.tpl` gates them mutually exclusively: `{{- if and .enabled .initDashboards }}` → initContainer, `{{- if and .enabled (not .initDashboards) }}` → sidecar container.
- Unlike `sidecar.alerts`, the **dashboards init block does render** `REQ_URL`, `REQ_METHOD`, `REQ_USERNAME` and `REQ_PASSWORD` (`secretKeyRef` → secret `grafana`, keys `admin-user`/`admin-password`), so nothing has to be supplied via `env`/`envValueFrom`.
- It sets `REQ_SKIP_INIT=true` because `watchMethod: WATCH`, suppressing the reload POST while Grafana is not listening yet.
- Health port: helper `grafana.sidecar.dashboards.healthPort` defaults to **8084** and is overridden by `startupProbe.httpGet.port`, so `8084` keeps probe and `HEALTH_PORT` consistent. (The commented example in `values.yaml` says 8083, which is the *notifiers* default.)

### Rendered pod-spec diff (helm template, 10.5.15)

```diff
-      enableServiceLinks: true
-      containers:
-        - name: grafana-sc-dashboard
+        - name: grafana-init-sc-dashboard
           image: "quay.io/kiwigrid/k8s-sidecar:2.5.0"
           imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /healthz
+              port: 8084
+            initialDelaySeconds: 5
+            periodSeconds: 5
           env:
+            - name: HEALTH_PORT
+              value: "8084"
...
             - name: REQ_METHOD
               value: POST
+            - name: REQ_SKIP_INIT
+              value: "true"
...
             - name: sc-dashboard-volume
               mountPath: "/tmp/dashboards"
+      enableServiceLinks: true
+      containers:
         - name: grafana
```

`initContainers: [download-dashboards, grafana-init-sc-dashboard]`, `containers: [grafana]` — the watch container is gone. Everything else in the pod spec is byte-identical apart from the `sc-dashboard-provider` config checksum.

### `provider.disableDelete` dropped

It was introduced purely as a crutch against the empty-directory race (see the comment it replaces), and that race is gone. Back at the chart default `false`, a removed ConfigMap now takes its dashboard with it instead of leaving an unmanaged orphan nobody notices.

Residual risk is acceptable and asymmetric in our favour: if the sidecar cannot sync, the `startupProbe` never passes and Grafana never starts — there is no running Grafana to delete anything. The failure mode is fail-closed, not fail-destructive. An accidentally unlabelled or deleted ConfigMap does now really remove its dashboard; the JSON lives in git and Grafana 12.3 keeps deleted dashboards restorable, but version history would be lost.

`sidecar.livenessProbe`/`readinessProbe` are deliberately **not** set: they apply chart-wide to every sidecar, and k8s-sidecar's `/healthz` flips to 503 once the last Kubernetes contact is older than `K8S_CONTACT_THRESHOLD_SECONDS` (60 s) — harmless as a startup gate, a restart loop as a liveness check.

## Validation

- `./scripts/validate.sh` → exit 0, 0 invalid / 0 errors across all layers
- `kubectl kustomize apps/clusters/feathre-core/base-apps/grafana` → exit 0
- `helm template` pod spec checked against every point above
- diff vs `main` touches **only** `spec.values.sidecar.dashboards`; `alerting`, `grafana.ini`, `dashboards`, `dashboardProviders` and all dashboard JSON are byte-identical

## Verification plan after merge

1. **Ordering** — in the new pod, `kubectl logs deploy/grafana -n grafana -c grafana-init-sc-dashboard` must show `Initial sync complete, sidecar is ready.` **before** the grafana container logs `starting to provision dashboards`. That ordering is the whole fix.
2. **No unprovisioning** — the grafana container must no longer log `unprovision` / `Deleting provisioned dashboard` lines right after start, and `/tmp/dashboards` must be non-empty at the first provisioning pass.
3. **No churn** — record `SELECT title, version FROM dashboard WHERE ...` for the sidecar dashboards, then force a rollout (`kubectl rollout restart deploy/grafana -n grafana`) and re-read: the versions must be **unchanged**. Today they gain +1 (or more) per rollout.
4. **No collisions** — Loki: zero `duplicate key value violates unique constraint UQE_dashboard_version_dashboard_id_version` over the following weeks, across several Renovate-driven rollouts.
5. **Live reload still works** — edit a dashboard ConfigMap, push, and confirm the change appears in Grafana without a pod restart (sidecar logs a `POST .../api/admin/provisioning/dashboards/reload` → 200).
6. **Deletion path** — with `disableDelete` gone, removing a dashboard from `kustomization.yaml` should now make the dashboard disappear from Grafana rather than linger as an unmanaged one.
