### PR TITLE
fix(grafana): file the loki and spegel chart dashboards into named folders

### DIFF
--- a/apps/clusters/feathre-core/monitoring/loki/release.yaml
+++ b/apps/clusters/feathre-core/monitoring/loki/release.yaml
@@ -313,6 +313,10 @@ spec:
     monitoring:
       dashboards:
         enabled: true
+        # Grafana's sidecar sorts by the folderAnnotation grafana_folder; without
+        # it these ten mixin dashboards land in the root folder "General".
+        annotations:
+          grafana_folder: Observability
       rules:
         enabled: true
       serviceMonitor:

--- a/infrastructure/base/controllers/spegel/release.yaml
+++ b/infrastructure/base/controllers/spegel/release.yaml
@@ -44,3 +44,7 @@ spec:
       mode: Sidecar
       labels:
         grafana_dashboard: "1"
+      # Grafana's sidecar sorts by the folderAnnotation grafana_folder; without
+      # it this dashboard lands in the root folder "General".
+      annotations:
+        grafana_folder: Controllers


### PR DESCRIPTION
## Problem

Eleven dashboards sit in Grafana's root folder **General** instead of a named folder:

- 9x Loki mixin: Chunks, Deletion, Logs, Operational, Reads, Reads Resources, Retention, Writes, Writes Resources
- **Recording Rules** (also from the Loki mixin, `loki-mixin-recording-rules.json`)
- **Spegel stateless cluster local OCI registry mirror**

## Cause

The Grafana dashboard sidecar runs with `folderAnnotation: grafana_folder` and
`provider.foldersFromFilesStructure: true`
(`apps/clusters/feathre-core/base-apps/grafana/release.yaml`). A ConfigMap **with**
that annotation is written into a subdirectory of `/tmp/dashboards` and becomes a
Grafana folder of the same name; a ConfigMap **without** it lands in the root and
therefore in "General".

The three affected ConfigMaps come from foreign Helm charts and carried only the
`grafana_dashboard` label, never the annotation:

| ConfigMap | Namespace | Chart | Dashboards |
|---|---|---|---|
| `loki-dashboards-1` | grafana | loki 7.3.0 | chunks, deletion, logs, **recording rules**, operational |
| `loki-dashboards-2` | grafana | loki 7.3.0 | reads-resources, reads, retention, writes-resources, writes |
| `spegel-dashboard` | kube-system | spegel 0.7.2 | spegel |

Before (from the live cluster):

```
$ kubectl get cm loki-dashboards-1 -n grafana -o jsonpath='{.metadata.annotations}'
{"meta.helm.sh/release-name":"loki","meta.helm.sh/release-namespace":"grafana"}
```

## Fix

Both charts expose a values key for annotations on exactly these ConfigMaps, so
this is fixed at the source instead of via a Flux `postRenderers` patch:

- **loki 7.3.0** — `monitoring.dashboards.annotations` → `grafana_folder: Observability`
- **spegel 0.7.2** — `grafanaDashboard.annotations` → `grafana_folder: Controllers`
  (the chart's own `values.yaml` even suggests `grafana_folder: "Spegel"` there)

Neither change touches the charts' `labels` keys, so the `grafana_dashboard: "1"`
that makes the sidecar select the ConfigMaps at all stays in place — without it the
dashboards would disappear entirely.

Spegel deliberately keeps **two** dashboards with different uids
(`spegel-monitoring-dashboard` from this repo, `1iY4QMJVk-psee` from the chart);
they barely overlap, and after this change both live in **Controllers**.

Two commits because the two releases sit in different Flux layers (`monitoring`
and `base-controllers`) and roll independently.

## Verification (rendered locally)

`helm template` with the new values:

```
loki-dashboards-1 | label grafana_dashboard: 1 | annotations: {'grafana_folder': 'Observability'}
   keys: loki-chunks.json, loki-deletion.json, loki-logs.json,
         loki-mixin-recording-rules.json, loki-operational.json
loki-dashboards-2 | label grafana_dashboard: 1 | annotations: {'grafana_folder': 'Observability'}
   keys: loki-reads-resources.json, loki-reads.json, loki-retention.json,
         loki-writes-resources.json, loki-writes.json
spegel-dashboard  | label grafana_dashboard: 1 | annotations: {'grafana_folder': 'Controllers'}
   keys: spegel.json
```

`./scripts/validate.sh` → exit 0.
`kubectl kustomize apps/clusters/feathre-core/monitoring/loki` → exit 0, HelmRelease values contain the annotation.
`kubectl kustomize infrastructure/base/controllers/spegel` → exit 0, HelmRelease values contain the annotation.

## Post-merge verification plan

1. Let Flux reconcile the `monitoring` and `base-controllers` layers, then check the
   annotation reached the ConfigMaps:

   ```
   kubectl get cm loki-dashboards-1 loki-dashboards-2 -n grafana \
     -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.metadata.annotations.grafana_folder}{"\n"}{end}'
   kubectl get cm spegel-dashboard -n kube-system \
     -o jsonpath='{.metadata.annotations.grafana_folder}{"\n"}'
   ```

   Expected: `Observability`, `Observability`, `Controllers`.
   The label must still be there: `kubectl get cm -A -l grafana_dashboard` lists all three.

2. The sidecar re-reads the ConfigMaps on the watch event and logs one line per
   ConfigMap:

   ```
   Found a folder override annotation, placing the loki-dashboards-1 in: /tmp/dashboards/Observability
   Found a folder override annotation, placing the loki-dashboards-2 in: /tmp/dashboards/Observability
   Found a folder override annotation, placing the spegel-dashboard in: /tmp/dashboards/Controllers
   ```

   ```
   kubectl logs -n grafana deploy/grafana -c grafana-sc-dashboard | grep 'folder override'
   ```

   If the files do not move on the live watch, restarting the Grafana pod re-runs the
   initial LIST and rewrites the whole directory.

3. In the Grafana UI the **General** folder should be empty of these dashboards:
   the ten Loki ones (including *Recording Rules*) under **Observability** next to
   `loki-quick-search`, and *Spegel stateless cluster local OCI registry mirror*
   under **Controllers** next to `spegel-monitoring-dashboard`.
