### PR TITLE
feat(security): add trivy-operator for running-workload scanning

### DIFF
--- a/infrastructure/base/controllers/trivy-operator/kustomization.yaml
+++ b/infrastructure/base/controllers/trivy-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: trivy-system
+resources:
+  - namespace.yaml
+  - release.yaml

--- a/infrastructure/base/controllers/trivy-operator/namespace.yaml
+++ b/infrastructure/base/controllers/trivy-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: trivy-system

--- a/infrastructure/base/controllers/trivy-operator/release.yaml
+++ b/infrastructure/base/controllers/trivy-operator/release.yaml
@@ -1,0 +1,26 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: trivy-operator
+  namespace: trivy-system
+spec:
+  releaseName: trivy-operator
+  chart:
+    spec:
+      chart: trivy-operator
+      sourceRef:
+        kind: HelmRepository
+        name: aquasecurity
+        namespace: flux-system
+  install:
+    crds: Create
+    remediation:
+      retries: 0
+  upgrade:
+    # The chart ships 12 CRDs; without this a Renovate chart bump would
+    # leave them at the old schema.
+    crds: CreateReplace
+  driftDetection:
+    mode: warn
+  interval: 1m0s
+  values: {}

--- a/infrastructure/clusters/feather-core/base-controllers/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/base-controllers/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - cnpg-operator
   - kube-prometheus-stack
   - metallb
+  - trivy-operator
   - ../../../../infrastructure/base/controllers/spegel
   - ../../../../infrastructure/base/controllers/mariadb-operator-crds
   - ../../../../infrastructure/base/controllers/envoy-crds

--- a/infrastructure/clusters/feather-core/base-controllers/trivy-operator/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/base-controllers/trivy-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base/controllers/trivy-operator
+patches:
+  - path: release.yaml

--- a/infrastructure/clusters/feather-core/base-controllers/trivy-operator/release.yaml
+++ b/infrastructure/clusters/feather-core/base-controllers/trivy-operator/release.yaml
@@ -1,0 +1,51 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: trivy-operator
+  namespace: trivy-system
+spec:
+  chart:
+    spec:
+      version: "=0.35.0"
+  values:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+
+    trivy:
+      # Standalone keeps this layer PVC-free. The chart's built-in trivy
+      # server is a StatefulSet on ceph storage, but base-controllers
+      # reconciles before rook — that would deadlock a cluster rebuild.
+      mode: Standalone
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+
+    operator:
+      # 7d instead of the 24h default: every Standalone scan job re-downloads
+      # the trivy DB, and this cluster has ~145 scannable workloads.
+      scannerReportTTL: "168h"
+      scanJobsConcurrentLimit: 5
+      scanJobTimeout: "10m"
+
+    nodeCollector:
+      # Without these it only ever reaches the 4 untainted workers, silently
+      # leaving control-plane and storage nodes out of the infra assessment.
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.feather/storage
+          operator: Exists
+          effect: NoSchedule
+
+    # Alloy discovers ServiceMonitors cluster-wide, same as the gateway.
+    serviceMonitor:
+      enabled: true
+      interval: 60s

--- a/infrastructure/clusters/feather-core/base-sources/aquasecurity.yml
+++ b/infrastructure/clusters/feather-core/base-sources/aquasecurity.yml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: aquasecurity
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: https://aquasecurity.github.io/helm-charts

--- a/infrastructure/clusters/feather-core/base-sources/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/kustomization.yaml
@@ -23,3 +23,4 @@ resources:
   - ollama.yml
   - descheduler.yml
   - plane.yml
+  - aquasecurity.yml


### PR DESCRIPTION
Adds [aquasecurity/trivy-operator](https://github.com/aquasecurity/trivy-operator) (chart `0.35.0`, app `v0.33.0`) to `base-controllers`, following the `cnpg-operator` layout: portable base + cluster overlay that pins the version and carries the values.

It scans **what is actually running** — vulnerabilities, config audit, exposed secrets, RBAC and infra assessment — and writes findings as CRs. This complements Harbor's built-in Trivy, which only ever sees images sitting in the registry, not what the cluster ended up running.

## Decisions worth reviewing

**Standalone mode, deliberately.** The chart's built-in trivy server is a StatefulSet with a `volumeClaimTemplate` on ceph storage. But `base-controllers` reconciles *before* `rook`, and `rook` cannot become ready until `base-controllers` is — a PVC here would deadlock a cluster rebuild. Standalone keeps this layer PVC-free.

The cost is that each scan job re-downloads the trivy DB. Mitigated with `scannerReportTTL: 168h` (7d instead of 24h) and `scanJobsConcurrentLimit: 5`, against ~145 scannable workloads. **If that traffic becomes a problem, the fix is ClientServer mode in a layer that reconciles after rook — not flipping the mode in place here.**

**nodeCollector tolerations.** This cluster taints control-plane (`node-role.kubernetes.io/control-plane`) and storage nodes (`node-role.feather/storage`). Without tolerations the collector only reaches the 4 untainted workers, and the infra assessment would quietly omit the control plane — the most security-relevant nodes.

**`upgrade.crds: CreateReplace`.** The chart ships 12 CRDs. Flux skips CRDs on upgrade by default, so a Renovate chart bump would otherwise leave them on the old schema. Same pattern as `rook` and `kube-prometheus-stack`.

**Resource limits everywhere** (memory limits, no CPU limits — matching `cnpg-operator`), so nothing lands in BestEffort.

## Verification

- `./scripts/validate.sh` — 13/13 overlays, 0 invalid, 0 errors.
- `helm template` with these **exact** values renders cleanly and produces **no StatefulSet and no PVC** — confirming Standalone actually took effect rather than being assumed.
- The rendered `ServiceMonitor` selector matches the `Service` labels and its `metrics` port exists (Alloy discovers ServiceMonitors cluster-wide, same as the gateway).
- The `HelmRelease` is accepted by a server-side dry-run against the live cluster.

## What to expect after merge

- A `trivy-system` namespace, one operator Deployment, and a burst of scan jobs as it works through existing workloads — capped at 5 concurrent.
- Findings appear as `VulnerabilityReport` / `ConfigAuditReport` / `ExposedSecretReport` / `RbacAssessmentReport` CRs, plus `trivy_*` metrics via the ServiceMonitor.
- Expect a lot of findings on first run. `severity` and `trivy.ignoreUnfixed` are left at chart defaults (all severities, including unfixable) — tuning those is a follow-up once there is a baseline to judge, not a guess made upfront.
- No dashboards or alert rules are included; that is deliberate and belongs in a separate change alongside the existing Grafana provisioning.