### PR TITLE
fix(security): unblock trivy node-collector and stop scan job OOMs

### DIFF
--- a/infrastructure/base/controllers/trivy-operator/namespace.yaml
+++ b/infrastructure/base/controllers/trivy-operator/namespace.yaml
@@ -2,3 +2,14 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: trivy-system
+  labels:
+    # The node-collector needs hostPID and hostPath mounts (/etc/kubernetes,
+    # /var/lib/etcd, ...) to assess node configuration; without this the
+    # cluster default of `baseline` rejects every one of its pods. Same
+    # exemption rook-ceph already carries.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest

--- a/infrastructure/clusters/feather-core/security/trivy-operator/release.yaml
+++ b/infrastructure/clusters/feather-core/security/trivy-operator/release.yaml
@@ -24,12 +24,19 @@ spec:
       mode: ClientServer
       storageClassName: ceph-rbd-fr01
       storageSize: 5Gi
+      # Reports carrying every severity exceeded etcd's object size limit
+      # ("request is too large") on image-heavy workloads. Unfixable and
+      # LOW findings are what nobody acts on anyway.
+      ignoreUnfixed: true
+      severity: "MEDIUM,HIGH,CRITICAL"
       resources:
         requests:
           cpu: 100m
           memory: 128Mi
         limits:
-          memory: 512Mi
+          # 512Mi OOMKilled the scans of larger images (reposilite, bluemap,
+          # dependency-track). Requests stay low — this is a burst ceiling.
+          memory: 2Gi
 
     operator:
       builtInTrivyServer: true


### PR DESCRIPTION
Three failures observed on the live operator after #135 — all in the values, not the design.

## 1. node-collector produced nothing — 0 of 10 nodes assessed

Its pods need `hostPID` and hostPath mounts (`/etc/kubernetes`, `/var/lib/etcd`, …) to read node configuration. `trivy-system` carried **no PodSecurity labels**, so the cluster default of `baseline` rejected every pod it created:

```
violates PodSecurity "baseline:latest": host namespaces (hostPID=true),
hostPath volumes ("var-lib-etcd", "var-lib-kubelet", "etc-kubernetes", ...)
```

The job retried until `DeadlineExceeded`, silently, while every other report type worked — so the operator looked healthy.

The namespace now carries the same `privileged` exemption `rook-ceph` already has. **This is a genuine trade-off**: it exempts the whole namespace from PodSecurity enforcement. It is also why that namespace holds nothing but trivy's own components. The alternative is disabling `nodeCollector` and giving up infra assessment of the control plane entirely.

## 2. Scan jobs OOMKilled — 7 occurrences

`reposilite` (3×), `app` (2×), `bluemap`, `dependency-track-api-server`. The 512Mi limit I set in #134 was simply too low for large images. Raised to **2Gi**; requests stay at 128Mi, so this is a burst ceiling, not a reservation.

## 3. Two reports rejected by etcd

```
etcdserver: request is too large
```

Reports carrying every severity, including unfixable findings, exceed etcd's object size limit on image-heavy workloads. Now `severity: MEDIUM,HIGH,CRITICAL` with `ignoreUnfixed: true`.

#134 stated severity tuning should be a follow-up based on a baseline rather than guessed upfront. It now has a concrete technical reason rather than a guess — and it drops precisely the findings nobody can act on (unfixable, LOW/UNKNOWN).

## Verification

- Rendered namespace carries `pod-security.kubernetes.io/enforce: privileged`; HelmRelease shows `mode=ClientServer`, `severity=MEDIUM,HIGH,CRITICAL`, `ignoreUnfixed=true`, memory limit `2Gi`.
- `./scripts/validate.sh` — 14 overlays, 0 invalid, 0 errors.

Post-merge I will confirm the node-collector actually reaches all 10 nodes (including the tainted control-plane and storage nodes) and that OOM and etcd errors stop.