### PR TITLE
fix(security): disable trivy node-collector on talos, drop psa exemption

### DIFF
--- a/infrastructure/base/controllers/trivy-operator/namespace.yaml
+++ b/infrastructure/base/controllers/trivy-operator/namespace.yaml
@@ -1,15 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  # No PodSecurity exemption on purpose. Only the node-collector needed
+  # hostPID/hostPath, and it is disabled here (see release.yaml) — the
+  # operator, trivy-server and scan jobs all run fine under `baseline`.
   name: trivy-system
-  labels:
-    # The node-collector needs hostPID and hostPath mounts (/etc/kubernetes,
-    # /var/lib/etcd, ...) to assess node configuration; without this the
-    # cluster default of `baseline` rejects every one of its pods. Same
-    # exemption rook-ceph already carries.
-    pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: privileged
-    pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: privileged
-    pod-security.kubernetes.io/warn-version: latest

--- a/infrastructure/clusters/feather-core/security/trivy-operator/release.yaml
+++ b/infrastructure/clusters/feather-core/security/trivy-operator/release.yaml
@@ -45,15 +45,13 @@ spec:
       scanJobTimeout: "10m"
 
     nodeCollector:
-      # Without these it only ever reaches the 4 untainted workers, silently
-      # leaving control-plane and storage nodes out of the infra assessment.
-      tolerations:
-        - key: node-role.kubernetes.io/control-plane
-          operator: Exists
-          effect: NoSchedule
-        - key: node-role.feather/storage
-          operator: Exists
-          effect: NoSchedule
+      # Disabled: these nodes run Talos, which has no systemd and a
+      # read-only rootfs, so the collector cannot even start
+      # ("mkdir /etc/systemd: read-only file system"). Excluding every
+      # linux node is the only switch the chart offers. The namespaced
+      # InfraAssessmentReports for the control-plane pods are unaffected —
+      # those come from the API, not from this collector.
+      excludeNodes: "kubernetes.io/os=linux"
 
     # Alloy discovers ServiceMonitors cluster-wide, same as the gateway.
     serviceMonitor:


### PR DESCRIPTION
The node-collector cannot run on this cluster at all — and #136 treated the wrong symptom.

## What #136 missed

These nodes run **Talos v1.13.4**: no systemd, immutable read-only rootfs. Once PodSecurity stopped rejecting its pods, the container failed to be created outright:

```
failed to apply OCI options: failed to mkdir "/etc/systemd": read-only file system
```

It wants hostPath mounts for `/etc/systemd`, `/lib/systemd`, `/etc/kubernetes`, `/var/lib/etcd` — paths that either do not exist on Talos or cannot be created. The CIS node benchmarks it runs read files this platform does not have. **No amount of permissions fixes that.**

I granted the namespace a `privileged` PodSecurity exemption in #136 to get the collector running, without first asking whether it *could* run here. It could not.

## This change

- **Collector excluded from every node.** `excludeNodes: "kubernetes.io/os=linux"` is the only switch the chart offers to drop just the node half of infra assessment.
- **PSA exemption removed.** It bought nothing: the collector was the only component needing hostPID/hostPath. The operator, trivy-server and scan jobs have been running under the cluster's `baseline` default the entire time. The namespace is back to being no more privileged than any other — strictly better than the state #136 left behind.
- **`infraAssessmentScannerEnabled` stays on.** The 12 namespaced `InfraAssessmentReports` covering `kube-apiserver`, `kube-controller-manager` and `kube-scheduler` come from the API, not the collector, and are unaffected.

## What is lost

CIS node-level benchmarks (kubelet config, file permissions on node paths). On Talos that is largely moot: the OS is API-managed and immutable, there are no config files on disk to assess, and Talos enforces much of what those benchmarks check by construction.

## Confirms #136 otherwise worked

The in-cluster trivy config now reads `mode=ClientServer`, `severity=MEDIUM,HIGH,CRITICAL`, `ignoreUnfixed=true`, memory limit `2Gi`. No `OOMKilled` and no `request is too large` has been logged since those took effect, and reports climbed from 171 to 307.

`./scripts/validate.sh` — 14 overlays, 0 invalid, 0 errors. Rendered namespace carries no PSA labels.