### PR TITLE
feat(apus): deploy the Apus operator

### DIFF
--- a/apps/base/apus/kustomization.yaml
+++ b/apps/base/apus/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: apus-system
+resources:
+  - namespace.yaml
+  - release-operator.yaml

--- a/apps/base/apus/namespace.yaml
+++ b/apps/base/apus/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apus-system

--- a/apps/base/apus/release-operator.yaml
+++ b/apps/base/apus/release-operator.yaml
@@ -1,0 +1,28 @@
+---
+# The operator alone is a usable Apus installation: it reconciles Tenants, WorldSources,
+# WorldIngests, BlueMapMaps, BlueMapRenders and BlueMapHostings from `kubectl` and Git.
+# The dashboard and REST API (apus-platform) sit on top and are deliberately not deployed
+# yet -- they require an OIDC issuer, and which identity broker sits in front of Apus is
+# still an open decision (design spec §15, point 3).
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: apus-operator
+  namespace: apus-system
+spec:
+  releaseName: apus-operator
+  chartRef:
+    kind: OCIRepository
+    name: apus-operator
+    namespace: flux-system
+  interval: 1m0s
+  install:
+    remediation:
+      retries: 3
+  # The chart installs six CRDs as templates (not in Helm's crds/ directory) so upgrades
+  # actually update them; they carry helm.sh/resource-policy: keep, so uninstalling the
+  # release never deletes a Tenant or a BlueMapMap along with it.
+  upgrade:
+    remediation:
+      retries: 3
+  values: {}

--- a/apps/clusters/feathre-core/base-apps/apus/bundle-bucket.yaml
+++ b/apps/clusters/feathre-core/base-apps/apus/bundle-bucket.yaml
@@ -1,0 +1,21 @@
+---
+# The platform-wide bundle bucket: normalised world snapshots live here, written by ingest
+# jobs and read by render jobs (design spec §5).
+#
+# Deliberately NOT in rook-ceph-fr01 like the other claims in this repository. Rook always
+# creates the credentials secret and the endpoint ConfigMap in the namespace of the claim,
+# and the operator reads them from its own namespace -- a claim in rook-ceph-fr01 would put
+# the secret out of its reach. The design spec calls this deviation out in §9.1.
+#
+# The secret Rook generates carries AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY, which is
+# exactly what the operator's ingest and render jobs expect.
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: apus-bundles
+  namespace: apus-system
+spec:
+  bucketName: apus-bundles
+  storageClassName: ceph-bucket-fr01
+  additionalConfig:
+    bucketOwner: apus

--- a/apps/clusters/feathre-core/base-apps/apus/kustomization.yaml
+++ b/apps/clusters/feathre-core/base-apps/apus/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: apus-system
+resources:
+  - ../../../../../apps/base/apus/
+  - bundle-bucket.yaml
+patches:
+  - path: release-operator.yaml

--- a/apps/clusters/feathre-core/base-apps/apus/release-operator.yaml
+++ b/apps/clusters/feathre-core/base-apps/apus/release-operator.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: apus-operator
+  namespace: apus-system
+spec:
+  values:
+    # Cluster reality, not the chart's defaults: this cluster's object store is feather-s3
+    # in rook-ceph-fr01, and its bucket class is ceph-bucket-fr01.
+    rook:
+      namespace: rook-ceph-fr01
+      cephObjectStore: feather-s3
+      bucketStorageClass: ceph-bucket-fr01
+    bundles:
+      bucket: apus-bundles
+      # In-cluster RGW service; the chart has no default because a wrong endpoint fails
+      # every ingest at runtime instead of at install time.
+      s3Endpoint: http://rook-ceph-rgw-feather-s3.rook-ceph-fr01.svc
+      s3Region: us-east-1
+      # Rook names the generated secret after the ObjectBucketClaim.
+      credentialsSecret: apus-bundles
+    metrics:
+      enabled: true
+      serviceMonitor:
+        # The operator exports no metrics yet -- that arrives with phase 8. Enabling this
+        # now would only add a scrape target answering with connection refused.
+        enabled: false

--- a/apps/clusters/feathre-core/base-apps/kustomization.yaml
+++ b/apps/clusters/feathre-core/base-apps/kustomization.yaml
@@ -21,3 +21,4 @@ resources:
   - alloy-logs
   - alloy-metrics
   - alloy-receiver
+  - apus

--- a/infrastructure/clusters/feather-core/base-sources/apus.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/apus.yaml
@@ -1,0 +1,32 @@
+---
+# Apus ships its charts as OCI artifacts from our own Harbor, versioned together with
+# the images they deploy: apus-operator 0.3.0 references apus/operator:0.3.0, because the
+# chart leaves image.tag empty and falls back to .Chart.AppVersion. Pin both repositories
+# to the same version for that reason -- mixing them defeats the coupling.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: apus-operator
+  namespace: flux-system
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://harbor.onelitefeather.dev/apus/charts/apus-operator
+  ref:
+    semver: "=0.3.0"
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: apus-platform
+  namespace: flux-system
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://harbor.onelitefeather.dev/apus/charts/apus-platform
+  ref:
+    semver: "=0.3.0"

--- a/infrastructure/clusters/feather-core/base-sources/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/kustomization.yaml
@@ -24,3 +24,4 @@ resources:
   - descheduler.yml
   - plane.yml
   - aquasecurity.yml
+  - apus.yaml


### PR DESCRIPTION
Deploys the operator of [Apus](https://github.com/OneLiteFeatherNET/Apus) — it renders Minecraft worlds with BlueMap on Kubernetes and hosts the results. The operator reconciles `Tenant`, `WorldSource`, `WorldIngest`, `BlueMapMap`, `BlueMapRender` and `BlueMapHosting`. On its own that is already a usable installation, driven from `kubectl` and Git.

## What lands

| | |
|---|---|
| `infrastructure/.../base-sources/apus.yaml` | two `OCIRepository` sources, charts from our own Harbor |
| `apps/base/apus/` | namespace + `HelmRelease` for the operator |
| `apps/clusters/feathre-core/base-apps/apus/` | cluster values + the bundle bucket |

## Values differ from the chart defaults, on purpose

The chart ships upstream Rook naming (`rook-ceph`, `ceph-objectstore`, `ceph-bucket`). This cluster uses `rook-ceph-fr01`, `feather-s3` and `ceph-bucket-fr01`, so the overlay sets all three, plus the in-cluster RGW endpoint. `bundles.s3Endpoint` has no chart default by design — a wrong endpoint would fail every ingest at runtime instead of at install time.

## The bundle bucket sits in `apus-system`, not `rook-ceph-fr01`

That deviates from every other claim in this repository, and it is deliberate: Rook always creates the credentials secret in the namespace of the claim, and the operator reads it from its own namespace. A claim in `rook-ceph-fr01` would put the secret out of its reach. Apus' design spec calls this out in §9.1.

The secret Rook generates carries `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` — exactly what the operator's ingest and render jobs expect (verified in `WorldIngestReconciler` and `IngestJobBuilder`).

## What is not deployed

`apus-platform` — the REST API and the dashboard. Its chart requires an OIDC issuer and a JWKS URI, and **which identity broker sits in front of Apus is still an open decision** (Apus design spec §15, point 3). Its `OCIRepository` is defined here anyway, so adding the release later needs no new source.

Two further gaps are recorded upstream and worth knowing before anyone reaches for the dashboard: the UI bakes its OIDC values in at build time and currently cannot be configured at all, and the workloads the operator creates carry no image pull secret yet.

## Verified

- `./scripts/validate.sh`: exit 0, no invalid resources.
- The chart rendered with **these exact values** and applied against the live cluster with `--dry-run=server`: all six CRDs, the ClusterRole and the ClusterRoleBinding validate. The three namespaced objects only fail on the not-yet-existing namespace.
- `kubectl kustomize` on the overlay produces the expected three objects, and the values patch reaches the `HelmRelease`.
- Chart availability confirmed: `helm show chart oci://harbor.onelitefeather.dev/apus/charts/apus-operator --version 0.3.0`.

The operator exports no metrics yet, so `metrics.serviceMonitor` stays off — enabling it would add a scrape target answering with connection refused.