### PR TITLE
fix(apus): add the CephObjectStoreUser the bundle bucket is owned by

### DIFF
--- a/infrastructure/clusters/feather-core/rook-fr01/users/apus.yaml
+++ b/infrastructure/clusters/feather-core/rook-fr01/users/apus.yaml
@@ -1,0 +1,14 @@
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: apus
+  namespace: rook-ceph-fr01
+spec:
+  store: feather-s3
+  displayName: apus
+  # Apus creates buckets of its own at runtime: the operator provisions one per BlueMapMap
+  # through an ObjectBucketClaim owned by this user, so its whole storage footprint counts
+  # against one quota (design spec §9.1, §10.2).
+  capabilities:
+    bucket: "*"
+    user: "*"

--- a/infrastructure/clusters/feather-core/rook-fr01/users/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/rook-fr01/users/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - olf.yaml
   - tempo.yaml
   - cygnus-pack.yaml
+  - apus.yaml


### PR DESCRIPTION
Follow-up to #138, found while verifying the rollout.

## The problem

The bundle bucket's `ObjectBucketClaim` names `apus` as its `bucketOwner`, but no `CephObjectStoreUser` of that name existed. Rook left the claim in `Pending` — with **no event explaining why**:

```
Spec:
  Additional Config:
    Bucket Owner:      apus
  Bucket Name:         apus-bundles
Status:
  Phase:  Pending
Events:   <none>
```

Without the claim being bound there is no generated secret, and without that secret the operator cannot reach S3 at all — every ingest and every render would fail. The operator pod itself is `Running` and all six CRDs are installed, so nothing else signals the problem.

Every other claim in this cluster has a matching user (`bakery`, `bluemap`, `cygnus-pack`, `harbor`, `loki`, …). This one was simply missing from #138.

## Capabilities

`bucket: "*"` / `user: "*"`, matching the existing users. Apus provisions further buckets at runtime — one per `BlueMapMap`, through claims owned by this same user — so its whole storage footprint counts against a single quota, which is what the design intends (§9.1, §10.2).

## Verified

- `./scripts/validate.sh`: exit 0.
- `kubectl kustomize infrastructure/clusters/feather-core/rook-fr01` renders the user.
- After merge I will confirm the claim leaves `Pending` and that the secret carries `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, which is what the operator reads.