### PR TITLE
chore(apus): bump the charts to 0.3.1

### DIFF
--- a/infrastructure/clusters/feather-core/base-sources/apus.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/apus.yaml
@@ -15,7 +15,7 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-operator
   ref:
-    semver: "=0.3.0"
+    semver: "=0.3.1"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -29,4 +29,4 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-platform
   ref:
-    semver: "=0.3.0"
+    semver: "=0.3.1"


### PR DESCRIPTION
Picks up the fix for the defect found while verifying #138.

## What 0.3.1 fixes

The operator container exited roughly every minute with `exitCode: 0` and `reason: Completed` — 4 restarts in 8 minutes on this cluster. `main()` returned right after `operator.start()`; JOSDK runs its controllers on background threads and does not block, so once no non-daemon thread remained the JVM exited cleanly. Nothing reported a failure, which is why the pod looked healthy between restarts and reconciled a `Tenant` correctly.

Upstream now parks on a latch released by the existing shutdown hook, so `SIGTERM` still ends the process promptly (measured: exit 143, 17 ms after the signal) instead of waiting out the grace period.

## Both pins move together

`apus-operator` and `apus-platform` go to `=0.3.1` in one step. The chart leaves `image.tag` empty and falls back to `.Chart.AppVersion`, so chart 0.3.1 deploys `apus/operator:0.3.1` — mixing versions would break that coupling.

## Verified

- `helm show chart oci://harbor.onelitefeather.dev/apus/charts/apus-operator --version 0.3.1` → `version: 0.3.1`, `appVersion: 0.3.1`.
- `./scripts/validate.sh`: exit 0.
- After merge I will confirm the restart count stops climbing — that is the whole point of this bump.