### PR TITLE
feat(apus): roll out 0.4.0 and point the operator at the otlp collector

### DIFF
--- a/apps/clusters/feathre-core/base-apps/apus/release-operator.yaml
+++ b/apps/clusters/feathre-core/base-apps/apus/release-operator.yaml
@@ -19,6 +19,12 @@ spec:
       s3Region: us-east-1
       # Rook names the generated secret after the ObjectBucketClaim.
       credentialsSecret: apus-bundles
+    otel:
+      # The cluster's OTLP collector: alloy-receiver in grafana, which fans traces out to
+      # Tempo, logs to Loki and metrics to Mimir. gRPC (4317), not the HTTP port.
+      # serviceName stays unset on purpose -- the chart then defaults it to the release
+      # name, so spans are attributed to "apus-operator".
+      endpoint: http://alloy-receiver.grafana.svc:4317
     metrics:
       enabled: true
       serviceMonitor:

--- a/infrastructure/clusters/feather-core/base-sources/apus.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/apus.yaml
@@ -1,6 +1,6 @@
 ---
 # Apus ships its charts as OCI artifacts from our own Harbor, versioned together with
-# the images they deploy: apus-operator 0.3.0 references apus/operator:0.3.0, because the
+# the images they deploy: apus-operator 0.4.0 references apus/operator:0.4.0, because the
 # chart leaves image.tag empty and falls back to .Chart.AppVersion. Pin both repositories
 # to the same version for that reason -- mixing them defeats the coupling.
 apiVersion: source.toolkit.fluxcd.io/v1
@@ -15,7 +15,7 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-operator
   ref:
-    semver: "=0.3.1"
+    semver: "=0.4.0"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -29,4 +29,4 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-platform
   ref:
-    semver: "=0.3.1"
+    semver: "=0.4.0"


### PR DESCRIPTION
## What

- Bump both Apus `OCIRepository` pins in `infrastructure/clusters/feather-core/base-sources/apus.yaml` from `=0.3.1` to `=0.4.0` (`apus-operator` and `apus-platform`). Chart version and image version are coupled through `appVersion`, so they move together.
- Set `otel.endpoint: http://alloy-receiver.grafana.svc:4317` on the operator's values overlay in `apps/clusters/feathre-core/base-apps/apus/release-operator.yaml`.

## Why

Apus 0.4.0 adds OpenTelemetry tracing and SLF4J logging to the operator, api and ingest. With `otel.endpoint` empty the SDK is a no-op, which is the current state — nothing is exported.

`alloy-receiver` in namespace `grafana` is the cluster's OTLP collector (ports 4317 grpc / 4318 http, verified on the Service). It forwards traces to `tempo-gateway`, logs to Loki and metrics to Mimir. The gRPC port is used.

`otel.serviceName` is deliberately left unset: the chart then defaults it to the release name, so spans and log records are attributed to `apus-operator`.

Logging stays on the console as well — the design is console for humans, OTLP for the pipeline.

## Validation

`./scripts/validate.sh` exits 0.