### PR TITLE
fix(renovate): widen manager patterns so flux and helm-values are seen

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "github>OneLiteFeatherNET/renovate:default(OneLiteFeatherNET/infrastructure-core-team)",
     "helpers:pinGitHubActionDigests"
+  ],
+  "flux": {
+    "managerFilePatterns": [
+      "/^(?:apps|infrastructure|clusters)/.+\\.ya?ml$/"
+    ]
+  },
+  "helm-values": {
+    "managerFilePatterns": [
+      "/(^|/)values\\.ya?ml$/",
+      "/^(?:apps|infrastructure)/.+/release\\.ya?ml$/"
+    ]
+  },
+  "packageRules": [
+    {
+      "description": "Keep chart and image bumps in one PR, otherwise the chart rolls without its matching image tags",
+      "matchFileNames": ["apps/**/harbor/**"],
+      "groupName": "harbor"
+    }
   ]
 }


### PR DESCRIPTION
## Problem

Renovate extracted **23 dependencies** from the entire repository — and not a single HelmRelease chart version.

Two blind spots, two different causes:

- The **flux** manager's default pattern only covers `gotk-components.yaml` and a `cluster/` directory. This repo uses `clusters/` (plural), `apps/` and `infrastructure/`, so it matched exactly one file.
- The **helm-values** manager reads `values.yaml` only. The image tags pinned inside the HelmRelease overlays were therefore invisible — which is why Harbor still runs `v2.15.0` while the pinned chart 1.19.1 already ships 2.15.1, and 1.19.2 ships 2.15.2.

## Change

Widen both manager patterns and move `extends` onto the org preset.

| | before | after |
|---|---|---|
| flux | 1 file / 1 dep | 45 files / 48 deps |
| helm-values | 4 files / 5 deps | 14 files / 24 deps |
| **total** | **9 files / 23 deps** | **64 files / 90 deps** |

All ten `goharbor/*` image pins are now picked up, along with the chart versions for grafana, rook-ceph, mariadb-operator, plane-enterprise and the rest.

The `values.yaml` pattern deliberately stays: the in-repo charts under `helm/` pin their images there, and that is where PR #52 (leantime 3.7.3 → 3.9.8) comes from.

The org preset replaces bare `config:recommended` and brings patch automerge, the reviewer team, `Europe/Berlin` office-hours scheduling, semantic commits and vulnerability alerts — so none of those are re-declared here. `infrastructure-core-team` was granted `maintain` on this repo so the reviewer assignment resolves.

## Verification

- `renovate-config-validator` 44.30.3 (same major as the GitHub App) — passes
- `RENOVATE_PLATFORM=local RENOVATE_DRY_RUN=extract` — the numbers above
- `./scripts/validate.sh` — exit 0

## Note

Expect a burst on the first run: 67 previously invisible dependencies come into view at once. `config:recommended` caps this at 10 concurrent PRs and 2 per hour.