### PR TITLE
feat(ci): scan pinned images with trivy and publish sboms to dependency-track

### DIFF
--- a/.github/workflows/sbom-scan.yaml
+++ b/.github/workflows/sbom-scan.yaml
@@ -1,0 +1,124 @@
+name: sbom-scan
+
+# Scan every image this repository pins with the Trivy CLI and push the
+# resulting CycloneDX SBOMs to Dependency-Track, one project per image with
+# the tag as its version - that is what lets Dependency-Track compare
+# v2.15.0 against v2.15.2 instead of filing them as unrelated projects.
+#
+# Only images the repo actually pins are visible from CI; whatever a chart
+# resolves on its own is not. The trivy-operator in the cluster covers that
+# side and reaches ~103 images against the ~30 seen here.
+#
+# Trivy is left to score nothing: DT does its own analysis from the SBOM, so
+# the scan runs with --scanners license and ships the component inventory.
+
+on:
+  schedule:
+    # after Renovate's office-hours window, so a merged bump is scanned same day
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Build SBOMs but upload nothing'
+        type: boolean
+        default: false
+  push:
+    branches: [main]
+    paths:
+      - 'apps/**'
+      - 'infrastructure/**'
+      - 'helm/**'
+      - 'clusters/**'
+      - 'scripts/collect-images.py'
+      - 'scripts/upload-sbom.py'
+      - '.github/workflows/sbom-scan.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  # Never cancel: a half-finished run leaves Dependency-Track with a partial
+  # picture that looks like a real drop in findings.
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    name: trivy sbom + dependency-track
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.x'
+
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+
+      # Same Trivy version the in-cluster trivy-operator runs, so CI numbers
+      # and cluster reports stay comparable.
+      - uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          version: v0.73.0
+          cache: true
+
+      - name: Collect pinned images
+        id: images
+        run: |
+          scripts/collect-images.py | tee images.txt
+          echo "count=$(wc -l < images.txt)" >> "$GITHUB_OUTPUT"
+
+      # One shared DB download instead of one per image.
+      - name: Warm Trivy database
+        run: trivy image --download-db-only
+
+      - name: Build SBOMs
+        run: |
+          mkdir -p sbom
+          ok=0 skipped=0
+          while read -r image; do
+            [ -z "$image" ] && continue
+            name=$(printf '%s' "$image" | tr '/:' '__')
+            if trivy image --quiet --scanners license --format cyclonedx \
+                 --timeout 10m -o "sbom/${name}.cdx.json" "$image"; then
+              ok=$((ok + 1))
+            else
+              # A private registry without credentials is expected here and
+              # must not fail the run - the cluster-side operator covers those.
+              echo "::warning title=Image not scannable::${image}"
+              rm -f "sbom/${name}.cdx.json"
+              skipped=$((skipped + 1))
+            fi
+            # Runners have ~14 GB; the layer cache fills it well before image 30.
+            trivy clean --scan-cache >/dev/null 2>&1 || true
+          done < images.txt
+          echo "scanned ${ok}, skipped ${skipped}"
+          [ "$ok" -gt 0 ] || { echo "::error::no image could be scanned"; exit 1; }
+
+      - name: Upload to Dependency-Track
+        env:
+          DT_URL: ${{ vars.DT_URL }}
+          DT_API_KEY: ${{ secrets.DT_API_KEY }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          if [ -z "${DT_API_KEY}" ]; then
+            echo "::warning title=Upload skipped::DT_API_KEY is not set; see README"
+            scripts/upload-sbom.py --dry-run 'sbom/*.cdx.json'
+          elif [ "${DRY_RUN}" = "true" ]; then
+            scripts/upload-sbom.py --dry-run 'sbom/*.cdx.json'
+          else
+            scripts/upload-sbom.py 'sbom/*.cdx.json'
+          fi
+
+      - name: Keep the SBOMs
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: sbom
+          path: sbom/
+          retention-days: 30
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -1,9 +1,172 @@
 # Kubernetes Cluster Management
-This repository contains the necessary files to manage OneLiteFeather Kubernetes cluster for different environments.
 
-## Used Tools
-- Sops
-- Helm
-- Kubectl
-- Kustomize
-- FluxCD
+[![flux-validate](https://github.com/OneLiteFeatherNET/Kubernetes-FLUX/actions/workflows/flux-validate.yaml/badge.svg?branch=main)](https://github.com/OneLiteFeatherNET/Kubernetes-FLUX/actions/workflows/flux-validate.yaml)
+[![sbom-scan](https://github.com/OneLiteFeatherNET/Kubernetes-FLUX/actions/workflows/sbom-scan.yaml/badge.svg?branch=main)](https://github.com/OneLiteFeatherNET/Kubernetes-FLUX/actions/workflows/sbom-scan.yaml)
+[![Renovate](https://img.shields.io/badge/renovate-enabled-1a7f8c)](https://docs.renovatebot.com/)
+
+GitOps configuration for OneLiteFeather's Kubernetes cluster **`feather-core`** — ten
+control-plane, storage and worker nodes running Talos. There is no application source code
+here, only manifests: Flux `Kustomization`s, Helm values, Kustomize overlays and a handful
+of in-repo charts.
+
+The cluster reconciles itself against `main`. A change takes effect **only once it is
+merged**, after which Flux picks it up — the Git source is polled every minute, the root
+Kustomization every ten.
+
+## Repository layout
+
+| Path | What lives here |
+|---|---|
+| `clusters/feather-core/` | The Flux control plane. `flux-system/` is the bootstrap; every other `*.yaml` is one Flux `Kustomization` — a layer. |
+| `infrastructure/` | Cluster plumbing: Flux sources, controllers and operators, and configs (databases, storage, PKI). |
+| `apps/` | The actual workloads. |
+| `helm/` | Charts maintained in this repo: `leantime`, `outline`, `shlink`, and `micronaut` — the generic chart several Micronaut services share. |
+| `scripts/` | Validation and SBOM tooling, all of it also run by CI. |
+
+Everything follows a **base + overlay** pattern: `*/base/<name>/` holds the portable
+definition, `*/clusters/feather-core/<layer>/<name>/` patches it for this cluster and
+attaches its secrets.
+
+> **Watch the spelling.** Infrastructure lives under `clusters/feather-core/`, apps under
+> `clusters/feathre-core/` — the typo is real, load-bearing and present in both Flux
+> Kustomizations. Do not "fix" one to match the other.
+
+## Layer order
+
+Layers depend on each other, and most wait for their dependencies to report healthy before
+they start. A layer therefore blocks everything downstream of it while it settles.
+
+```mermaid
+graph LR
+  base-sources --> base-controllers
+  base-controllers --> controllers
+  base-controllers --> base-configs
+  base-sources & base-configs & controllers --> rook
+  rook --> rook-fr01
+  base-configs & controllers & rook --> configs
+  controllers --> internal-certs
+  configs --> base-apps --> apps
+  configs --> monitoring
+  configs --> security
+  rbac
+```
+
+`base-sources` and `rbac` have no dependencies and start immediately. All layers decrypt
+SOPS secrets through the `sops` provider, except `internal-certs`.
+
+## Working on this repository
+
+```bash
+# Validate everything the way CI does: kustomize build every Flux path, then kubeconform.
+./scripts/validate.sh
+
+# Render a single overlay while iterating.
+kubectl kustomize infrastructure/clusters/feather-core/controllers/<name>
+
+# Apply a merged change now instead of waiting for the poll interval.
+flux reconcile kustomization <layer> --with-source
+flux get kustomizations -A
+```
+
+Do not loop `flux reconcile`. Forcing a layer mid-flight flips it back to `Reconciling`,
+which makes every dependent report "dependency not ready" — you create the churn you were
+trying to clear.
+
+Two things bite regularly:
+
+- **Bump `version:` in `Chart.yaml` when you edit a chart under `helm/`.** Helm caches by
+  chart version; without a bump your template edits never reach the cluster.
+- **Changing a secret's contents does not restart anything.** Overlays set
+  `disableNameSuffixHash: true`, so the generated `Secret` name stays the same and no
+  rollout is triggered. Restart the consumer yourself.
+
+## Secrets
+
+Secrets are encrypted whole-file with [SOPS](https://github.com/getsops/sops) and age. The
+full workflow is in [`docs/sops.md`](docs/sops.md); the essentials:
+
+- Recipients live in exactly one place: `.sops.yaml` at the repo root, holding three age
+  public keys — maintainer, cluster and CI.
+- Encrypted suffixes are `*.sops.{env,yaml,json,crt,key,conf}` **and plain `*.env`**. There
+  is deliberately no rule for plain `*.yaml`, so `sops -e` on one fails closed. Name a
+  Secret manifest `*.sops.yaml`.
+- Edit in place with `sops <file>`. After changing recipients, re-encrypt everything with
+  `./scripts/rekey.sh`.
+
+> `.sops.yaml` and the ciphertext must move in the **same commit**. A file that is validly
+> encrypted but missing the cluster's key breaks every Flux layer that touches it.
+> `scripts/check-sops-encryption.py` enforces this in CI — run it locally after any
+> recipient change.
+
+## Supply-chain scanning
+
+Two scanners run against the same images from two directions, because neither sees
+everything on its own.
+
+**In the cluster.** [trivy-operator](https://github.com/aquasecurity/trivy-operator) runs in
+the `security` layer and scans what is actually running — roughly 103 images — producing
+`VulnerabilityReport`s, `ConfigAuditReport`s, RBAC assessments and CycloneDX
+`SBOMReport`s. It runs in ClientServer mode against an in-cluster `trivy-server`; standalone
+mode deadlocks on the shared DB lock for multi-container pods.
+
+**In CI.** The [`sbom-scan`](.github/workflows/sbom-scan.yaml) workflow scans the ~30 images
+this repository *pins* and pushes their SBOMs to
+[Dependency-Track](https://dependencytrack.org/). It runs nightly, on every push to `main`
+that touches a manifest, and on demand. What a chart resolves on its own is invisible to CI
+by definition — that gap is exactly what the in-cluster operator covers.
+
+```bash
+# Which images can CI see, and where is each pinned?
+scripts/collect-images.py --stats
+
+# Build an SBOM and rehearse the upload without touching the server.
+trivy image --format cyclonedx --scanners license -o sbom/x.cdx.json <image>
+scripts/upload-sbom.py --dry-run 'sbom/*.cdx.json'
+```
+
+Each image becomes one Dependency-Track project, named after the image repository with the
+tag as its version. That is what makes the server compare `v2.15.0` against `v2.15.2`
+instead of filing them as unrelated projects.
+
+Dependency-Track and Trivy will not agree on the numbers, and that is expected.
+Dependency-Track analyses from OSV, the GitHub Advisory Database and NVD; Trivy uses the
+distributions' own security trackers. Dependency-Track therefore reports far more on Go,
+npm, PyPI and Maven dependencies — 86 % of what these images contain — while raising
+findings on Debian or Photon packages the distribution has long since backported. **For
+"did this bump actually reduce anything?", an A/B `trivy image` run is the sharper tool.**
+
+### Enabling the upload
+
+The workflow scans and publishes its SBOMs as artifacts regardless, but skips the upload
+with a warning until it has somewhere to send them:
+
+1. In Dependency-Track, under *Administration → Access Management → Teams*, create a team
+   with `BOM_UPLOAD`, `PROJECT_CREATION_UPLOAD` and `VIEW_PORTFOLIO`, and generate an API key.
+2. Add it to this repository as the secret **`DT_API_KEY`**, and the server URL as the
+   variable **`DT_URL`**.
+
+Trivy emits CycloneDX 1.7 with no way to ask for less, while Dependency-Track 4.13 ships
+cyclonedx-core-java 11.x and rejects anything past 1.6. `scripts/upload-sbom.py` rewrites
+each document before upload — it drops the spec version and moves license IDs the 1.6 SPDX
+enum does not know from `license.id` to `license.name`. Both steps are lossless for what
+Dependency-Track analyses, and the rewrite becomes a harmless no-op once the server reaches
+4.14.
+
+## Conventions
+
+- **Conventional Commits are enforced.** Allowed types are
+  `build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test`; the subject starts
+  lowercase and the header stays under 100 characters. The PR title is linted too, because
+  it becomes the squash-merge subject.
+- **CI runs `scripts/validate.sh` on every PR** touching `clusters`, `infrastructure`,
+  `apps` or `helm`. Run it locally first.
+- **Renovate opens the version bumps.** It watches the Flux `HelmRelease` chart versions and
+  the image tags pinned in overlays and `helm/*/values.yaml`, and merges patch updates on
+  its own once CI is green. Expect `main` to move under you — rebase before pushing.
+
+## Tooling
+
+[Flux](https://fluxcd.io/) · [Kustomize](https://kustomize.io/) ·
+[Helm](https://helm.sh/) · [SOPS](https://github.com/getsops/sops) ·
+[Trivy](https://trivy.dev/) · [Dependency-Track](https://dependencytrack.org/) ·
+[Renovate](https://docs.renovatebot.com/)

--- a/scripts/collect-images.py
+++ b/scripts/collect-images.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Collect every container image this repository pins, for SBOM scanning.
+
+Walks the manifest trees and reports image references in the three shapes
+that actually occur here:
+
+  image: registry/name:tag                    plain string, e.g. a CronJob
+  image: {repository: name, tag: v1}          Helm values inside a HelmRelease
+  images: [{name: x, newName: y, newTag: z}]  a Kustomize image transformer
+
+Images a chart resolves on its own are invisible here by definition - only
+what the repo actually pins can be scanned from CI. Run scripts/collect-images.py
+--stats to see how far that reaches.
+
+  scripts/collect-images.py            one image reference per line
+  scripts/collect-images.py --json     same, as a JSON array
+  scripts/collect-images.py --stats    counts and the sources they came from
+"""
+import argparse
+import json
+import os
+import sys
+
+import yaml
+
+ROOTS = ("apps", "infrastructure", "helm", "clusters")
+SKIP_DIRS = {".git", "node_modules", ".claude", "graphify-out", ".serena", ".venv"}
+# whole-file encrypted; parsing them yields nothing but noise
+SKIP_SUFFIX = (".sops.yaml", ".sops.env", ".sops.json", ".sops.crt", ".sops.key", ".sops.conf")
+
+
+def is_image_string(value):
+    """A tag or digest is what separates an image ref from an arbitrary string."""
+    if not isinstance(value, str) or not value or value.startswith(("$", "{")):
+        return False
+    if "@sha256:" in value:
+        return True
+    tail = value.rsplit("/", 1)[-1]
+    return ":" in tail and not tail.endswith(":")
+
+
+def join(registry, repository, tag):
+    if not repository or not isinstance(repository, str):
+        return None
+    if registry and isinstance(registry, str):
+        repository = f"{registry.rstrip('/')}/{repository}"
+    if tag and isinstance(tag, (str, int, float)):
+        return f"{repository}:{tag}"
+    return None
+
+
+def walk(node, out, where):
+    """Depth-first: any dict may carry an image in one of the known shapes."""
+    if isinstance(node, dict):
+        img = node.get("image")
+        if is_image_string(img):
+            out.setdefault(img, set()).add(where)
+        elif isinstance(img, dict):
+            ref = join(img.get("registry"), img.get("repository"), img.get("tag"))
+            if ref:
+                out.setdefault(ref, set()).add(where)
+
+        # a HelmRelease often splits registry/repository/tag across the same level
+        if "repository" in node and "tag" in node and "image" not in node:
+            ref = join(node.get("registry"), node.get("repository"), node.get("tag"))
+            if ref:
+                out.setdefault(ref, set()).add(where)
+
+        for key, value in node.items():
+            if key == "images" and isinstance(value, list):
+                for entry in value:
+                    if not isinstance(entry, dict):
+                        continue
+                    name = entry.get("newName") or entry.get("name")
+                    ref = join(None, name, entry.get("newTag"))
+                    if ref:
+                        out.setdefault(ref, set()).add(where)
+            walk(value, out, where)
+
+    elif isinstance(node, list):
+        for value in node:
+            walk(value, out, where)
+
+
+def collect(repo_root):
+    out = {}
+    for root in ROOTS:
+        base = os.path.join(repo_root, root)
+        if not os.path.isdir(base):
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+            for name in filenames:
+                if not name.endswith((".yaml", ".yml")) or name.endswith(SKIP_SUFFIX):
+                    continue
+                path = os.path.relpath(os.path.join(dirpath, name), repo_root)
+                try:
+                    with open(os.path.join(repo_root, path), encoding="utf-8") as fh:
+                        docs = list(yaml.safe_load_all(fh))
+                except (yaml.YAMLError, UnicodeDecodeError):
+                    continue  # templates and encrypted files are not our business
+                for doc in docs:
+                    walk(doc, out, path)
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--stats", action="store_true")
+    args = parser.parse_args()
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    found = collect(repo_root)
+    # a floating tag says nothing about what was scanned, so leave it out
+    images = sorted(i for i in found if not i.endswith((":latest", ":stable", ":main")))
+
+    if args.stats:
+        print(f"{len(found)} image references, {len(images)} scannable\n")
+        for image in images:
+            print(f"  {image}")
+            for source in sorted(found[image]):
+                print(f"      {source}")
+        skipped = sorted(set(found) - set(images))
+        if skipped:
+            print(f"\nskipped, floating tag ({len(skipped)}):")
+            for image in skipped:
+                print(f"  {image}")
+    elif args.json:
+        json.dump(images, sys.stdout)
+    else:
+        print("\n".join(images))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upload-sbom.py
+++ b/scripts/upload-sbom.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Upload CycloneDX SBOMs to Dependency-Track, one project per image.
+
+Trivy writes CycloneDX 1.7. Dependency-Track 4.13 ships cyclonedx-core-java
+11.x, which validates against 1.6 and rejects 1.7 outright, so every BOM is
+rewritten before upload:
+
+  1. specVersion and $schema are set to 1.6
+  2. license IDs the 1.6 SPDX enum does not know (SMAIL-GPL and friends) move
+     from license.id to license.name, which is where non-SPDX licenses belong
+
+Both steps are lossless for what Dependency-Track actually analyses. Once the
+server runs 4.14 or newer the rewrite becomes a no-op that costs nothing, so it
+stays unconditional rather than sniffing the server version.
+
+Project name is the image repository, project version its tag - that is what
+makes Dependency-Track compare v2.15.0 against v2.15.2 instead of treating them
+as unrelated projects.
+
+  DT_URL=https://dependency-track.example DT_API_KEY=odt_... \
+    scripts/upload-sbom.py sbom/*.cdx.json
+"""
+import argparse
+import base64
+import glob
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+SPDX_1_6 = "https://raw.githubusercontent.com/CycloneDX/specification/1.6/schema/spdx.schema.json"
+
+
+def spdx_ids():
+    """The license IDs CycloneDX 1.6 accepts. Empty set means: rewrite nothing."""
+    try:
+        with urllib.request.urlopen(SPDX_1_6, timeout=30) as response:
+            return set(json.load(response).get("enum") or [])
+    except Exception as exc:
+        print(f"note: SPDX 1.6 enum unavailable ({exc}); leaving license IDs alone", file=sys.stderr)
+        return set()
+
+
+def to_1_6(bom, allowed):
+    bom["specVersion"] = "1.6"
+    bom["$schema"] = "http://cyclonedx.org/schema/bom-1.6.schema.json"
+    if not allowed:
+        return bom, 0
+
+    moved = 0
+
+    def walk(node):
+        nonlocal moved
+        if isinstance(node, dict):
+            for entry in node.get("licenses") or []:
+                license_ = entry.get("license") if isinstance(entry, dict) else None
+                if isinstance(license_, dict) and license_.get("id") not in allowed and "id" in license_:
+                    license_["name"] = license_.pop("id")
+                    moved += 1
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(bom)
+    return bom, moved
+
+
+def image_of(bom, fallback):
+    """Trivy records the scanned image as the BOM's own metadata component,
+    and puts the tag in the name rather than in version: goharbor/x:v2.15.0."""
+    component = (bom.get("metadata") or {}).get("component") or {}
+    name = component.get("name") or fallback
+    version = component.get("version") or ""
+
+    repository, colon, tag = name.rpartition(":")
+    if colon and "/" not in tag:  # a tag never contains a slash, a registry port does
+        name, version = repository, version or tag
+    return name, version or "unknown"
+
+
+def upload(url, key, project, version, bom, dry_run):
+    payload = json.dumps({
+        "project": "",
+        "projectName": project,
+        "projectVersion": version,
+        "projectTags": ["source:trivy-ci"],
+        "autoCreate": True,
+        "bom": base64.b64encode(json.dumps(bom).encode()).decode(),
+    }).encode()
+
+    if dry_run:
+        return "dry-run"
+
+    request = urllib.request.Request(
+        f"{url}/api/v1/bom", data=payload, method="PUT",
+        headers={"Content-Type": "application/json", "X-Api-Key": key},
+    )
+    with urllib.request.urlopen(request, timeout=180) as response:
+        return str(response.status)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("boms", nargs="+", help="CycloneDX files, globs allowed")
+    parser.add_argument("--dry-run", action="store_true", help="convert and report, upload nothing")
+    args = parser.parse_args()
+
+    url = os.environ.get("DT_URL", "").rstrip("/")
+    key = os.environ.get("DT_API_KEY", "")
+    if not args.dry_run and not (url and key):
+        sys.exit("DT_URL and DT_API_KEY must be set")
+
+    paths = sorted({p for pattern in args.boms for p in glob.glob(pattern)})
+    if not paths:
+        sys.exit("no SBOM files matched")
+
+    allowed = spdx_ids()
+    failures = 0
+    moved_total = 0
+    empty = 0
+
+    for path in paths:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                bom = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"FAIL  {path}: unreadable ({exc})")
+            failures += 1
+            continue
+
+        bom, moved = to_1_6(bom, allowed)
+        moved_total += moved
+        project, version = image_of(bom, os.path.basename(path))
+        components = len(bom.get("components") or [])
+
+        # Distroless and busybox-style images carry no package database. Uploading
+        # those would leave empty projects that read as "nothing to fix here".
+        if not components:
+            print(f"empty   {project}:{version}  (no package database)")
+            empty += 1
+            continue
+
+        try:
+            status = upload(url, key, project, version, bom, args.dry_run)
+            print(f"{status:8}{project}:{version}  ({components} components)")
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode(errors="replace")[:160]
+            print(f"FAIL {exc.code}  {project}:{version}  {body}")
+            failures += 1
+        except Exception as exc:
+            print(f"FAIL     {project}:{version}  {exc}")
+            failures += 1
+
+    uploaded = len(paths) - failures - empty
+    print(f"\n{uploaded}/{len(paths)} uploaded, {empty} empty, {moved_total} license IDs rewritten")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds the CI-side half of supply-chain scanning and grows the README to match.

The in-cluster `trivy-operator` covers what is *running* (~103 images). Nothing watched what this repository *pins*. This closes that gap and feeds both into Dependency-Track.

## What is new

**`scripts/collect-images.py`** walks the manifest trees and reports image references in the three shapes that occur here — a plain string, a Helm values `repository`/`tag` pair, and a Kustomize image transformer. It finds **30 scannable images**, including all ten `goharbor/*` pins that carry the bulk of the current findings.

```
$ scripts/collect-images.py --stats
32 image references, 30 scannable
```

Images a chart resolves on its own stay invisible from CI by definition — that is the operator's half of the job, and the README says so.

**`scripts/upload-sbom.py`** pushes each SBOM as its own Dependency-Track project: name = image repository, version = tag. That is what makes the server compare `v2.15.0` against `v2.15.2` instead of filing them as unrelated projects.

It rewrites CycloneDX 1.7 → 1.6 on the way. Trivy emits 1.7 with no flag to ask for less, while DT 4.13 ships cyclonedx-core-java 11.x and rejects anything past 1.6. Beyond the spec version that means moving license IDs the 1.6 SPDX enum does not know (`SMAIL-GPL` and friends) from `license.id` to `license.name`. Both steps are lossless for what DT analyses, and the rewrite becomes a no-op once the server reaches 4.14.

**`.github/workflows/sbom-scan.yaml`** runs it nightly at 04:00, on pushes to `main` touching manifests, and on demand with a dry-run switch.

## Failure modes it tolerates

- A **private registry** without credentials warns and moves on rather than failing the run — `harbor.onelitefeather.dev` and `docker.getoutline.com` both hit this today.
- Images with **no package database** (busybox, distroless) are not uploaded, so they cannot leave empty projects that read as "nothing to fix here".
- **Without `DT_API_KEY`** the workflow still scans, still uploads the artifacts, and only skips the publish with a warning.
- `trivy clean --scan-cache` runs between images; the layer cache otherwise fills a runner's 14 GB well before image 30.

## Verification

- `./scripts/validate.sh` — exit 0
- Scan loop exercised locally against real images, including the private-registry skip path
- Converted SBOM validated against the official CycloneDX 1.6 JSON schema — passes
- All four action SHAs verified against their upstream tags

## Before the upload works

Not doable from CI:

1. In Dependency-Track → *Administration → Access Management → Teams*, create a team with `BOM_UPLOAD`, `PROJECT_CREATION_UPLOAD` and `VIEW_PORTFOLIO`, and generate an API key.
2. Add it as the repository secret **`DT_API_KEY`** and the server URL as the variable **`DT_URL`**.

Until then the workflow is green and produces artifacts, just does not publish.