### PR TITLE
docs(readme): state the actual image count the ci scan covers

### DIFF
--- a/.github/workflows/sbom-scan.yaml
+++ b/.github/workflows/sbom-scan.yaml
@@ -7,7 +7,7 @@ name: sbom-scan
 #
 # Only images the repo actually pins are visible from CI; whatever a chart
 # resolves on its own is not. The trivy-operator in the cluster covers that
-# side and reaches ~103 images against the ~30 seen here.
+# side and reaches ~103 images against the couple of dozen seen here.
 #
 # Trivy is left to score nothing: DT does its own analysis from the SBOM, so
 # the scan runs with --scanners license and ships the component inventory.

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ the `security` layer and scans what is actually running — roughly 103 images �
 `SBOMReport`s. It runs in ClientServer mode against an in-cluster `trivy-server`; standalone
 mode deadlocks on the shared DB lock for multi-container pods.
 
-**In CI.** The [`sbom-scan`](.github/workflows/sbom-scan.yaml) workflow scans the ~30 images
-this repository *pins* and pushes their SBOMs to
+**In CI.** The [`sbom-scan`](.github/workflows/sbom-scan.yaml) workflow scans every image
+this repository *pins* — 27 today — and pushes their SBOMs to
 [Dependency-Track](https://dependencytrack.org/). It runs nightly, on every push to `main`
 that touches a manifest, and on demand. What a chart resolves on its own is invisible to CI
 by definition — that gap is exactly what the in-cluster operator covers.


### PR DESCRIPTION
The first `sbom-scan` run is in: **23 of 27** pinned images scanned, the other four sitting in private registries that CI has no credentials for. Replaces the `~30` estimate with the real number.