### PR TITLE
chore(apus): pin the operator and platform charts to 0.4.1

### DIFF
--- a/infrastructure/clusters/feather-core/base-sources/apus.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/apus.yaml
@@ -1,6 +1,6 @@
 ---
 # Apus ships its charts as OCI artifacts from our own Harbor, versioned together with
-# the images they deploy: apus-operator 0.4.0 references apus/operator:0.4.0, because the
+# the images they deploy: apus-operator 0.4.1 references apus/operator:0.4.1, because the
 # chart leaves image.tag empty and falls back to .Chart.AppVersion. Pin both repositories
 # to the same version for that reason -- mixing them defeats the coupling.
 apiVersion: source.toolkit.fluxcd.io/v1
@@ -15,7 +15,7 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-operator
   ref:
-    semver: "=0.4.0"
+    semver: "=0.4.1"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -29,4 +29,4 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-platform
   ref:
-    semver: "=0.4.0"
+    semver: "=0.4.1"


### PR DESCRIPTION
Bumps both Apus `OCIRepository` pins in `infrastructure/clusters/feather-core/base-sources/apus.yaml` from `=0.4.0` to `=0.4.1`.

## Why

0.4.0 shipped `logback.xml` files for `operator` and `ingest` that were not well-formed XML (a `--` inside a comment). Logback aborted its configuration and attached no appender, so both services logged nothing at all: `kubectl logs` on the running operator shows only Logback's own parsing stack trace, and no log record reached the OTLP collector either.

Tracing was unaffected and is confirmed working at 0.4.0, so the `otel.endpoint` in the operator's values overlay stays untouched.

0.4.1 fixes those two files, fixes the template they were generated from, and adds a test that loads every shipped `logback.xml` through Logback's own `JoranConfigurator`.

## Verification

- Charts `apus-operator:0.4.1` and `apus-platform:0.4.1` and images `apus/operator:0.4.1` / `apus/ingest:0.4.1` are present in Harbor.
- `./scripts/validate.sh` exits 0.