### PR TITLE
docs(repo): move the operational narrative to outline and trim comments

### DIFF
--- a/.github/workflows/sbom-scan.yaml
+++ b/.github/workflows/sbom-scan.yaml
@@ -1,16 +1,8 @@
 name: sbom-scan
 
-# Scan every image this repository pins with the Trivy CLI and push the
-# resulting CycloneDX SBOMs to Dependency-Track, one project per image with
-# the tag as its version - that is what lets Dependency-Track compare
-# v2.15.0 against v2.15.2 instead of filing them as unrelated projects.
-#
-# Only images the repo actually pins are visible from CI; whatever a chart
-# resolves on its own is not. The trivy-operator in the cluster covers that
-# side and reaches ~103 images against the couple of dozen seen here.
-#
-# Trivy is left to score nothing: DT does its own analysis from the SBOM, so
-# the scan runs with --scanners license and ships the component inventory.
+# SBOMs of the images this repo pins -> Dependency-Track. The in-cluster
+# trivy-operator covers what actually runs; this covers what the repo declares.
+# outline.onelitefeather.dev/doc/supply-chain-scanning-trivy-und-dependency-track-sQdPCnAGdO
 
 on:
   schedule:
@@ -38,8 +30,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}
-  # Never cancel: a half-finished run leaves Dependency-Track with a partial
-  # picture that looks like a real drop in findings.
+  # A half-finished run leaves Dependency-Track looking like findings dropped.
   cancel-in-progress: false
 
 jobs:
@@ -59,8 +50,7 @@ jobs:
       - name: Install PyYAML
         run: pip install --quiet pyyaml
 
-      # Same Trivy version the in-cluster trivy-operator runs, so CI numbers
-      # and cluster reports stay comparable.
+      # Match the in-cluster trivy-operator so the numbers stay comparable.
       - uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
         with:
           version: v0.73.0
@@ -72,7 +62,6 @@ jobs:
           scripts/collect-images.py | tee images.txt
           echo "count=$(wc -l < images.txt)" >> "$GITHUB_OUTPUT"
 
-      # One shared DB download instead of one per image.
       - name: Warm Trivy database
         run: trivy image --download-db-only
 
@@ -87,13 +76,12 @@ jobs:
                  --timeout 10m -o "sbom/${name}.cdx.json" "$image"; then
               ok=$((ok + 1))
             else
-              # A private registry without credentials is expected here and
-              # must not fail the run - the cluster-side operator covers those.
+              # Private registries have no CI credentials; the operator covers them.
               echo "::warning title=Image not scannable::${image}"
               rm -f "sbom/${name}.cdx.json"
               skipped=$((skipped + 1))
             fi
-            # Runners have ~14 GB; the layer cache fills it well before image 30.
+            # The layer cache fills a runner's disk well before the last image.
             trivy clean --scan-cache >/dev/null 2>&1 || true
           done < images.txt
           echo "scanned ${ok}, skipped ${skipped}"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ control-plane, storage and worker nodes running Talos. There is no application s
 here, only manifests: Flux `Kustomization`s, Helm values, Kustomize overlays and a handful
 of in-repo charts.
 
+> **Operational documentation lives in Outline**, under
+> [Infrastruktur → Kubernetes-FLUX](https://outline.onelitefeather.dev/doc/kubernetes-flux-gitops-fur-feather-core-x27ljhcgMA).
+> That is where the *why* belongs — in particular
+> [Betriebsfallen](https://outline.onelitefeather.dev/doc/betriebsfallen-im-feather-core-cluster-qgL9Dgd4Ra),
+> the behaviours that are not visible in the manifests and that mostly cost an outage to
+> learn. Comments in this repository stay short and point there.
+
 The cluster reconciles itself against `main`. A change takes effect **only once it is
 merged**, after which Flux picks it up — the Git source is polled every minute, the root
 Kustomization every ten.

--- a/apps/clusters/feathre-core/base-apps/apus/bundle-bucket.yaml
+++ b/apps/clusters/feathre-core/base-apps/apus/bundle-bucket.yaml
@@ -1,14 +1,7 @@
 ---
-# The platform-wide bundle bucket: normalised world snapshots live here, written by ingest
-# jobs and read by render jobs (design spec §5).
-#
-# Deliberately NOT in rook-ceph-fr01 like the other claims in this repository. Rook always
-# creates the credentials secret and the endpoint ConfigMap in the namespace of the claim,
-# and the operator reads them from its own namespace -- a claim in rook-ceph-fr01 would put
-# the secret out of its reach. The design spec calls this deviation out in §9.1.
-#
-# The secret Rook generates carries AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY, which is
-# exactly what the operator's ingest and render jobs expect.
+# Deliberately NOT in rook-ceph-fr01 like the other claims: Rook creates the
+# credentials secret in the namespace of the claim, and the operator reads it
+# from its own.
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:

--- a/apps/clusters/feathre-core/base-apps/grafana/alerting/rules.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/alerting/rules.yaml
@@ -980,14 +980,8 @@ groups:
             datasourceUid: mimir
             model:
               editorMode: code
-              # count() returns a real value (currently 10, one per kubelet target) when
-              # the pipeline is healthy - evaluated normally against the threshold below,
-              # not firing. If every kubelet target vanishes from Mimir (the whole Alloy
-              # remote-write pipeline going dark), this query returns NO series, which
-              # triggers Grafana's NoData path -> noDataState: Alerting -> fires. Do NOT
-              # use absent() here: it returns empty exactly when healthy (the opposite of
-              # what noDataState: Alerting needs), which was a real bug (empty result +
-              # noDataState: Alerting fired immediately on a healthy cluster).
+              # Do NOT use absent() here: it returns empty when healthy, which is the
+              # opposite of what noDataState: Alerting needs. count() relies on NoData.
               expr: count(up{job="kubelet", metrics_path="/metrics"})
               instant: true
               intervalMs: 1000
@@ -1165,13 +1159,8 @@ groups:
             model:
               editorMode: code
               queryType: instant
-              # Two signatures, because a bad provisioning file surfaces on two paths. The
-              # sidecar reload is the live one: Grafana answers the POST with 500 and logs
-              # msg="Request Completed" ... path=/api/admin/provisioning/alerting/reload
-              # status=500 (verified against grafana/grafana:12.3.1). "Failed to provision
-              # alerting" is the fatal startup path, which only exists if the alerts sidecar
-              # is ever turned back into an init sidecar - matched anyway, it costs nothing.
-              # sum() collapses both replicas into one series, so one message, not two.
+              # Two signatures: the sidecar reload path (HTTP 500) and the fatal startup
+              # path. sum() collapses both replicas into one message.
               expr: 'sum(count_over_time({namespace="grafana", container="grafana"} |~ "Failed to provision alerting|provisioning/alerting/reload.*status=500" [10m]))'
               intervalMs: 1000
               maxDataPoints: 43200
@@ -1233,13 +1222,8 @@ groups:
             datasourceUid: mimir
             model:
               editorMode: code
-              # kube_node_status_condition carries all 3 statuses for every
-              # condition (150 series = 10 nodes x 5 conditions x 3 statuses),
-              # so this always has data -> noDataState: OK is correct.
-              # status="false" is NotReady, status="unknown" is Unreachable
-              # (kubelet stopped reporting) - both are pages, one rule.
-              # Do NOT write `{status="true"} == 0`: the filtered value is 0,
-              # so a `gt 0` threshold would never fire.
+              # Always has data, so noDataState: OK is correct. Do NOT write
+              # `{status="true"} == 0` — the filtered value is 0 and gt 0 never fires.
               expr: max by (node) (kube_node_status_condition{condition="Ready", status=~"false|unknown"})
               instant: true
               intervalMs: 1000

--- a/apps/clusters/feathre-core/base-apps/grafana/alerting/templates.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/alerting/templates.yaml
@@ -1,17 +1,9 @@
 apiVersion: 1
 templates:
-  # Static annotations come from (index .Alerts 0) and must never be templated per-$labels in
-  # a rule; per-instance values come from index $a.Labels (Labels, never templated annotations):
-  # after a restart warmStateCache hands back the RAW annotation template (grafana#114973,
-  # fixed in 12.4.x), while instance labels survive correctly.
-  # Grafana reads this file verbatim (Kustomize copies it into a ConfigMap, Helm never sees
-  # it), so the Go template is the only escaping layer left: backticks, single quotes and
-  # trailing whitespace are all allowed again. The "{{ define" rule below is Grafana's own
-  # and still applies.
-  # The payload is built via coll.Dict/coll.Slice and serialized by data.ToJSON (= json.Marshal),
-  # never concatenated, so no value can break the JSON. Every printf precision is a Discord
-  # limit guard; the 12-instance cap follows from field.value <= 1024 (worst case 71 runes/line
-  # x 12 + 38 = 890). printf counts runes. No arithmetic is available (no sprig, no math.Sub).
+  # Read per-instance values from .Labels, never from templated annotations —
+  # after a restart warmStateCache hands back the raw template (grafana#114973).
+  # Helm never sees this file, so the Go template is the only escaping layer.
+  # outline.onelitefeather.dev/doc/betriebsfallen-im-feather-core-cluster-qgL9Dgd4Ra
   - name: discord.title
     template: '{{ define "discord.title" }}{{ if eq .Status "firing" }}{{ if eq (index .CommonLabels "severity") "warning" }}🟠{{ else }}🔴{{ end }} FIRING{{ if gt (len .Alerts.Firing) 1 }} ({{ len .Alerts.Firing }}x){{ end }}{{ else }}✅ RESOLVED{{ if gt (len .Alerts.Resolved) 1 }} ({{ len .Alerts.Resolved }}x){{ end }}{{ end }} · {{ index .CommonLabels "alertname" }}{{ end }}'
   # Must open with "{{ define", never "{{- define": Grafana validates with \{\{\s*define, so a

--- a/apps/clusters/feathre-core/base-apps/grafana/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/release.yaml
@@ -112,13 +112,8 @@ spec:
         ha_listen_address: $${POD_IP}:9094
         ha_advertise_address: $${POD_IP}:9094
         rule_version_record_limit: "5"
-        # Provisioning only writes the Alertmanager config to the database; the running
-        # Alertmanager picks it up in this poll loop. At the 1m default a notification can
-        # render against a config that does not know a just-provisioned template yet, which
-        # fails with "template not defined" - and the webhook notifier does not retry, so the
-        # alert is dropped silently. Measured 62.3s between "finished provision alerting" and
-        # the following "Applying new configuration to Alertmanager". ApplyConfig is a no-op
-        # while the config hash is unchanged, so the cost is one small query per interval.
+        # The 1m default let notifications render against a config that did not know
+        # a just-provisioned template yet; the webhook notifier drops those silently.
         alertmanager_config_poll_interval: 10s
       alerting:
         enabled: false
@@ -173,13 +168,8 @@ spec:
     dashboardProviders:
       dashboardproviders.yaml:
         apiVersion: 1
-        # Every provider here still serves remote (gnetId/url) dashboards only;
-        # its inline ones moved to sidecar ConfigMaps (see dashboards/ next to
-        # this file). disableDeletion: true is what makes that move safe: Grafana
-        # would otherwise delete the dashboard record once the file disappears
-        # and the sidecar would recreate it under a new id, losing the version
-        # history; with the flag the record is merely unprovisioned, so the
-        # sidecar adopts the existing one by uid.
+        # Remote (gnetId/url) dashboards only — inline ones live in sidecar
+        # ConfigMaps. disableDeletion keeps the version history across that move.
         providers:
           - name: kubernetes
             orgId: 1
@@ -280,23 +270,12 @@ spec:
         searchNamespace:
           - grafana
         watchMethod: WATCH
-        # Deliberately NOT initAlerts/native-sidecar like the dashboards one. Alerting
-        # provisioning never prunes on absence (every Unprovision path needs an explicit
-        # deleteRules/deleteContactPoints/resetPolicies directive), so an empty directory at
-        # startup is a no-op and the churn the dashboards had has no counterpart here. In
-        # exchange, provisioning moves off Grafana's fatal starting() path -- where a bad file
-        # is a CrashLoopBackOff -- onto the reload path, where it is an HTTP 500 and Grafana
-        # keeps serving the previous config.
+        # Deliberately not a native sidecar like the dashboards one: this keeps a bad
+        # provisioning file an HTTP 500 instead of a CrashLoopBackOff.
     dashboards:
       kubernetes:
-        # kubernetes-dashboard (gnetId 22523) removed: it never worked. It
-        # pinned revision 2, which does not exist (the API lists only
-        # revision 1), so the download 404'd and left a 0-byte file that
-        # Grafana rejected with a permanent error=EOF. Bumping to revision 1
-        # is not the fix either -- that revision carries uid
-        # k8s_views_global, which a manually imported, non-provisioned
-        # dashboard already holds, and provisioning adopts an occupied uid
-        # instead of erroring, so it would silently overwrite and rename it.
+        # kubernetes-dashboard (gnetId 22523) removed: it never worked, and
+        # revision 1 would silently overwrite a manually imported dashboard.
         kubernetes-cluster:
           gnetId: 7249
           revision: 1
@@ -362,13 +341,8 @@ spec:
           gnetId: 13106
           revision: 1
           datasource: Mimir
-        # redis-exporter (gnetId 14091) removed: queried redis_exporter-
-        # style redis_* metric names, which nothing in this cluster ever
-        # produced (confirmed dead since the bitnami Redis -> Dragonfly
-        # migration -- no redis_up sample in 21+ days). Replaced with the
-        # official dragonfly-operator dashboard, matched against the
-        # dragonfly_* metrics the new PodMonitor actually scrapes; it now lives
-        # in dashboards/databases/dragonfly.json.
+        # redis-exporter (gnetId 14091) removed: nothing produces redis_* metrics
+        # since the Dragonfly migration. Replaced by dashboards/databases/dragonfly.json.
       storage:
         ceph-pools:
           gnetId: 5342

--- a/apps/clusters/feathre-core/base-apps/n8n/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/n8n/release.yaml
@@ -19,13 +19,8 @@ spec:
       workerReplicaCount: 2
       workerConcurrency: 10
 
-    # External Postgres on the shared CNPG cluster. Connect to the primary
-    # -rw service directly, NOT the PgBouncer pooler: n8n sends
-    # statement_timeout as a libpq startup parameter, which PgBouncer rejects
-    # ("unsupported startup parameter: statement_timeout") unless it's in
-    # ignore_startup_parameters — and changing that on the shared pooler would
-    # affect every other app. DB + role provisioned via CNPG in
-    # infrastructure/.../configs/postgresql.
+    # The -rw service directly, NOT the PgBouncer pooler: n8n sends
+    # statement_timeout as a startup parameter, which PgBouncer rejects.
     database:
       type: postgresdb
       useExternal: true

--- a/apps/clusters/feathre-core/base-apps/outline/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/outline/release.yaml
@@ -52,17 +52,9 @@ spec:
     httpRoute:
       enabled: false
 
-    # Outline services run as stateless Deployments. Only the HTTP/realtime
-    # surface (web, websockets) and the BullMQ services (worker, cron) are run
-    # together in the web component: websockets has no WEBSOCKETS_URL, and an
-    # isolated worker/cron grows memory unbounded (BullMQ leak when run alone),
-    # whereas the proven all-in-one process model is stable. cron duplication
-    # across the 2 web replicas is safe (BullMQ repeatable jobs are idempotent).
-    # collaboration has its own URL/path and runs separately for independent
-    # scaling. The Cloudflare Tunnel Ingress (ingress.yaml) routes:
-    #   /collaboration -> outline-collaboration
-    #   /              -> outline-web (app, API, /realtime, worker, cron)
-    # Multi-replica collaboration requires REDIS_COLLABORATION_URL in outline-env.
+    # websockets, worker and cron must stay inside the web component — none of
+    # them survives being run standalone:
+    # outline.onelitefeather.dev/doc/betriebsfallen-im-feather-core-cluster-qgL9Dgd4Ra
     components:
       web:
         enabled: true

--- a/apps/clusters/feathre-core/base-apps/plane/ingress.yaml
+++ b/apps/clusters/feathre-core/base-apps/plane/ingress.yaml
@@ -10,37 +10,10 @@ spec:
     - host: tasks.onelitefeather.net
       http:
         paths:
-          # ============================================================
-          # IMPORTANT — how cloudflare-tunnel-ingress-controller actually
-          # matches these paths (verified against its source, v0.0.23,
-          # pkg/cloudflare-controller/tunnel-client.go):
-          #
-          #   1. Rules for one hostname are sorted by len(path) DESCENDING
-          #      before being pushed to Cloudflare. The order they're
-          #      written in below has NO effect on evaluation order.
-          #   2. Each rule's "path" becomes a Cloudflare Tunnel ingress
-          #      `path`, which is an UNANCHORED regex — it matches if the
-          #      text appears ANYWHERE in the request path, not just as a
-          #      leading prefix. cloudflared evaluates the length-sorted
-          #      list top to bottom; first match wins.
-          #   3. Consequence: any two rules of EQUAL path length race in
-          #      an unspecified (non-deterministic sort) order if both
-          #      match the same request. Every rule below MUST have a
-          #      length distinct from any other rule it could plausibly
-          #      collide with. Two known, deliberately-resolved cases:
-          #        - plane-web's hashed bundle "/assets/*.js" vs
-          #          plane-api's "/api/assets/*" upload endpoints — both
-          #          contain "/assets" as a substring.
-          #        - plane-space's own "/spaces/assets/*.js" bundle vs
-          #          the same generic "/assets" rule.
-          #      Both were live outages/breakage before being split out
-          #      into their own longer, more specific rules below.
-          #      /silo, /live, /auth are still tied at 5 chars — left
-          #      alone since no real path has been found that matches
-          #      more than one of them, but treat any future addition of
-          #      an endpoint containing one of those words as a substring
-          #      as a potential silent misroute until re-verified.
-          # ============================================================
+          # Paths are matched as UNANCHORED regexes, sorted by length, not by the
+          # order below. Equal-length rules race non-deterministically — keep every
+          # length distinct. Two outages came from this:
+          # outline.onelitefeather.dev/doc/betriebsfallen-im-feather-core-cluster-qgL9Dgd4Ra
 
           # plane-space's own hashed JS/CSS bundle, e.g.
           # /spaces/assets/entry.client-*.js — must outrank the generic
@@ -93,13 +66,8 @@ spec:
                 port:
                   number: 3000
 
-          # Integrations backend. The chart's SILO_BASE_PATH/SILO_API_BASE_URL
-          # env vars (plane-silo-vars ConfigMap) already assume this exact
-          # path. Routed to plane-silo-ingress (silo-service.yaml), NOT the
-          # chart's own "plane-silo" Service — that one is headless
-          # (clusterIP: None), which this controller can't parse a backend
-          # for; referencing it directly previously took down the whole
-          # domain (see git history on this file).
+          # Must point at plane-silo-ingress, not the chart's headless plane-silo
+          # Service — a headless backend took the whole domain down once.
           - path: /silo
             pathType: Prefix
             backend:

--- a/apps/clusters/feathre-core/base-apps/plane/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/plane/release.yaml
@@ -22,19 +22,10 @@ spec:
               - op: add
                 path: /spec/template/spec/priorityClassName
                 value: feather-standard
-          # Carried over from the CE cutover: the shared makeplane/backend* image's
-          # docker-entrypoint-worker.sh runs `celery -A plane worker` with no
-          # --concurrency flag, forking one process per *node* CPU core (32 here)
-          # regardless of cpuLimit. Kept as a precaution since this chart's worker
-          # Deployment (plane-worker-wl) execs the same-named entrypoint script on
-          # the "-commercial" variant of the same backend image; verify after
-          # cutover whether the bug still applies (harmless either way — this pins
-          # concurrency to 2 regardless).
-          # services.rabbitmq exposes no resource keys in plane-enterprise 3.0.0,
-          # so the StatefulSet ships with `resources: {}` — BestEffort, and the
-          # first thing the kubelet evicts, despite being the queue every worker
-          # depends on. No CPU limit on purpose: throttling a broker is worse
-          # than letting it burst (observed 453m under normal load).
+          # The image entrypoint runs celery without --concurrency and forks one
+          # process per node core (32 here) regardless of cpuLimit. This pins it.
+          # The chart exposes no resources for rabbitmq, leaving it BestEffort and
+          # first to be evicted. No CPU limit on purpose: never throttle a broker.
           - target:
               kind: StatefulSet
               name: plane-rabbitmq-wl
@@ -125,14 +116,8 @@ spec:
         memoryRequest: 256Mi
         cpuRequest: 50m
 
-      # Pi (the AI assistant) is left at the chart default (disabled): its
-      # migrator job hard-fails without an embedding model configured
-      # (tries to auto-create one via Cohere, errors out if COHERE_API_KEY
-      # or OPENSEARCH_ML_MODEL_ID isn't set), which blocks the whole release
-      # from ever becoming Ready. Re-enable (pi.enabled: true, plus
-      # pi_beat_worker/pi_worker, plus an AI provider key in
-      # external_secrets.pi_api_env_existingSecret) once a provider key is
-      # available.
+      # Left disabled: without an AI provider key the migrator job hard-fails and
+      # blocks the whole release from becoming Ready.
 
     external_secrets:
       app_env_existingSecret: plane-app-env
@@ -143,17 +128,8 @@ spec:
       silo_env_existingSecret: plane-silo
 
     env:
-      # Global storage class for every chart-bundled StatefulSet PVC (rabbitmq,
-      # opensearch, monitor). NOT a per-service field despite matching per-service
-      # value blocks elsewhere in this chart — services.*.storageClass doesn't
-      # exist; every workloads/*.stateful.yaml template reads this single
-      # env.storageClass value. Left unset, opensearch/monitor's PVC templates
-      # render an explicit storageClassName: "" (they `| quote` the empty
-      # default), which blocks the cluster's default-StorageClass admission
-      # behavior and leaves the PVC Pending forever — rabbitmq's template omits
-      # the quote filter, so it degrades to an unset field instead and happens
-      # to pick up the default class by luck. Set explicitly so all three behave
-      # the same way on purpose.
+      # Global, not per-service — services.*.storageClass does not exist. Leaving
+      # it unset renders storageClassName: "" and pins those PVCs Pending forever.
       storageClass: ceph-rbd-fr01
       docstore_bucket: plane
       cors_allowed_origins: "https://tasks.onelitefeather.net"

--- a/apps/clusters/feathre-core/base-apps/reposilite/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/reposilite/release.yaml
@@ -18,22 +18,9 @@ spec:
                 path: /spec/template/spec/priorityClassName
                 value: feather-standard
   values:
-    # Ingot instead of Reposilite. The fork is a drop-in replacement: same
-    # entrypoint, same paths, same environment variables, same schema in the
-    # same database. Nothing else in this release changes, and
-    # REPOSILITE_LOCAL_DATABASE below keeps working because Ingot reads the
-    # legacy prefix as a fallback.
-    #
-    # Rehearsed against a full copy of this instance, the database plus 19.7
-    # GiB of artifacts across all five buckets: artifacts came back byte
-    # identical, all six access tokens survived, an upload authenticated with
-    # REPOSILITE_OPTS was accepted, and dzikoysk/reposilite:3.5.28 was then
-    # pointed back at the same data and read everything Ingot had written.
-    #
-    # `tag` is mandatory, not cosmetic. The chart renders
-    # `{{ image.name }}:{{ image.tag | default .Chart.AppVersion }}`, so
-    # leaving it out asks for ghcr.io/onelitefeathernet/ingot:3.5.28, which
-    # does not exist. Bump it together with the chart pin above.
+    # Ingot is a drop-in fork of Reposilite. `tag` is mandatory, not cosmetic:
+    # without it the chart asks for a tag that does not exist. Bump it together
+    # with the chart pin above.
     image:
       name: ghcr.io/onelitefeathernet/ingot
       tag: "1.1.0"

--- a/apps/clusters/feathre-core/base-apps/shlink/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/shlink/release.yaml
@@ -113,13 +113,8 @@ spec:
             key: GEOLITE_LICENSE_KEY
       - name: REDIS_PUB_SUB_ENABLED
         value: "true"
-      # Dragonfly cutover: single DIRECT connection (no Sentinel; the operator
-      # keeps the `dragonfly` Service pointed at the current master). IMPORTANT:
-      # in standalone mode shlink-common (RedisFactory::resolveOptions) ONLY
-      # applies REDIS_SERVERS_PASSWORD for sentinel; for a plain server the
-      # password MUST be embedded in the URI (tcp://:pass@host:port/db). The full
-      # URI (incl. password + DB 8) therefore comes from the secret so it stays
-      # out of git. See docs/dragonfly-redis-cutover.md.
+      # Standalone mode ignores REDIS_SERVERS_PASSWORD — the password must be
+      # embedded in the URI, which is why the whole URI comes from the secret.
       - name: REDIS_SERVERS
         valueFrom:
           secretKeyRef:

--- a/apps/clusters/feathre-core/monitoring/mimir/release.yaml
+++ b/apps/clusters/feathre-core/monitoring/mimir/release.yaml
@@ -42,29 +42,13 @@ spec:
           push_grpc_method_enabled: true
         limits:
           compactor_blocks_retention_period: 365d
-          # Default 150k was exhausted (new series silently rejected with
-          # err-mimir-max-series-per-user), blocking envoy metrics ingestion.
-          # 400k covers the in-memory head (stale series linger up to 2h
-          # after compaction) on top of ~275k active series; the apiserver
-          # bucket drops in kube-prometheus-stack bring actives down again.
-          #
-          # Temporarily raised to 600k on 2026-07-13: the alloy-metrics
-          # clustering bugfix (both replicas were scraping the full target
-          # set, undeduplicated, for ~2.5h before the fix) filled the
-          # ingesters to exactly 400k with duplicate series that hadn't
-          # aged out yet. Revert to 400000 once cortex_ingester_memory_series
-          # settles back near its ~275k baseline.
+          # Temporarily 600k since 2026-07-13 (duplicate series from the
+          # alloy-metrics clustering bug). Back to 400000 once
+          # cortex_ingester_memory_series settles near its ~275k baseline.
           max_global_series_per_user: 600000
-          # Default (10000/s, 200000 burst) started rejecting the whole
-          # tenant with err-mimir-tenant-max-ingestion-rate on 2026-07-13,
-          # after this session added several new metrics sources (otis/
-          # vulpes-backend/reposilite OTel metrics, envoy tracing span-
-          # metrics, tempo local-blocks generator). The 429 backpressure
-          # cascaded into err-mimir-sample-timestamp-too-old, dropping
-          # unrelated pre-existing metrics (node-exporter, kubelet/cadvisor,
-          # envoy, ceph, mariadb) as the remote_write retry queue backed up.
-          # Revisit sizing once the actual sustained rate is confirmed via
-          # cortex_distributor_ingestion_rate_samples_per_second.
+          # Raised after the default rejected the whole tenant; the 429
+          # backpressure cascaded and dropped unrelated metrics. Revisit once
+          # cortex_distributor_ingestion_rate_samples_per_second is confirmed.
           ingestion_rate: 30000
           ingestion_burst_size: 600000
         common:

--- a/apps/clusters/feathre-core/monitoring/tempo/release.yaml
+++ b/apps/clusters/feathre-core/monitoring/tempo/release.yaml
@@ -40,15 +40,8 @@ spec:
       # and crashloops on it ("Maximum connections must be greater than 0").
       extraArgs:
         - -config.expand-env=true
-      # Bumped after repeated OOMKills: enabling the local-blocks generator
-      # processor means the compactor now also compacts blocks flushed from
-      # metrics-generator. vParquet4 compaction memory scales with the
-      # number of distinct trace IDs being combined across input blocks
-      # (an in-memory index per trace), not with on-disk block size — three
-      # ~1-17MB blocks totaling ~92k objects still OOMKilled at 1Gi within
-      # seconds of "compacting hash" starting. Matches the same
-      # bytes-on-disk-understates-memory-need pattern already seen on the
-      # ingester above.
+      # vParquet4 compaction memory scales with the number of distinct trace IDs,
+      # not with block size on disk — small blocks still OOMKilled at 1Gi.
       resources:
         requests:
           cpu: 100m
@@ -102,26 +95,15 @@ spec:
                     app.kubernetes.io/component: distributor
                 topologyKey: kubernetes.io/hostname
     ingester:
-      # 3 replicas + replication_factor 3 2026-07-19: every span was going to
-      # a single ingester with zero redundancy - any restart (routine or
-      # OOMKill) meant a real gap in ingestion/query availability, not just
-      # elevated latency. With RF == replica count every ingester holds a
-      # full copy of every trace (simple full mirroring, not sharding) -
-      # appropriate at this scale where a single ingester already handles
-      # the full load comfortably; this is purely for redundancy.
+      # RF == replica count: every ingester holds a full copy of every trace.
+      # Full mirroring for redundancy, not sharding for load.
       replicas: 3
       extraArgs:
         - -config.expand-env=true
       config:
         replication_factor: 3
-      # Bumped after repeated OOMKills: each crash left more WAL blocks to
-      # replay+flush on the next start, so the ingester needed more memory
-      # each time just to get past startup, compounding the crashloop.
-      # Bumped again 2026-07-19: same compounding crashloop recurred at 2Gi
-      # (51 OOMKills in 46m) once span ingestion roughly tripled (48-78/s ->
-      # 100-190/s); working set was plateauing at 1.2-2GB before each kill.
-      # Node has ample headroom (~27% memory used), so going straight to 4Gi
-      # rather than a marginal bump that likely just delays the next round.
+      # Each OOM leaves more WAL to replay on the next start, so an undersized
+      # limit compounds its own crashloop. Do not trim this back marginally.
       resources:
         requests:
           cpu: 100m
@@ -158,14 +140,8 @@ spec:
       replicas: 3
       extraArgs:
         - -config.expand-env=true
-      # Bumped 2026-07-19 after OOMKills: memcached became briefly unreachable
-      # during a tempo-wide rollout ("connect timeout to <clusterIP>:11211"),
-      # so every parquet-footer/bloom/frontend-search cache lookup fell
-      # through to uncached in-memory work; working set jumped from its
-      # normal ~30MB baseline to 394MB+ within seconds and got OOMKilled at
-      # 512Mi. Memcached itself was healthy throughout - this is about
-      # surviving that class of transient cache-miss storm, not a sustained
-      # need for more memory day to day.
+      # Sized to survive a transient cache-miss storm, not for day-to-day need:
+      # a brief memcached outage pushed the working set from ~30MB past 394MB.
       resources:
         requests:
           cpu: 50m
@@ -238,16 +214,8 @@ spec:
           remote_write:
             - url: http://mimir-gateway.grafana.svc.cluster.local/api/v1/push
         processor:
-          # Persist the local-blocks WAL to the trace S3 backend. Without this,
-          # local-blocks only keeps a short in-memory/live window (~query_backend_after,
-          # default 30m), so Grafana Traces Drilldown's TraceQL-metrics panels
-          # (histogram by duration, rate, etc.) show "No data" as soon as the
-          # selected range reaches past the live window — while the plain
-          # "Slow traces" list (a normal trace search) still returns results.
-          # Flushing to S3 lets the query-frontend answer older sub-ranges from
-          # object storage. Note: adds block-build/flush load on the generator
-          # and extra compaction work — watch the 512Mi generator limit and the
-          # compactor (both have prior OOMKill history).
+          # Without this, TraceQL-metrics panels show "No data" past the ~30m live
+          # window. Costs generator and compactor load — both have OOM history.
           local_blocks:
             flush_to_storage: true
       resources:

--- a/helm/leantime/Chart.yaml
+++ b/helm/leantime/Chart.yaml
@@ -2,14 +2,6 @@ apiVersion: v2
 name: leantime
 description: A Helm chart for Kubernetes to deploy LeanTime project management tool.
 
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes

--- a/helm/leantime/values.yaml
+++ b/helm/leantime/values.yaml
@@ -89,10 +89,6 @@ httpRoute:
         value: /
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #   cpu: 100m
   #   memory: 128Mi

--- a/helm/micronaut/Chart.yaml
+++ b/helm/micronaut/Chart.yaml
@@ -2,14 +2,6 @@ apiVersion: v2
 name: micronaut
 description: A Helm chart for Kubernetes
 
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes

--- a/helm/outline/Chart.yaml
+++ b/helm/outline/Chart.yaml
@@ -2,14 +2,6 @@ apiVersion: v2
 name: outline
 description: A Helm chart for Kubernetes
 
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes

--- a/helm/outline/values.yaml
+++ b/helm/outline/values.yaml
@@ -1,25 +1,6 @@
-# Outline ships as a single image whose sub-services are selected via the
-# SERVICES env var. To survive node failures and rolling updates without an
-# outage we run every service as its own stateless Deployment ("component").
-# Nothing here is a StatefulSet: all state lives in Postgres, Redis and S3.
-#
-#   web           -> app, API, static, websockets /realtime, worker AND cron
-#   collaboration -> Hocuspocus realtime editing            (path /collaboration)
-#
-# websockets (socket.io) and the BullMQ services (worker, cron) do not run
-# correctly standalone (websockets has no WEBSOCKETS_URL; an isolated
-# worker/cron grows memory unbounded), so they run inside the web component via
-# SERVICES="web,websockets,worker,cron". cron duplication across web replicas
-# is safe (BullMQ repeatable jobs are idempotent). collaboration scales
-# independently. Each container only serves the routes of its own SERVICES, so
-# the gateway must route:
-#   /collaboration -> <release>-collaboration
-#   /              -> <release>-web   (also serves /realtime)
-#
-# Running collaboration with >1 replica requires Redis sync:
-#   - websockets    uses REDIS_URL (socket.io adapter)            -- already set
-#   - collaboration needs REDIS_COLLABORATION_URL in the .env secret
-# See https://docs.getoutline.com/s/hosting/doc/horizontal-scaling-hkfU5Stao7
+# One image, sub-services selected per component via the SERVICES env var.
+# websockets, worker and cron cannot run standalone and must stay inside web.
+# outline.onelitefeather.dev/doc/betriebsfallen-im-feather-core-cluster-qgL9Dgd4Ra
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
@@ -44,14 +25,8 @@ extraEnv: []
 # - name: FOO
 #   value: bar
 
-# Components are the per-service Deployments. Each runs the same image but a
-# different SERVICES subset. Disable a component by setting enabled: false.
-# Fields per component:
-#   services   (string)  -> value of the SERVICES env var (required)
-#   http       (bool)    -> exposes the container port + gets a Service
-#   service    (bool)    -> create a Service for this component (defaults to http)
-#   replicaCount, strategy, resources, livenessProbe, readinessProbe,
-#   autoscaling, pdb, nodeSelector, affinity, tolerations, topologySpreadConstraints
+# Per-service Deployments, same image, different SERVICES subset.
+# `services` is required; `http` exposes the port and creates a Service.
 components:
   web:
     enabled: true

--- a/helm/shlink/Chart.yaml
+++ b/helm/shlink/Chart.yaml
@@ -2,14 +2,6 @@ apiVersion: v2
 name: shlink
 description: A Helm chart for Kubernetes
 
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes

--- a/infrastructure/base/controllers/cloudflare-tunnel-ingress-controller/namespace.yaml
+++ b/infrastructure/base/controllers/cloudflare-tunnel-ingress-controller/namespace.yaml
@@ -3,19 +3,10 @@ kind: Namespace
 metadata:
   name: cloudflare-tunnel-ingress-controller
   labels:
-    # `baseline`, not `privileged`. The connector Deployment the controller
-    # generates is indeed not "restricted"-compliant (no runAsNonRoot, no
-    # drop: ALL, no seccompProfile) — but none of that needs `privileged`,
-    # which `baseline` already permits. Verified with a server-side dry-run:
-    # baseline admits all four pods with no warning, restricted rejects them.
-    #
-    # This namespace terminates the tunnel fronting every public hostname and
-    # holds the tunnel token, so it is the last place that should accept a
-    # pod asking for privileged: true or hostPath /.
-    #
-    # Set explicitly rather than deleted, so the intent survives a change to
-    # the Talos cluster-wide default. Re-check after a controller upgrade —
-    # the exemption existed because of what the controller *generates*.
+    # `baseline`, not `privileged`: the generated connector is not restricted-
+    # compliant but needs nothing privileged. This namespace holds the tunnel
+    # token — do not widen it. Set explicitly so the intent survives a change
+    # to the Talos cluster-wide default.
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/warn: baseline
     pod-security.kubernetes.io/audit: baseline

--- a/infrastructure/clusters/feather-core/base-controllers/cloudflare-tunnel-ingress-controller/release.yaml
+++ b/infrastructure/clusters/feather-core/base-controllers/cloudflare-tunnel-ingress-controller/release.yaml
@@ -53,13 +53,8 @@ spec:
       # connector, not just s3.onelitefeather.net.
       extraArgs:
         - "--proxy-keepalive-timeout=10m"
-    # cloudflared already runs its Prometheus /metrics endpoint on :44483
-    # (the controller sets --metrics itself, not configurable via Helm) --
-    # this just wires up scraping for it. No tracing equivalent exists:
-    # cloudflared's OTel spans are shipped only to Cloudflare's own edge as
-    # an internal header, with no external-export flag at all (confirmed
-    # upstream, cloudflare/cloudflared#671 -- maintainer: "we do not plan
-    # for the OpenTelemetry traces ... to be exposed externally").
+    # cloudflared serves /metrics on :44483 by itself; this only wires up the
+    # scrape. There is no tracing equivalent — see cloudflare/cloudflared#671.
     cloudflaredServiceMonitor:
       create: true
     affinity:

--- a/infrastructure/clusters/feather-core/base-controllers/kube-prometheus-stack/release.yaml
+++ b/infrastructure/clusters/feather-core/base-controllers/kube-prometheus-stack/release.yaml
@@ -10,25 +10,11 @@ spec:
       enabled: false
     alertmanager:
       enabled: false
-    # Scraping + remote_write now happens via a dedicated Alloy instance
-    # (apps/clusters/feathre-core/base-apps/alloy-metrics) instead of the
-    # Prometheus Operator's own Prometheus-Agent StatefulSet. `crds.enabled`
-    # is left at its chart default (true) so the PodMonitor/ServiceMonitor
-    # CRDs — and the chart's own built-in ServiceMonitors below — keep
-    # existing.
-    #
-    # Deliberately staged in two steps, NOT done in one shot:
-    # step 1 (this change) only removes the PrometheusAgent CR while the
-    # operator is still running, so its finalizer-driven reconcile loop
-    # actually tears down the prometheus-agent StatefulSet/PVCs itself.
-    # The generated StatefulSet has no Kubernetes ownerReference back to
-    # the CR, so if the operator were disabled in the same apply, nothing
-    # would be left to clean it up — the old Agent pods would keep running
-    # and double-writing to Mimir alongside alloy-metrics, forever.
-    # Step 2 — set prometheusOperator.enabled: false — only once
-    # `kubectl get statefulset -n monitoring -l operator.prometheus.io/name=kube-prometheus-stack-prometheus`
-    # (or `flux get helmrelease kube-prometheus-stack -n monitoring`) confirms
-    # the agent StatefulSet is actually gone.
+    # Scraping moved to alloy-metrics. Do NOT disable prometheusOperator in the
+    # same change that drops the PrometheusAgent CR — the generated StatefulSet
+    # has no ownerReference, so nothing would clean it up and the old pods would
+    # keep double-writing to Mimir. Two-step teardown:
+    # outline.onelitefeather.dev/doc/betriebsfallen-im-feather-core-cluster-qgL9Dgd4Ra
     prometheus:
       enabled: false
     # Apiserver duration-histogram buckets alone were ~127k of ~275k active
@@ -51,15 +37,9 @@ spec:
         # collector set.
         limits:
           memory: 384Mi
-      # Restores per-object Flux Ready/Suspended status as gotk_resource_info
-      # (the metric the Flux Cluster Stats dashboard was built for -- it's
-      # not a native Flux controller metric, it's this kube-state-metrics
-      # feature, which was simply never configured here). Deliberately
-      # does NOT set collectors/extraArgs --custom-resource-state-only:
-      # both would replace/restrict the chart's existing full resource
-      # collector list, breaking every other kube-state-metrics-backed
-      # dashboard (Kubernetes Views, Objects, Kube State Metrics v2, etc.)
-      # instead of adding Flux metrics alongside them.
+      # gotk_resource_info comes from kube-state-metrics, not from Flux itself.
+      # Do NOT add --custom-resource-state-only: it would replace the chart's
+      # collector list and break every other kube-state-metrics dashboard.
       rbac:
         extraRules:
           - apiGroups:
@@ -279,14 +259,9 @@ spec:
                       ready: [status, conditions, "[type=Ready]", status]
                       suspended: [spec, suspend]
                       webhook_path: [status, webhookPath]
-              # Plugin-based (barman-cloud) backups don't update the CNPG
-              # operator's own cnpg_collector_last_available/failed_backup_timestamp
-              # metrics -- confirmed live they stay 0 forever regardless of
-              # real completed backups. These two gauges read the Backup CR
-              # itself instead. stoppedAt is only ever set once a backup
-              # finishes (completed or failed both leave it unset on error),
-              # so nilIsZero is required or KSM would skip the series for
-              # in-progress/failed backups entirely.
+              # The CNPG operator's own backup metrics stay 0 forever with
+              # barman-cloud, so read the Backup CR instead. nilIsZero is required
+              # or in-progress and failed backups get no series at all.
               - groupVersionKind:
                   group: postgresql.cnpg.io
                   version: v1

--- a/infrastructure/clusters/feather-core/configs/mariadb-galera/mariadb.yaml
+++ b/infrastructure/clusters/feather-core/configs/mariadb-galera/mariadb.yaml
@@ -7,37 +7,11 @@ metadata:
 #    kustomize.toolkit.fluxcd.io/reconcile: disabled
 spec:
   image: "mariadb:12.3.2"
-  # Without this, the official image's entrypoint silently skips mariadb-upgrade
-  # on every major-version bump (confirmed during the 11.8.8 -> 12.3.2 upgrade:
-  # "MariaDB upgrade ... skipped due to $MARIADB_AUTO_UPGRADE setting"), leaving
-  # stale mysql.* system tables until someone notices and runs it by hand.
+  # Without this the entrypoint silently skips mariadb-upgrade on every major
+  # bump and leaves stale mysql.* system tables behind.
   env:
     - name: MARIADB_AUTO_UPGRADE
       value: "1"
-#  securityContext:
-#    allowPrivilegeEscalation: false
-#    capabilities:
-#      drop: ["ALL"]
-#    runAsNonRoot: true
-#    runAsUser: 999
-#    runAsGroup: 999
-#    seccompProfile:
-#      type: RuntimeDefault
-#  podSecurityContext:
-#    runAsNonRoot: true
-#    runAsUser: 999
-#    runAsGroup: 999
-#    fsGroup: 999
-#    seccompProfile:
-#      type: RuntimeDefault
-#  podSecurityContext:
-#    seccompProfile:
-#      type: RuntimeDefault
-#  securityContext:
-#    allowPrivilegeEscalation: false
-#    capabilities:
-#      drop:
-#        - ALL
   replicas: 3
   livenessProbe:
     failureThreshold: 15
@@ -93,13 +67,8 @@ spec:
     tmp_table_size=64M
     max_heap_table_size=64M
 
-    # Diagnostics (slow_query_log) intentionally left off: with no rotation
-    # configured, it grew mariadb-galera-0's log to 17GB/96% disk over ~6 days
-    # (long_query_time=1 logs every query >1s; Galera only logs
-    # client-originated queries, not applied write-sets, so it lands
-    # disproportionately on whichever node handles write traffic at the
-    # time). Buffer pool hit ratio was already 99.34% with no other perf
-    # signal, so it was disabled rather than given a rotation mechanism.
+    # slow_query_log stays off: without rotation it grew to 17GB / 96% disk in
+    # six days, and there was no performance signal to justify it.
   affinity:
     antiAffinityEnabled: true
     nodeAffinity:

--- a/infrastructure/clusters/feather-core/configs/mariadb-galera/maxscale.yaml
+++ b/infrastructure/clusters/feather-core/configs/mariadb-galera/maxscale.yaml
@@ -21,18 +21,10 @@ spec:
     limits:
       memory: 256Mi
 
-  # Spread the 2 MaxScale replicas across nodes, but only against each other
-  # (preferred/soft) — NOT against MariaDB, since there aren't enough nodes to
-  # keep MaxScale and MariaDB fully separated. antiAffinityEnabled would make
-  # it a HARD rule against both maxscale + mariadb, over-constraining the 4
-  # DB-eligible workers (3 MariaDB already occupy 3 of them) and leaving the
-  # 2nd MaxScale pod Pending.
-  #
-  # IMPORTANT: spec.affinity.antiAffinityEnabled is immutable (webhook-enforced).
-  # Going from antiAffinityEnabled:true to this soft rule — and setting
-  # priorityClassName above — requires RECREATING the MaxScale CR:
-  #   kubectl delete maxscale maxscale-galera -n mariadb-galera
-  # Flux then re-applies this manifest fresh (brief rw-router VIP blip).
+  # Soft, and only against the other MaxScale replica — antiAffinityEnabled would
+  # make it hard against MariaDB too and leave the 2nd pod Pending. The field is
+  # immutable, so changing it means deleting and recreating the MaxScale CR:
+  # outline.onelitefeather.dev/doc/betriebsfallen-im-feather-core-cluster-qgL9Dgd4Ra
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/infrastructure/clusters/feather-core/rook-fr01/cluster/objectstore.yaml
+++ b/infrastructure/clusters/feather-core/rook-fr01/cluster/objectstore.yaml
@@ -17,20 +17,10 @@ spec:
       requireSafeReplicaSize: true
   preservePoolsOnDelete: true
   hosting:
-    # advertiseEndpoint is used by the Rook operator for RGW admin-ops calls
-    # (user/bucket reconcile) and must be reachable from inside the cluster.
-    # The external name belongs in dnsNames only; omitting advertiseEndpoint
-    # makes Rook default to the internal RGW service. Setting it to the external
-    # s3.onelitefeather.net caused all CephObjectStoreUser reconciles to time out
-    # (no NAT hairpin to the public IP). Virtual-host-style still works via the
-    # Envoy gateway + s3-proxy HTTPRoute, driven by rgw_dns_name from dnsNames.
-    #
-    # A host must be listed here for RGW to treat it as PATH-STYLE; any host not
-    # in dnsNames (nor an internal RGW service name Rook adds automatically) is
-    # parsed as virtual-host-style with the whole hostname as the bucket name.
-    # Hence the path-style endpoints below must be present:
-    #   - s3-path.onelitefeather.net   external path-style via Cloudflare Tunnel
-    #   - s3.apps.onelite.feather      internal path-style via the Envoy gateway
+    # A host listed here is served PATH-STYLE; anything else is parsed as
+    # virtual-host-style with the hostname as the bucket. Do NOT set
+    # advertiseEndpoint to the external name — that times out every user reconcile.
+    # outline.onelitefeather.dev/doc/betriebsfallen-im-feather-core-cluster-qgL9Dgd4Ra
     dnsNames:
       - s3.onelitefeather.net
       - s3-path.onelitefeather.net

--- a/infrastructure/clusters/feather-core/rook-fr01/s3-external-tunnel.yaml
+++ b/infrastructure/clusters/feather-core/rook-fr01/s3-external-tunnel.yaml
@@ -1,16 +1,7 @@
-# External path-style S3 endpoint via Cloudflare Tunnel.
-#
-# Lives in rook-ceph-fr01 because Ingress backends are namespace-local and the
-# RGW service is here. The host s3-path.onelitefeather.net is deliberately NOT
-# in the CephObjectStore dnsNames (which only lists s3.onelitefeather.net), so
-# RGW serves requests to this host as PATH-STYLE (s3-path.onelitefeather.net/<bucket>/<key>).
-# The existing virtual-host-style s3.onelitefeather.net + *.s3.onelitefeather.net
-# on Envoy is untouched.
-#
-# NOTE: Cloudflare's proxy caps request bodies at 100 MB. A single PutObject
-# >100 MB will fail; multipart-capable clients (aws-cli, most SDKs) are fine
-# because each part stays under the limit. For large single-shot uploads use the
-# Envoy endpoint instead.
+# External path-style S3 endpoint via Cloudflare Tunnel. The host is deliberately
+# NOT in the CephObjectStore dnsNames, which is what makes RGW serve it path-style.
+# Cloudflare caps request bodies at 100 MB — large single-shot uploads need Envoy.
+# outline.onelitefeather.dev/doc/betriebsfallen-im-feather-core-cluster-qgL9Dgd4Ra
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -32,14 +23,9 @@ spec:
                 port:
                   number: 80
 ---
-# Public PATH-STYLE endpoint for the canonical host s3.onelitefeather.net.
-#
-# s3.onelitefeather.net is listed in the CephObjectStore dnsNames, so RGW serves
-# it PATH-STYLE (s3.onelitefeather.net/<bucket>/<key>) — same parsing as the
-# s3-path host above. The Envoy HTTPRoute rgw-external-proxy still claims this
-# host internally, but the Envoy gateway LB is internal-only (10.200.90.1), so
-# the only PUBLIC route is this Cloudflare Tunnel. The tunnel controller creates
-# the public DNS CNAME for the host. Same 100 MB single-request body cap applies.
+# Public path-style endpoint for the canonical host. Envoy claims the same host
+# internally, but its LB is internal-only — this tunnel is the only public route.
+# The same 100 MB body cap applies.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/scripts/collect-images.py
+++ b/scripts/collect-images.py
@@ -1,16 +1,8 @@
 #!/usr/bin/env python3
 """Collect every container image this repository pins, for SBOM scanning.
 
-Walks the manifest trees and reports image references in the three shapes
-that actually occur here:
-
-  image: registry/name:tag                    plain string, e.g. a CronJob
-  image: {repository: name, tag: v1}          Helm values inside a HelmRelease
-  images: [{name: x, newName: y, newTag: z}]  a Kustomize image transformer
-
-Images a chart resolves on its own are invisible here by definition - only
-what the repo actually pins can be scanned from CI. Run scripts/collect-images.py
---stats to see how far that reaches.
+Only what the repo pins is visible here; whatever a chart resolves on its own
+is not. Use --stats to see how far that reaches.
 
   scripts/collect-images.py            one image reference per line
   scripts/collect-images.py --json     same, as a JSON array
@@ -30,7 +22,7 @@ SKIP_SUFFIX = (".sops.yaml", ".sops.env", ".sops.json", ".sops.crt", ".sops.key"
 
 
 def is_image_string(value):
-    """A tag or digest is what separates an image ref from an arbitrary string."""
+    """A tag or digest separates an image ref from an arbitrary string."""
     if not isinstance(value, str) or not value or value.startswith(("$", "{")):
         return False
     if "@sha256:" in value:
@@ -50,7 +42,6 @@ def join(registry, repository, tag):
 
 
 def walk(node, out, where):
-    """Depth-first: any dict may carry an image in one of the known shapes."""
     if isinstance(node, dict):
         img = node.get("image")
         if is_image_string(img):
@@ -60,7 +51,7 @@ def walk(node, out, where):
             if ref:
                 out.setdefault(ref, set()).add(where)
 
-        # a HelmRelease often splits registry/repository/tag across the same level
+        # a HelmRelease splits registry/repository/tag across one level
         if "repository" in node and "tag" in node and "image" not in node:
             ref = join(node.get("registry"), node.get("repository"), node.get("tag"))
             if ref:
@@ -98,7 +89,7 @@ def collect(repo_root):
                     with open(os.path.join(repo_root, path), encoding="utf-8") as fh:
                         docs = list(yaml.safe_load_all(fh))
                 except (yaml.YAMLError, UnicodeDecodeError):
-                    continue  # templates and encrypted files are not our business
+                    continue  # templates and encrypted files
                 for doc in docs:
                     walk(doc, out, path)
     return out
@@ -112,7 +103,7 @@ def main():
 
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     found = collect(repo_root)
-    # a floating tag says nothing about what was scanned, so leave it out
+    # a floating tag says nothing about what was scanned
     images = sorted(i for i in found if not i.endswith((":latest", ":stable", ":main")))
 
     if args.stats:

--- a/scripts/upload-sbom.py
+++ b/scripts/upload-sbom.py
@@ -1,21 +1,10 @@
 #!/usr/bin/env python3
 """Upload CycloneDX SBOMs to Dependency-Track, one project per image.
 
-Trivy writes CycloneDX 1.7. Dependency-Track 4.13 ships cyclonedx-core-java
-11.x, which validates against 1.6 and rejects 1.7 outright, so every BOM is
-rewritten before upload:
-
-  1. specVersion and $schema are set to 1.6
-  2. license IDs the 1.6 SPDX enum does not know (SMAIL-GPL and friends) move
-     from license.id to license.name, which is where non-SPDX licenses belong
-
-Both steps are lossless for what Dependency-Track actually analyses. Once the
-server runs 4.14 or newer the rewrite becomes a no-op that costs nothing, so it
-stays unconditional rather than sniffing the server version.
-
-Project name is the image repository, project version its tag - that is what
-makes Dependency-Track compare v2.15.0 against v2.15.2 instead of treating them
-as unrelated projects.
+Rewrites 1.7 to 1.6 on the way, because Trivy only emits the former and
+Dependency-Track 4.13 only accepts the latter. Project name is the image
+repository, version its tag, so the server compares tags of one image.
+https://outline.onelitefeather.dev/doc/supply-chain-scanning-trivy-und-dependency-track-sQdPCnAGdO
 
   DT_URL=https://dependency-track.example DT_API_KEY=odt_... \
     scripts/upload-sbom.py sbom/*.cdx.json
@@ -33,7 +22,7 @@ SPDX_1_6 = "https://raw.githubusercontent.com/CycloneDX/specification/1.6/schema
 
 
 def spdx_ids():
-    """The license IDs CycloneDX 1.6 accepts. Empty set means: rewrite nothing."""
+    """License IDs CycloneDX 1.6 accepts. Empty set means: rewrite nothing."""
     try:
         with urllib.request.urlopen(SPDX_1_6, timeout=30) as response:
             return set(json.load(response).get("enum") or [])
@@ -69,8 +58,7 @@ def to_1_6(bom, allowed):
 
 
 def image_of(bom, fallback):
-    """Trivy records the scanned image as the BOM's own metadata component,
-    and puts the tag in the name rather than in version: goharbor/x:v2.15.0."""
+    """Trivy puts the tag in the name, not in version: goharbor/x:v2.15.0."""
     component = (bom.get("metadata") or {}).get("component") or {}
     name = component.get("name") or fallback
     version = component.get("version") or ""
@@ -136,8 +124,7 @@ def main():
         project, version = image_of(bom, os.path.basename(path))
         components = len(bom.get("components") or [])
 
-        # Distroless and busybox-style images carry no package database. Uploading
-        # those would leave empty projects that read as "nothing to fix here".
+        # An empty project would read as "nothing to fix here".
         if not components:
             print(f"empty   {project}:{version}  (no package database)")
             empty += 1


### PR DESCRIPTION
Comment blocks in the manifests had grown into full incident write-ups — **60 blocks of seven lines or more**, several past 30. That is the wrong place for the reasoning: a code comment should flag a constraint in passing, the full story belongs where someone who wants it goes looking.

Nothing is lost. It moved to Outline, under **Infrastruktur**:

| Document | Contents |
|---|---|
| [Kubernetes-FLUX — GitOps für feather-core](https://outline.onelitefeather.dev/doc/kubernetes-flux-gitops-fur-feather-core-x27ljhcgMA) | Repo layout, layer dependency graph, secrets, conventions |
| [Betriebsfallen im feather-core-Cluster](https://outline.onelitefeather.dev/doc/betriebsfallen-im-feather-core-cluster-qgL9Dgd4Ra) | Every non-obvious behaviour, grouped by subsystem — routing, databases, apps, monitoring, storage |
| [Supply-Chain-Scanning](https://outline.onelitefeather.dev/doc/supply-chain-scanning-trivy-und-dependency-track-sQdPCnAGdO) | trivy-operator, the CI workflow, the CycloneDX 1.7/1.6 gap |

What stays in the code is one or two lines naming the constraint, with a link where the reasoning runs long. Example — `plane/ingress.yaml` went from 31 lines to four:

```yaml
# Paths are matched as UNANCHORED regexes, sorted by length, not by the
# order below. Equal-length rules race non-deterministically — keep every
# length distinct. Two outages came from this:
# outline.onelitefeather.dev/doc/betriebsfallen-im-feather-core-cluster-qgL9Dgd4Ra
```

## Deliberately left alone

- **`harbor/release.yaml`** — those comments come from goharbor's own `values.yaml` and earn their place when diffing against upstream.
- **`rekey.sh` / `validate.sh`** — usage headers documenting a CLI, not narrative.
- The untracked bluemap job files.

## Also removed

- `helm create` scaffold boilerplate in four `Chart.yaml` files ("A chart can be either an 'application' or a 'library' chart…")
- A block of commented-out `securityContext` in `mariadb.yaml` — dead, and duplicated twice over

## Numbers

| | before | after |
|---|---|---|
| Comment blocks ≥ 7 lines | 60 | 15 (11 of them upstream or CLI usage) |
| Lines | | −513 / +131 |

`./scripts/validate.sh` passes. The README now points at Outline up front.