### PR TITLE
feat(apus): deploy the platform api and dashboard

### DIFF
--- a/apps/base/apus/kustomization.yaml
+++ b/apps/base/apus/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: apus-system
 resources:
   - namespace.yaml
   - release-operator.yaml
+  - release-platform.yaml

--- a/apps/base/apus/release-operator.yaml
+++ b/apps/base/apus/release-operator.yaml
@@ -1,9 +1,8 @@
 ---
 # The operator alone is a usable Apus installation: it reconciles Tenants, WorldSources,
 # WorldIngests, BlueMapMaps, BlueMapRenders and BlueMapHostings from `kubectl` and Git.
-# The dashboard and REST API (apus-platform) sit on top and are deliberately not deployed
-# yet -- they require an OIDC issuer, and which identity broker sits in front of Apus is
-# still an open decision (design spec §15, point 3).
+# The dashboard and REST API sit on top and are deployed alongside it as apus-platform
+# (release-platform.yaml), validating tokens against this cluster's Entra ID tenant.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/apps/base/apus/release-platform.yaml
+++ b/apps/base/apus/release-platform.yaml
@@ -1,0 +1,32 @@
+---
+# The dashboard and REST API on top of the operator. The API validates JWTs against an OIDC
+# issuer, so auth.issuer and auth.jwksUri have no chart defaults and the chart's
+# values.schema.json rejects an install without them - both are set per cluster in the
+# overlay, never here.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: apus-platform
+  namespace: apus-system
+spec:
+  releaseName: apus-platform
+  chartRef:
+    kind: OCIRepository
+    name: apus-platform
+    namespace: flux-system
+  interval: 1m0s
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # No Ingress on purpose, both Services stay ClusterIP. The dashboard image cannot complete
+    # a login: ui/nuxt.config.ts leaves oidcIssuer/oidcClientId empty and ui/Dockerfile runs
+    # `pnpm generate` with no build arguments, so the SPA's OIDC configuration is baked in at
+    # image build time and is empty in the published image. A public hostname would only
+    # publish something that cannot be logged into. Reach the API with `kubectl port-forward`
+    # until the UI image is built with its OIDC configuration.
+    ingress:
+      enabled: false

--- a/apps/clusters/feathre-core/base-apps/apus/kustomization.yaml
+++ b/apps/clusters/feathre-core/base-apps/apus/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - bundle-bucket.yaml
 patches:
   - path: release-operator.yaml
+  - path: release-platform.yaml

--- a/apps/clusters/feathre-core/base-apps/apus/release-platform.yaml
+++ b/apps/clusters/feathre-core/base-apps/apus/release-platform.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: apus-platform
+  namespace: apus-system
+spec:
+  values:
+    auth:
+      # This cluster's OIDC provider is Microsoft Entra ID, the same tenant dependency-track
+      # already authenticates against. Both values are public discovery metadata, read from
+      # https://login.microsoftonline.com/<tenant>/v2.0/.well-known/openid-configuration, and
+      # neither is a secret. The chart's values.schema.json makes both mandatory: an API
+      # started without them would have no issuer to check and no keys to verify signatures
+      # with.
+      issuer: https://login.microsoftonline.com/1a14dfb5-0eac-41bf-94cb-195c2e387520/v2.0
+      jwksUri: https://login.microsoftonline.com/1a14dfb5-0eac-41bf-94cb-195c2e387520/discovery/v2.0/keys
+    otel:
+      # The cluster's OTLP collector: alloy-receiver in grafana, gRPC (4317), the same one
+      # apus-operator exports to.
+      endpoint: http://alloy-receiver.grafana.svc:4317
+      # Only the API emits telemetry - the UI is a static SPA behind nginx with no
+      # instrumentation - so the service is named for the API, next to "apus-operator" in
+      # Tempo and Loki rather than the chart's default "apus-platform-api".
+      serviceName: apus-api


### PR DESCRIPTION
## What

Adds the `apus-platform` HelmRelease (Apus REST API + Nuxt dashboard) to `apps/base/apus`, and the cluster-specific values to the `feathre-core` overlay. The `apus-platform` OCIRepository has been pinned to `=0.4.1` since #145 with nothing consuming it — this is the consumer.

- `apps/base/apus/release-platform.yaml` — HelmRelease in `apus-system`, `chartRef` → the `apus-platform` OCIRepository in `flux-system`, install/upgrade remediation retries 3, same conventions as `release-operator.yaml`.
- `apps/clusters/feathre-core/base-apps/apus/release-platform.yaml` — the cluster patch: Entra ID issuer/JWKS URI and the `alloy-receiver.grafana.svc:4317` OTLP endpoint.
- The comment at the top of `release-operator.yaml` claimed the platform was "deliberately not deployed yet" — that is no longer true, so it is updated rather than left standing.

## Auth values

The chart's `values.schema.json` makes `auth.issuer` and `auth.jwksUri` required (`minLength: 1`, `format: uri`) with no chart defaults — an install without them fails by design, because the API would otherwise start with no issuer to check and no keys to verify signatures with. Both values are public OIDC discovery metadata for the same Entra ID tenant `dependency-track` already authenticates against; neither is a secret.

## No Ingress

Both Services stay ClusterIP and no hostname is invented. `ui/nuxt.config.ts` defaults `oidcIssuer`/`oidcClientId` to `''` and `ui/Dockerfile` runs `pnpm generate` with no build arguments, copying only `.output/public` into nginx — the SPA's OIDC configuration is baked in at image build time and is empty in the published image, so the dashboard cannot complete a login. A public URL would publish a dead end.

## Known limitations (not addressed here, deployment-only PR)

- `PrincipalResolver.TENANT_CLAIM` is `"organization"`. Entra ID does not emit such a claim by default, so `TenantResolver.namespaceFor` throws `ForbiddenException` for real user tokens and every tenant-scoped endpoint answers 403 until a claims-mapping policy or optional claim supplies it.
- `Role.fromClaim` accepts exactly `platform-admin`, `tenant-owner`, `tenant-operator`, `tenant-viewer` (case-insensitive, trimmed, no separator tolerance). Entra App Roles can satisfy this only if their *values* are spelled exactly that way.
- The API has no `micronaut-management` on its classpath at 0.4.1, hence no `/health` endpoint and no probes on the API Deployment (the chart says so in a comment).

## Verification

- `helm template` of the 0.4.1 chart with exactly these values renders cleanly; the same template without them fails the schema gate on both `auth` fields.
- `./scripts/validate.sh` — all layers build, 0 invalid, 0 errors.
- `kubectl kustomize apps/clusters/feathre-core/base-apps/apus` confirms the patch merges onto the base release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)