### PR TITLE
fix(cert-manager): stop throttling the webhook into a restart loop

### DIFF
--- a/infrastructure/clusters/feather-core/base-controllers/cert-manager/release.yaml
+++ b/infrastructure/clusters/feather-core/base-controllers/cert-manager/release.yaml
@@ -49,13 +49,23 @@ spec:
         cpu: "20m"
         memory: "40Mi"
     webhook:
+      # The 10m CPU limit that used to sit here throttled the webhook so hard it
+      # could not answer its own /livez within the probe's 1s timeout, so the
+      # kubelet killed it: 406 restarts in 17 days, and an endpointless Service
+      # in between. Every admission dry-run then failed with "failed calling
+      # webhook webhook.cert-manager.io", which stalled the base-controllers
+      # layer and, through dependsOn, every layer behind it.
+      #
+      # No CPU limit on purpose: this sits on the admission path of every Flux
+      # apply, so throttling it stalls reconciliation cluster-wide. Same
+      # reasoning the rabbitmq broker patch used. The request reserves enough to
+      # schedule; memory keeps a limit because a leak should be bounded.
       resources:
         limits:
-          cpu: "10m"
-          memory: "25Mi"
+          memory: "128Mi"
         requests:
-          cpu: "5m"
-          memory: "15Mi"
+          cpu: "50m"
+          memory: "64Mi"
     cainjector:
       resources:
         limits:


### PR DESCRIPTION
Found while waiting for the Penpot layers to reconcile (#148).

## Symptom

`cert-manager-webhook` had **406 restarts in 17 days** and its Service was
frequently endpointless. Every Flux layer behind `base-controllers` sat at
`dependency ... is not ready`, with:

```
Certificate/cnpg-system/barman-cloud-client dry-run failed (InternalError):
Internal error occurred: failed calling webhook "webhook.cert-manager.io"
```

## Cause

```yaml
webhook:
  resources:
    limits:
      cpu: "10m"      # <- 1% of a core
```

against a liveness probe with `timeoutSeconds: 1`. Events confirm it:

```
Liveness probe failed: Get "http://10.244.1.212:6080/livez": context deadline exceeded
Container cert-manager-webhook failed liveness probe, will be restarted
```

Exit code 137, node shows no MemoryPressure — this is CPU throttling, not OOM.
The pod starts fine and issues its serving cert, then gets killed once the
probe times out.

## Fix

Drop the CPU limit and raise memory to a size the process fits in. The repo
already has precedent for leaving a latency-sensitive component unlimited
(the rabbitmq broker patch: "No CPU limit on purpose: never throttle a
broker"). This one sits on the admission path of *every* Flux apply, so
throttling it stalls reconciliation cluster-wide.

`./scripts/validate.sh` exits 0.

## Verify after merge

```bash
kubectl -n cert-manager get pod -l app.kubernetes.io/name=webhook
kubectl -n cert-manager get endpoints cert-manager-webhook
```

Restart count should stop climbing and the Service should keep its endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Qx7mKDeDhysBWsqtqM1yr