### PR TITLE
fix(penpot): raise the frontend memory limit out of an oom loop

### DIFF
--- a/apps/clusters/feathre-core/base-apps/penpot/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/penpot/release.yaml
@@ -110,15 +110,18 @@ spec:
         limits:
           memory: 2Gi
 
+    # nginx plus an entrypoint that rewrites the built JS bundle on every start.
+    # That rewrite spikes well past what steady-state nginx needs: a 256Mi limit
+    # OOMKilled the container four times before it ever served a request.
     frontend:
       podLabels:
         logs.onelitefeather.net/env: prod
       resources:
         requests:
           cpu: 25m
-          memory: 64Mi
+          memory: 128Mi
         limits:
-          memory: 256Mi
+          memory: 1Gi
 
     # Headless browser for PDF/PNG export — memory-hungry by nature.
     exporter:


### PR DESCRIPTION
Follow-up to #148, fixing a limit I set too low there.

## Symptom

```
penpot-frontend-956b9d99d-prhdz   0/1   CrashLoopBackOff   4 (80s ago)
lastReason=OOMKilled exit=137
```

The frontend never served a request.

## Cause

The Penpot frontend container is nginx plus an entrypoint that rewrites the
built JS bundle on every start. That rewrite peaks well above what
steady-state nginx needs, and #148 capped it at 256Mi.

## Measured

| Component | Usage | Limit | Verdict |
|---|---|---|---|
| backend | 887Mi | 2Gi | fine |
| exporter | 123Mi | 1500Mi | fine |
| mcp | 63Mi | 512Mi | fine |
| frontend | OOM at 256Mi | — | **raised to 1Gi** |

Only the frontend changes; the other three are sized correctly.

`./scripts/validate.sh` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Qx7mKDeDhysBWsqtqM1yr