### PR TITLE
fix(penpot): let entra users be provisioned on first login

### DIFF
--- a/apps/clusters/feathre-core/base-apps/penpot/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/penpot/release.yaml
@@ -25,10 +25,23 @@ spec:
       # enable-mcp is the ONLY switch for the MCP component — the chart's
       # penpot.mcpEnabled helper greps exactly this string, there is no
       # mcp.enabled value.
-      # enable-login-with-password stays on deliberately: it is the fallback if
-      # the Entra app registration ever breaks. Remove it once OIDC has proven
-      # itself in daily use.
-      flags: "disable-registration enable-login-with-password enable-login-with-oidc disable-email-verification enable-mcp"
+      # Registration has to be ON: Penpot provisions an OIDC user by *creating*
+      # a profile on first login, and disable-registration rejected exactly that
+      # with error=registration-disabled. There is no "only register via OIDC"
+      # flag -- registration is one global switch.
+      #
+      # So the gate is moved elsewhere: enable-login-with-password is deliberately
+      # absent, which leaves Entra as the only way in. That matters because this
+      # cluster has no SMTP relay, so disable-email-verification is required, and
+      # registration + password login + no verification together would let anyone
+      # claim an @onelitefeather.net address they do not own. Dropping password
+      # login costs nothing -- no password profile exists to fall back to.
+      #
+      # enable-mcp is the ONLY switch for the MCP component; the chart's
+      # penpot.mcpEnabled helper greps exactly this string.
+      flags: "enable-registration enable-login-with-oidc disable-email-verification enable-mcp"
+      # Second gate: even through Entra, only this domain may be provisioned.
+      registrationDomainWhitelist: "onelitefeather.net"
       telemetryEnabled: false
 
       # Microsoft Entra ID — the same tenant the rest of the cluster already


### PR DESCRIPTION
Second half of getting Entra login working (after the `email` optional claim
was added to the app registration, which fixed `hint=incomplete+user+info`).

## Symptom

```
https://penpot.onelitefeather.net/#/auth/login?error=registration-disabled
```

## Cause

Penpot provisions an OIDC user by **creating a profile** on first login. That
counts as a registration, so the `disable-registration` flag from #148
rejected it. Registration is a single global switch — Penpot has no
"register via OIDC only" flag.

Confirmed empty profile table at the time:

```
$ psql -d penpot -tAc "select count(*) from profile;"
0
```

## Fix

Rather than just loosening the switch, the gate moves:

| Flag | Before | After | Why |
|---|---|---|---|
| `disable-registration` | on | **`enable-registration`** | required for OIDC provisioning |
| `enable-login-with-password` | on | **dropped** | now the only remaining self-service path |
| `registrationDomainWhitelist` | unset | **`onelitefeather.net`** | second gate |

The password flag matters more than it looks. This cluster has no SMTP relay,
so `disable-email-verification` is required. Registration + password login +
no verification together would let anyone register an `@onelitefeather.net`
address they do not own. With password login gone, Entra is the only way in.

Dropping it costs nothing: the profile table is empty, so there was no
password account to fall back to.

`./scripts/validate.sh` exits 0. Rendered result:

```
PENPOT_FLAGS = enable-registration enable-login-with-oidc disable-email-verification enable-mcp
PENPOT_REGISTRATION_DOMAIN_WHITELIST = onelitefeather.net
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Qx7mKDeDhysBWsqtqM1yr