### PR TITLE
docs(penpot): correct the mcp security claim and record the login fixes

### DIFF
--- a/docs/penpot-mcp.md
+++ b/docs/penpot-mcp.md
@@ -46,16 +46,53 @@ claude mcp add --transport http penpot https://penpot-mcp.onelitefeather.net/mcp
 Für Clients ohne HTTP-Transport steht der Legacy-SSE-Endpunkt unter `/sse`
 bereit; `mcp-remote` überbrückt auf stdio.
 
-## ⚠️ Sicherheit
+## Das Plugin verbinden
 
-Der MCP-Endpunkt bringt **keine eigene Authentifizierung** mit. Wer die URL
-kennt, kann Design-Daten lesen **und verändern** — der Server unterstützt
-ausdrücklich auch Schreiboperationen.
+Ein AI-Client allein reicht nicht. Der MCP-Server führt keine Operationen
+selbst aus — er reicht sie an das **Penpot-MCP-Plugin** weiter, das im Browser
+in der geöffneten Design-Datei läuft. Beide Seiten werden über ein
+**User-Token** einander zugeordnet.
 
-Beide MCP-Hosts gehören deshalb hinter **Cloudflare Access**. Das wird in der
-Cloudflare-Konfiguration gesetzt, nicht in diesem Repo — es gibt hier keine
-Cloudflare-Access-Manifeste. Der Schritt ist verpflichtend, bevor produktiv
-mit dem Endpunkt gearbeitet wird.
+Solange kein Plugin verbunden ist, antworten nur die Metawerkzeuge
+(`high_level_overview`, `penpot_api_info`). Alles, was Designdaten anfasst,
+scheitert mit:
+
+```
+No plugin instance connected for user token.
+Please ensure the plugin is running and connected with the correct token.
+```
+
+Serverseitig sieht man dasselbe im Log:
+
+```
+Session initialized with id=… for userTokenFp=…
+Tool execution failed: execute_code; No plugin instance connected for user token
+```
+
+Ablauf: Penpot im Browser öffnen, das MCP-Plugin starten und dort dasselbe
+Token hinterlegen, das auch im AI-Client konfiguriert ist. Danach greifen
+`execute_code` und `export_shape`.
+
+## Sicherheit
+
+Die Zugriffsschichten, von außen nach innen:
+
+1. Eine MCP-Session lässt sich **ohne Token** eröffnen — ein anonymer
+   `initialize` bekommt eine gültige Antwort mit `serverInfo`, und die
+   Metawerkzeuge funktionieren.
+2. Für alles Weitere bindet der Server die Session an ein User-Token.
+3. Designzugriff gibt es erst, wenn unter **demselben** Token ein Plugin
+   verbunden ist.
+
+Das heißt: die URL allein genügt nicht, um Designs zu lesen oder zu
+verändern. Wer aber ein Token erbeutet, zu dem gerade ein Plugin verbunden
+ist, kann darüber schreiben — der Server unterstützt ausdrücklich
+Schreiboperationen.
+
+Beide MCP-Hosts gehören deshalb zusätzlich hinter **Cloudflare Access**, als
+Schranke vor dem Token statt als einziger Schutz. Das wird in der
+Cloudflare-Konfiguration gesetzt, nicht in diesem Repo — Access-Manifeste gibt
+es hier nicht.
 
 ## Betriebshinweise
 

--- a/docs/penpot-oidc.md
+++ b/docs/penpot-oidc.md
@@ -8,6 +8,28 @@ Tenant   1a14dfb5-0eac-41bf-94cb-195c2e387520
 Issuer   https://login.microsoftonline.com/1a14dfb5-0eac-41bf-94cb-195c2e387520/v2.0
 ```
 
+## Zwei Stolpersteine, die den Login zunächst verhindert haben
+
+**`hint=incomplete+user+info`** — Entra liefert den `email`-Claim **nur**, wenn
+die App-Registrierung ihn als *optional claim* führt. Der `email`-Scope allein
+genügt nicht, auch wenn das `mail`-Attribut des Nutzers gefüllt ist. Penpots
+eigener Hinweis „please set correct scopes" führt hier in die Irre. Der Claim
+ist auf ID- und Access-Token gesetzt:
+
+```bash
+az rest --method PATCH \
+  --url "https://graph.microsoft.com/v1.0/applications/c0189833-2572-40b2-b17a-214f107fad54" \
+  --headers "Content-Type=application/json" \
+  --body '{"optionalClaims":{"idToken":[{"name":"email","source":null,"essential":false,"additionalProperties":[]}],"accessToken":[{"name":"email","source":null,"essential":false,"additionalProperties":[]}],"saml2Token":[]}}'
+```
+
+**`error=registration-disabled`** — Penpot legt beim ersten OIDC-Login ein
+Profil an, und das zählt als Registrierung. Mit `disable-registration` wird
+genau das abgelehnt. Registrierung ist ein einziger globaler Schalter; ein
+„nur über OIDC registrieren" gibt es nicht. Deshalb ist `enable-registration`
+gesetzt, dafür aber `enable-login-with-password` entfernt und
+`registrationDomainWhitelist` auf `onelitefeather.net` gesetzt — siehe unten.
+
 ## Chart-Fallstricke
 
 Zwei Defaults des Penpot-Charts brechen den Login, wenn man sie stehen lässt.
@@ -21,9 +43,16 @@ Beide sind in `release.yaml` überschrieben:
 Zusätzlich braucht es `enable-login-with-oidc` in `config.flags` — die
 `providers.oidc.enabled: true` allein reicht nicht.
 
-`enable-login-with-password` bleibt vorerst zusätzlich aktiv, damit ein
-kaputter Entra-Zustand niemanden aussperrt. Nimm es heraus, sobald OIDC im
-Alltag trägt.
+`enable-login-with-password` ist **entfernt** — Entra ist der einzige Weg
+hinein. Das ist kein Schönheitsentscheid: der Cluster hat kein SMTP-Relay,
+deshalb ist `disable-email-verification` zwingend, und Registrierung plus
+Passwort-Login plus fehlende Verifikation zusammen würden es jedem erlauben,
+sich eine fremde `@onelitefeather.net`-Adresse zuzulegen.
+`registrationDomainWhitelist: onelitefeather.net` ist die zweite Schranke.
+
+Falls Entra je ausfällt, sperrt das alle aus. Der Weg zurück ist ein Commit,
+der `enable-login-with-password` wieder in `config.flags` aufnimmt — dann aber
+bitte zusammen mit einer Lösung für die Mailverifikation.
 
 ## Die Registrierung (bereits angelegt)
 


### PR DESCRIPTION
Documentation catch-up after getting Entra login and the MCP endpoint working.

## Corrects an overstated security claim

`docs/penpot-mcp.md` said the MCP endpoint has *no authentication* and that
anyone with the URL could read and modify designs. That was wrong. Observed
behaviour:

```
Session initialized with id=48a393a1-… for userTokenFp=VEFqqO6a
Tool execution #1 complete: high_level_overview
Tool execution #2 failed: execute_code; No plugin instance connected for user token
```

The real layering:

1. An anonymous `initialize` **does** get a valid session, and the metadata
   tools answer.
2. Beyond that the server binds the session to a user token.
3. Design access needs a plugin connected under that **same** token.

So the URL alone does not grant design access. Cloudflare Access is still
worth doing — as a layer in front of the token, not as the only protection.

## Documents the plugin pairing

The MCP server executes nothing itself; it forwards to the Penpot MCP plugin
running in the browser. Without it, `execute_code` and `export_shape` fail.
That step was missing from the docs.

## Records the two login blockers

- `hint=incomplete+user+info` — Entra emits the `email` claim only when the
  app registration declares it as an *optional claim*. The `email` scope is
  not enough, even with the user's `mail` attribute populated. Includes the
  `az rest` command used.
- `error=registration-disabled` — Penpot provisions an OIDC user by creating
  a profile, which counts as a registration.

Also fixes the now-stale note in `docs/penpot-oidc.md` claiming password login
stays enabled as a fallback; it was removed in #152, and the doc explains why
plus how to get back if Entra fails.

`./scripts/validate.sh` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Qx7mKDeDhysBWsqtqM1yr