### PR TITLE
feat(apus): upgrade to 0.7.0 and publish the dashboards behind Entra SSO

### DIFF
--- a/apps/base/apus/release-platform.yaml
+++ b/apps/base/apus/release-platform.yaml
@@ -22,11 +22,14 @@ spec:
     remediation:
       retries: 3
   values:
-    # No Ingress on purpose, both Services stay ClusterIP. The dashboard image cannot complete
-    # a login: ui/nuxt.config.ts leaves oidcIssuer/oidcClientId empty and ui/Dockerfile runs
-    # `pnpm generate` with no build arguments, so the SPA's OIDC configuration is baked in at
-    # image build time and is empty in the published image. A public hostname would only
-    # publish something that cannot be logged into. Reach the API with `kubectl port-forward`
-    # until the UI image is built with its OIDC configuration.
+    # No Ingress in the base: a hostname is a per-cluster decision and there is no sensible
+    # default for one. Overlays that want the applications reachable set ingress.enabled,
+    # className and host themselves.
+    #
+    # The reason this used to say is gone: until 0.5.0 the dashboard image baked its OIDC
+    # configuration in at build time via `pnpm generate`, so a published image could never
+    # complete a login and a hostname would only have exposed something unusable. Since 0.5.0
+    # the images run Nitro and read NUXT_PUBLIC_* at runtime, which is what makes exposing
+    # them worth doing.
     ingress:
       enabled: false

--- a/apps/clusters/feathre-core/base-apps/apus/release-platform.yaml
+++ b/apps/clusters/feathre-core/base-apps/apus/release-platform.yaml
@@ -14,11 +14,54 @@ spec:
       # with.
       issuer: https://login.microsoftonline.com/1a14dfb5-0eac-41bf-94cb-195c2e387520/v2.0
       jwksUri: https://login.microsoftonline.com/1a14dfb5-0eac-41bf-94cb-195c2e387520/discovery/v2.0/keys
+
+    # One hostname serves all three: the API under /api, the management console under
+    # /console, and the tenant application everywhere else. Path order is load bearing and
+    # the chart emits it correctly -- the catch-all has to come last or it swallows the other
+    # two.
+    #
+    # Cloudflare terminates TLS at the edge, as it does for every other public service here,
+    # so tls stays disabled and no cert-manager annotation is wanted; the tunnel controller
+    # reaches the Services over plain HTTP inside the cluster.
+    ingress:
+      enabled: true
+      className: cloudflare-tunnel
+      host: apus.onelitefeather.dev
+      annotations:
+        cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol: http
+      tls:
+        enabled: false
+
+    # Both SPAs read their configuration at runtime from these variables (since 0.5.0 the
+    # images run Nitro and no longer bake anything in at build time). None of them is a
+    # secret: this is a public OIDC client and every value ends up in the served HTML by
+    # design.
+    #
+    # The two applications share one Entra app registration and differ only in base path, so
+    # every value here is identical between them. Keep them that way -- a client id that
+    # differs between the two would produce two sessions for one person.
+    ui: &uiRuntime
+      env:
+        # Same origin as the SPAs themselves; the ingress routes /api to the API Service.
+        NUXT_PUBLIC_API_BASE_URL: https://apus.onelitefeather.dev/api
+        NUXT_PUBLIC_OIDC_ISSUER: https://login.microsoftonline.com/1a14dfb5-0eac-41bf-94cb-195c2e387520/v2.0
+        # App registration "Apus" in the OneLiteFeather tenant.
+        NUXT_PUBLIC_OIDC_CLIENT_ID: 59a9ea74-a98c-4b6b-b60b-3a309128a1cb
+        # Entra-specific and not optional. Asking for only `openid profile email` returns an
+        # access token addressed to Microsoft Graph -- wrong audience, v1 issuer, and none of
+        # Apus's app roles -- so the API rejects every call while the UI has nothing to show
+        # for it. Naming the API's own scope is what makes the token ours.
+        NUXT_PUBLIC_OIDC_SCOPE: >-
+          api://59a9ea74-a98c-4b6b-b60b-3a309128a1cb/access_as_user openid profile email
+
+    # The management console: same runtime configuration, different image and base path.
+    console: *uiRuntime
+
     otel:
       # The cluster's OTLP collector: alloy-receiver in grafana, gRPC (4317), the same one
       # apus-operator exports to.
       endpoint: http://alloy-receiver.grafana.svc:4317
-      # Only the API emits telemetry - the UI is a static SPA behind nginx with no
+      # Only the API emits telemetry - the two SPAs are served by Nitro with no
       # instrumentation - so the service is named for the API, next to "apus-operator" in
       # Tempo and Loki rather than the chart's default "apus-platform-api".
       serviceName: apus-api

--- a/infrastructure/clusters/feather-core/base-sources/apus.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/apus.yaml
@@ -1,8 +1,13 @@
 ---
 # Apus ships its charts as OCI artifacts from our own Harbor, versioned together with
-# the images they deploy: apus-operator 0.4.1 references apus/operator:0.4.1, because the
+# the images they deploy: apus-operator 0.7.0 references apus/operator:0.7.0, because the
 # chart leaves image.tag empty and falls back to .Chart.AppVersion. Pin both repositories
 # to the same version for that reason -- mixing them defeats the coupling.
+#
+# 0.7.0 brings two things the platform overlay depends on: the dashboard split into a
+# tenant application and a separate management console (apus/console, served under
+# /console), and NUXT_PUBLIC_OIDC_SCOPE, without which neither can obtain a token Entra
+# will let through to the API.
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
@@ -15,7 +20,7 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-operator
   ref:
-    semver: "=0.4.1"
+    semver: "=0.7.0"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -29,4 +34,4 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-platform
   ref:
-    semver: "=0.4.1"
+    semver: "=0.7.0"


### PR DESCRIPTION
Upgrades Apus from 0.4.1 to 0.7.0 and makes both dashboards reachable and loggable-into for
the first time.

## What changes on the cluster

| | Before | After |
| --- | --- | --- |
| Chart | 0.4.1 | 0.7.0 |
| Workloads | `api`, `ui` | `api`, `ui`, **`console`** (new, 1 replica) |
| Exposure | none, ClusterIP only | `apus.onelitefeather.dev` via the Cloudflare tunnel |
| UI config | none — the SPA could not log in | full OIDC config at runtime |

Paths on the one host, in the order the chart emits them (a controller evaluates a host's
paths as listed, so the catch-all must come last): `/api` → API, `/console` → console,
`/` → tenant application.

TLS stays off and no cert-manager annotation is set: Cloudflare terminates at the edge, as
for every other public service in this cluster, and the tunnel controller reaches the
Services over plain HTTP.

## Entra SSO

A new app registration **Apus** (`59a9ea74-a98c-4b6b-b60b-3a309128a1cb`) in the OneLiteFeather
tenant, shared by both applications — they differ only in base path, so a differing client id
would produce two sessions for one person.

- SPA redirect URIs for both apps, plus `localhost:3000` for development
- App roles `platform-admin`, `tenant-owner`, `tenant-operator`, `tenant-viewer` — Entra emits
  these under the `roles` claim, which is what `PrincipalResolver` reads
- `api://<client-id>/access_as_user`, pre-authorized for the SPA itself
- `api.requestedAccessTokenVersion: 2`

Those last two are not optional and both fail invisibly. Asking Entra for only
`openid profile email` returns an access token addressed to Microsoft Graph — wrong audience,
none of Apus's roles — and a v1 token carries the `sts.windows.net` issuer, which does not match
the v2.0 issuer the API validates against. In both cases the API rejects every request, the UI
has no way to explain it, and nothing in Entra's own logs looks wrong. Hence
`NUXT_PUBLIC_OIDC_SCOPE`, which Apus 0.7.0 adds for exactly this.

## Known gap: the tenant application still has no tenant

`PrincipalResolver.TENANT_CLAIM` expects an `organization` claim naming the caller's tenant, and
Entra does not emit one without a claims-mapping policy or a directory extension attribute.

The **management console works** — `platform-admin` is read from `roles` alone. The **tenant
application will show "no tenant to show"** for every Entra user until that claim exists. Worth
doing next; it needs a decision about where a user's tenant is stored in the directory.

## Verification before merge

- `kubectl kustomize` renders the overlay; the YAML anchor gives `ui` and `console` identical env
- `helm template` against the real 0.7.0 chart with the rendered values: ingress class,
  annotation, host and path order correct; the scope string survives YAML folding intact into
  both containers; the console's probes hit `/console/` rather than `/`, which is where its shell
  actually is

Flux reconciles on merge (`interval: 1m`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Bff5mpWkUnZA77jys8DiR
