### PR TITLE
fix(sentry): pin clickhouse to the version sentry 26.7 actually needs

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sentry/clickhouse.yaml
+++ b/apps/clusters/feathre-core/base-apps/sentry/clickhouse.yaml
@@ -15,11 +15,29 @@ spec:
                 value: feather-standard
   values:
     clickhouse:
+      # The chart's own appVersion is 23.8, which is far behind what Sentry
+      # 26.7 needs: upstream self-hosted builds its ClickHouse from
+      # altinity/clickhouse-server:25.3.6.10034.altinitystable. On 23.8 the
+      # events_analytics_platform migrations 0049/0050 died mid-run and left
+      # themselves marked in_progress, which blocks every later migration
+      # attempt. Pin the image the upstream actually uses.
+      image: altinity/clickhouse-server
+      imageVersion: "25.3.6.10034.altinitystable"
+
       # Upstream self-hosted Sentry runs a single ClickHouse. The chart default
       # is 3, but replication here needs Zookeeper, which this cluster does not
       # have -- three nodes without it would be three unsynchronised copies,
       # not a cluster.
       replicas: 1
+      configmap:
+        remote_servers:
+          replica:
+            backup:
+              # Gates a second StatefulSet (clickhouse-replica) plus its
+              # services. Without Zookeeper that replica can never stay in
+              # sync, so it is pure overhead -- and `replicas: 1` alone does
+              # not remove it.
+              enabled: false
       persistentVolumeClaim:
         enabled: true
         dataPersistentVolume:


### PR DESCRIPTION
Fixes the failed install from #156 and corrects a wrong call in the design.

## Symptom

`sentry-snuba-migrate` failed seven times, so the Sentry HelmRelease never went Ready:

```
MigrationInProgress: events_analytics_platform: 0050_add_attributes_array_column
```

Migrations 0049 and 0050 are wedged at `in_progress`: a first run died mid-migration, and every later run refuses to touch a group that still has one open. ClickHouse itself is healthy — zero restarts, no OOM.

## Cause

The `clickhouse` chart from sentry-kubernetes carries **appVersion 23.8**, while upstream self-hosted Sentry builds from `altinity/clickhouse-server:25.3.6.10034.altinitystable`.

The design justified that chart as "the version Snuba is tested against". True once; not for Sentry 26.7, whose `events_analytics_platform` migrations need the newer server. My mistake.

## Fix

- Pin `image`/`imageVersion` to the Altinity build upstream uses.
- Disable the replica StatefulSet. It is gated on `remote_servers.replica.backup.enabled`, **not** on `replicas`, so `replicas: 1` still left `clickhouse-replica-0` running — with no Zookeeper it can never sync.

Rendered: one StatefulSet, correct image, `replicas: 1`, no replica services.

## Manual step after merge

ClickHouse holds no real data yet, so the wedged state is cleared by starting fresh:

```bash
kubectl -n sentry delete pvc -l app.kubernetes.io/name=clickhouse
flux reconcile helmrelease clickhouse -n sentry
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)