### PR TITLE
fix(penpot): actually disable password login

### DIFF
--- a/apps/clusters/feathre-core/base-apps/penpot/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/penpot/release.yaml
@@ -30,16 +30,21 @@ spec:
       # with error=registration-disabled. There is no "only register via OIDC"
       # flag -- registration is one global switch.
       #
-      # So the gate is moved elsewhere: enable-login-with-password is deliberately
-      # absent, which leaves Entra as the only way in. That matters because this
-      # cluster has no SMTP relay, so disable-email-verification is required, and
-      # registration + password login + no verification together would let anyone
-      # claim an @onelitefeather.net address they do not own. Dropping password
-      # login costs nothing -- no password profile exists to fall back to.
+      # So the gate is moved elsewhere: password login is switched off, leaving
+      # Entra as the only way in. That matters because this cluster has no SMTP
+      # relay, so disable-email-verification is required, and registration +
+      # password login + no verification together would let anyone claim an
+      # @onelitefeather.net address they do not own.
+      #
+      # It has to be spelled `disable-login-with-password`, not merely omitted.
+      # The chart renders PENPOT_FLAGS as "$PENPOT_FLAGS <ours>", so these are
+      # ADDITIVE to the image's built-in defaults -- and login-with-password is
+      # one of those defaults. Leaving it out kept it enabled; the running pod
+      # reported `login-with-password` in its startup flags the whole time.
       #
       # enable-mcp is the ONLY switch for the MCP component; the chart's
       # penpot.mcpEnabled helper greps exactly this string.
-      flags: "enable-registration enable-login-with-oidc disable-email-verification enable-mcp"
+      flags: "enable-registration disable-login-with-password enable-login-with-oidc disable-email-verification enable-mcp"
       # Second gate: even through Entra, only this domain may be provisioned.
       registrationDomainWhitelist: "onelitefeather.net"
       telemetryEnabled: false

--- a/docs/penpot-oidc.md
+++ b/docs/penpot-oidc.md
@@ -43,8 +43,17 @@ Beide sind in `release.yaml` überschrieben:
 Zusätzlich braucht es `enable-login-with-oidc` in `config.flags` — die
 `providers.oidc.enabled: true` allein reicht nicht.
 
-`enable-login-with-password` ist **entfernt** — Entra ist der einzige Weg
-hinein. Das ist kein Schönheitsentscheid: der Cluster hat kein SMTP-Relay,
+`disable-login-with-password` ist gesetzt — Entra ist der einzige Weg hinein.
+
+⚠️ Es muss **explizit** `disable-login-with-password` heißen. Das Chart rendert
+`PENPOT_FLAGS` als `"$PENPOT_FLAGS <unsere>"`, die Flags sind also **additiv zu
+den eingebauten Defaults** des Images — und `login-with-password` ist einer
+dieser Defaults. Es einfach wegzulassen lässt den Passwort-Login aktiv. Prüfen
+lässt sich der tatsächliche Zustand nur am Startup-Log:
+
+```bash
+kubectl -n penpot logs deploy/penpot-backend | grep "welcome to penpot"
+``` Das ist kein Schönheitsentscheid: der Cluster hat kein SMTP-Relay,
 deshalb ist `disable-email-verification` zwingend, und Registrierung plus
 Passwort-Login plus fehlende Verifikation zusammen würden es jedem erlauben,
 sich eine fremde `@onelitefeather.net`-Adresse zuzulegen.


### PR DESCRIPTION
#152 claimed to close a hole and did not.

## What went wrong

It removed `enable-login-with-password` from `config.flags`, on the assumption that omitting a flag disables it. It does not. The chart renders:

```
PENPOT_FLAGS = $PENPOT_FLAGS enable-registration enable-login-with-oidc disable-email-verification enable-mcp
```

Our flags are **additive to the image's built-in defaults**, and `login-with-password` is one of those defaults. The running pod has been reporting it the whole time:

```
flags="...,login-with-password,...,login-with-oidc,...,registration,..."
```

So `registration` + password login + `disable-email-verification` were all active together — precisely the combination #152 set out to prevent. On an instance with no SMTP relay, that lets anyone register an `@onelitefeather.net` address they do not own.

## Fix

Spell it out: `disable-login-with-password`.

Also records in `docs/penpot-oidc.md` that the values file is not a trustworthy source of truth for effective flags — only the startup log is:

```bash
kubectl -n penpot logs deploy/penpot-backend | grep "welcome to penpot"
```

Note: local `validate.sh` could not complete (DNS failure fetching kubeconform schemas), so CI is the authority here. The change itself is a single string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)