### PR TITLE
fix(sentry): let clickhouse 25.3 start under the chart's read-only users dir

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sentry/clickhouse.yaml
+++ b/apps/clusters/feathre-core/base-apps/sentry/clickhouse.yaml
@@ -13,6 +13,29 @@ spec:
               - op: add
                 path: /spec/template/spec/priorityClassName
                 value: feather-standard
+          # ClickHouse images from 24.x on run a user-setup step in their
+          # entrypoint: with neither CLICKHOUSE_USER nor CLICKHOUSE_PASSWORD
+          # set, it writes users.d/default-user.xml to disable network access
+          # for `default`. This chart mounts users.d from a ConfigMap, so that
+          # path is read-only and the container dies before the server starts:
+          #
+          #   /entrypoint.sh: line 156:
+          #     /etc/clickhouse-server/users.d/default-user.xml: Read-only file system
+          #
+          # Flux then saw StatefulSet status 'Failed' and rolled back to 23.8
+          # five times over. The chart has no env: block at all -- it only
+          # exports SHARD in the container command -- so this cannot come from
+          # values and has to be patched in here. The chart's own users
+          # ConfigMap already defines `default`, so skipping the step is right.
+          - target:
+              kind: StatefulSet
+              name: clickhouse
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/env
+                value:
+                  - name: CLICKHOUSE_SKIP_USER_SETUP
+                    value: "1"
   values:
     clickhouse:
       # The chart's own appVersion is 23.8, which is far behind what Sentry


### PR DESCRIPTION
The image pin from #158 was necessary but not sufficient. Flux rolled back to 23.8 five times:

```
Stalled=True: Failed to upgrade after 5 attempt(s)
Released=False: ... [StatefulSet/sentry/clickhouse status: 'Failed']
```

**Not the image.** A throwaway pod running `altinity/clickhouse-server:25.3.6.10034.altinitystable` pulls and exits 0.

**The entrypoint.** ClickHouse images from 24.x on run a user-setup step. With neither `CLICKHOUSE_USER` nor `CLICKHOUSE_PASSWORD` set it writes `users.d/default-user.xml`, but this chart mounts `users.d` from a ConfigMap, so the path is read-only and the container dies before the server starts:

```
/entrypoint.sh: line 156: /etc/clickhouse-server/users.d/default-user.xml: Read-only file system
```

Verified by running the image with the chart's three ConfigMaps mounted (fails exactly there), then again with `CLICKHOUSE_SKIP_USER_SETUP=1` (starts cleanly, merges config). 23.8 had no such step, which is why it only surfaced after the bump.

**Why a postRenderer.** The chart has no `env:` block at all — it only exports `SHARD` in the container command — so this cannot come from values. Skipping is correct rather than a workaround: the chart's users ConfigMap already defines `default`.

Also resets the HelmRelease out of its `Stalled` state, since the spec changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)