### PR TITLE
fix(penpot): cap the database pool that was starving the shared cluster

### DIFF
--- a/apps/clusters/feathre-core/base-apps/penpot/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/penpot/release.yaml
@@ -49,6 +49,19 @@ spec:
       registrationDomainWhitelist: "onelitefeather.net"
       telemetryEnabled: false
 
+      # Penpot's default connection pool is 60, and it holds all of them open
+      # even while completely idle -- `pg_stat_activity` showed 60/60 in state
+      # `idle`. On a shared cluster with max_connections=200 that is a sixth of
+      # everything for one dormant app, and it helped push the primary to 207
+      # connections, at which point Postgres started refusing new ones with
+      # "remaining connection slots are reserved" and Sentry's login broke.
+      #
+      # 10 is ample for this team's usage; raise it if the backend ever reports
+      # pool exhaustion.
+      extraEnvs:
+        - name: PENPOT_DATABASE_POOL_MAX
+          value: "10"
+
       # Microsoft Entra ID — the same tenant the rest of the cluster already
       # authenticates against (dependency-track, apus, grafana). Penpot
       # auto-discovers the endpoints from baseURI, so authURI/tokenURI/userURI


### PR DESCRIPTION
Penpot's default connection pool is **60**, and it holds every one open while completely idle:

```
datname | state | count
penpot  | idle  | 60
sentry  | idle  | 51
dependency-track | idle | 22
harbor  | idle  | 13
```

146 idle connections against `max_connections = 200` pushed the primary to **207**, and Postgres started refusing new connections:

```
FATAL: remaining connection slots are reserved for
       non-replication superuser connections
```

That is what broke the Sentry admin login — the saturation is cluster-wide, not a Sentry problem.

## Fix

`PENPOT_DATABASE_POOL_MAX=10` via `config.extraEnvs`. A dormant app has no business holding a sixth of the shared cluster's connections; 10 is ample for this team, and the backend will say so if it ever runs short.

Frees roughly 50 slots, which brings the primary back under the limit on its own.

## What this does not fix

`cluster.yaml` already names the real remedy — *"the proper fix is pooler adoption + trimming idle pools"*. This is the trimming half.

Sentry's 51 connections are spread over ~56 pods at roughly one each, so a smaller pool will not help there; it needs the PgBouncer pooler (`feather-core-cluster-pg-pooler-rw`, which already exists). I routed both Penpot and Sentry straight at `-rw` on the grounds that PgBouncer rejects some startup parameters — that lesson came from n8n and I over-generalised it. Pooler adoption deserves its own PR and its own compatibility check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)