### PR TITLE
fix(penpot): use the pool env vars penpot actually reads

### DIFF
--- a/apps/clusters/feathre-core/base-apps/penpot/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/penpot/release.yaml
@@ -58,8 +58,21 @@ spec:
       #
       # 10 is ample for this team's usage; raise it if the backend ever reports
       # pool exhaustion.
+      #
+      # The names matter and are not documented upstream: an earlier attempt
+      # with PENPOT_DATABASE_POOL_MAX was silently ignored. The backend prints
+      # the values it actually applied, which is the only reliable check:
+      #
+      #   kubectl -n penpot logs deploy/penpot-backend \
+      #     | grep "initialize connection pool"
+      #   ... min-size=60, max-size=60      <- before, the default
+      #
+      # min-size matters as much as max-size: Penpot opens the minimum eagerly
+      # and holds it, which is why an idle instance sat at exactly 60.
       extraEnvs:
-        - name: PENPOT_DATABASE_POOL_MAX
+        - name: PENPOT_DATABASE_MIN_POOL_SIZE
+          value: "5"
+        - name: PENPOT_DATABASE_MAX_POOL_SIZE
           value: "10"
 
       # Microsoft Entra ID — the same tenant the rest of the cluster already


### PR DESCRIPTION
Follow-up to #166, which did not work.

That PR set `PENPOT_DATABASE_POOL_MAX`. Penpot ignores it. The backend prints the values it applied, and after the rollout it still reported:

```
hint="initialize connection pool" ... min-size=60, max-size=60
```

So the pool stayed at the default and the primary stayed at 200/200.

## Correct names

Penpot maps `PENPOT_<NAME>` to config key `<name>`, and the log labels the values `min-size`/`max-size` — giving `database-min-pool-size` and `database-max-pool-size`.

**Both** are set. `min-size` matters as much as `max`: Penpot opens the minimum eagerly and holds it, which is exactly why an idle instance sat at precisely 60.

## Verification

The values file says nothing about what took effect — only the log does:

```bash
kubectl -n penpot logs deploy/penpot-backend | grep "initialize connection pool"
```

Expect `min-size=5, max-size=10` after this rolls out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)