### PR TITLE
feat(sentry): make saml with entra id possible at all

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sentry/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/sentry/release.yaml
@@ -43,6 +43,49 @@ spec:
       adminEmail: "themeinerlp@onelitefeather.net"
       public: false
 
+    config:
+      # Makes SAML with Entra ID possible at all.
+      #
+      # Sentry derives its SAML SP entityId from a Django URL, so it always
+      # ends in a slash: https://sentry.onelitefeather.net/saml/metadata/sentry/
+      # Entra refuses to store any identifierUri ending in a slash --
+      # "IdentifierUrisEndsWithSlash", on both the v1.0 and beta Graph APIs --
+      # and python3-saml compares the assertion Audience with `not in`, i.e.
+      # exact string equality with no normalisation. Without this the two can
+      # never agree and every login fails the audience check.
+      #
+      # Dropping the trailing slash lines both sides up: Sentry then sends and
+      # expects the same value Entra is able to store.
+      #
+      # Patched lazily on the first request rather than at import time: this
+      # file is the Django settings module, and importing sentry.auth there
+      # would touch the app registry before it is ready. The try/except is
+      # deliberate -- a broken patch must never stop Sentry from booting; it
+      # would only mean SSO stays unconfigurable.
+      sentryConfPy: |
+        from django.core.signals import request_started
+
+        def _strip_saml_sp_entity_id_slash(*args, **kwargs):
+            request_started.disconnect(_strip_saml_sp_entity_id_slash)
+            try:
+                from sentry.auth.providers.saml2 import provider as _saml2
+
+                _orig_build_saml_config = _saml2.build_saml_config
+
+                def _build_saml_config(provider_config, org):
+                    config = _orig_build_saml_config(provider_config, org)
+                    sp = config.get("sp") or {}
+                    entity_id = sp.get("entityId")
+                    if isinstance(entity_id, str) and entity_id.endswith("/"):
+                        sp["entityId"] = entity_id[:-1]
+                    return config
+
+                _saml2.build_saml_config = _build_saml_config
+            except Exception:
+                pass
+
+        request_started.connect(_strip_saml_sp_entity_id_slash, weak=False)
+
     user:
       create: true
       email: "themeinerlp@onelitefeather.net"


### PR DESCRIPTION
Sentry and Entra cannot agree on the SAML entity ID, which blocks SSO outright. This unblocks it.

## The conflict

Sentry derives its SP entityId from a Django URL, so it always ends in a slash:

```
https://sentry.onelitefeather.net/saml/metadata/sentry/
```

Entra refuses to store **any** identifierUri ending in a slash:

```
IdentifierUrisEndsWithSlash: ValueCannotEndWithSlash
```

Confirmed on the v1.0 **and** beta Graph APIs. The `servicePrincipalNames` route fails too — it must mirror the application object.

And python3-saml compares the assertion Audience with exact string equality, under `"strict": True`:

```python
if valid_audiences and sp_entity_id not in valid_audiences:
    raise '%s is not a valid audience for this Response'
```

No normalisation. So the two values can never match, and every login would fail the audience check.

## The fix

Strip the trailing slash from Sentry's SP entityId, so it sends and expects exactly what Entra is able to store.

All callers of `build_saml_config` live in the same module and use the global, so patching the module attribute covers the metadata endpoint, the AuthnRequest and the ACS validation alike.

## Safety

The patch runs on the **first request**, not at import: `sentry.conf.py` is the Django settings module, and importing `sentry.auth` there would touch the app registry too early.

The `try/except` is deliberate — a broken patch must never stop Sentry booting; at worst it leaves SSO unconfigurable.

## Verify after rollout

```bash
curl -s https://sentry.onelitefeather.net/saml/metadata/sentry/ | grep -o 'entityID="[^"]*"'
```

Expect the value **without** a trailing slash — matching the Entra app `Sentry` (`6fc03dbf-9406-4d93-92c0-e7143908a1bd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)