### PR TITLE
feat(apus): upgrade to 0.8.0 for per-tenant options

### DIFF
--- a/infrastructure/clusters/feather-core/base-sources/apus.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/apus.yaml
@@ -1,6 +1,6 @@
 ---
 # Apus ships its charts as OCI artifacts from our own Harbor, versioned together with
-# the images they deploy: apus-operator 0.7.2 references apus/operator:0.7.2, because the
+# the images they deploy: apus-operator 0.8.0 references apus/operator:0.8.0, because the
 # chart leaves image.tag empty and falls back to .Chart.AppVersion. Pin both repositories
 # to the same version for that reason -- mixing them defeats the coupling.
 #
@@ -8,6 +8,12 @@
 # tenant application and a separate management console (apus/console, served under
 # /console), and NUXT_PUBLIC_OIDC_SCOPE, without which neither can obtain a token Entra
 # will let through to the API.
+#
+# 0.8.0 adds per-tenant options with override and lock: Tenant.spec.policy, which the operator
+# chart ships as a CRD change. The api module enforces four keys (source types, poll floor,
+# keepVersions cap, forced renders) and reports every other entry as stored-but-not-enforced.
+# Upgrading the operator chart before the platform chart is not required -- an older api simply
+# ignores the field -- but keeping the pins equal keeps the coupling the comment above describes.
 #
 # 0.7.2 is what makes any of it usable, and is the floor for this cluster. The API named
 # the JWKS endpoint `jwks-uri` in application.yml, a property Micronaut does not bind
@@ -27,7 +33,7 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-operator
   ref:
-    semver: "=0.7.2"
+    semver: "=0.8.0"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -41,4 +47,4 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-platform
   ref:
-    semver: "=0.7.2"
+    semver: "=0.8.0"


### PR DESCRIPTION
feat(apus): upgrade to 0.8.0 for per-tenant options

0.8.0 adds Tenant.spec.policy -- options a platform admin sets on a tenant from
the console, and locks the ones the tenant must not deviate from. The operator
chart ships the CRD change; the api module enforces four keys (allowed source
types, poll floor, keepVersions cap, forced renders) and reports every other
entry as stored-but-not-enforced rather than implying a lock that does not bite.

A tenant with no policy behaves exactly as it does today, which is asserted
rather than assumed.
