### PR TITLE
feat(sentry): add the discord integration

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sentry/kustomization.yaml
+++ b/apps/clusters/feathre-core/base-apps/sentry/kustomization.yaml
@@ -43,3 +43,11 @@ secretGenerator:
       - sentry-github.sops.env
     files:
       - private-key=sentry-github.sops.key
+  # Discord application for the Sentry integration -- a separate app from the
+  # existing discordbot, since both would otherwise fight over the same
+  # interactions endpoint. Same trap as sentry-github: with
+  # discord.existingSecret set, the chart references all four keys
+  # unconditionally.
+  - name: sentry-discord
+    envs:
+      - sentry-discord.sops.env

--- a/apps/clusters/feathre-core/base-apps/sentry/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/sentry/release.yaml
@@ -110,6 +110,19 @@ spec:
       existingSecretAppIdKey: app-id
       existingSecretAppNameKey: app-name
 
+    # Discord application dedicated to Sentry. Deliberately not the existing
+    # discordbot: Discord allows one interactions endpoint per application, so
+    # sharing one would make the two integrations fight over it.
+    #
+    # Everything including the application id lives in the secret -- unlike
+    # GitHub, where appId is public anyway, Discord's id is paired with a bot
+    # token whose leak would let someone act as the bot.
+    #
+    # Same trap as github above: existingSecret makes the chart reference
+    # application-id, public-key, client-secret and bot-token unconditionally.
+    discord:
+      existingSecret: sentry-discord
+
     sentry:
       singleOrganization: true
       existingSecret: sentry-secret

--- a/apps/clusters/feathre-core/base-apps/sentry/sentry-discord.sops.env
+++ b/apps/clusters/feathre-core/base-apps/sentry/sentry-discord.sops.env
@@ -1,0 +1,14 @@
+application-id=ENC[AES256_GCM,data:x4B4g3i4da3HKiMjSs42l+QMng==,iv:St16gm13iaaMvUZnHThrTRAfeIYBetyPv8qxIpB4A6k=,tag:n4Tm3muIug89k84TJdHeMw==,type:str]
+public-key=ENC[AES256_GCM,data:BUm2mivzaHDkLOCbillcvEMh3/ElKSQ4CCvoFsGKzBCHVGk8tWtTckRNheCpKXo9Dm90cmcvoYaE3UX+VOMDAA==,iv:S8M82LnbvgHZLdK1PtSp1fWRPsGni5GjINgj3Wq5mlE=,tag:i9CBW3c0ZUcUQOtaI5ihHA==,type:str]
+client-secret=ENC[AES256_GCM,data:ZeL1028A74eFRSc+W/TOeW6BiZay5io/Q+5pTUW0bc8=,iv:DM82qSZHpyP9LGh3itPp3Pq4Qc33zIN70ufhRNgMaRM=,tag:/ZWpbHck+SYborg0HPhF0w==,type:str]
+bot-token=ENC[AES256_GCM,data:Y1Sfgaj+ztaN4xFbxvlIZ5p15Onm21C3KmiMAESdQJo+XrUJfJQnBpx2NsgvVLZE/6LZcYnQSJp2ff675e05kToAmXF/uyLt,iv:hHJoaJEySnUGXpaU5F2wNh1W8asgI9sw83PGqCOtGoI=,tag:lCY6D7ArbHipjzh8mIuQBA==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6bUJvYWN0OVJoaTkrNFZ3\nVFIzV21NU2w1SXR6c25CeUJVQmJIdFRFbTF3CmpKNCtEK0ovTmpmNjNHN1ZaSll3\nN2xxMmhJSDF0aTQ2elhxNE9qdHQwNW8KLS0tIFI3ZWpFRWdpSWx0V1NhRThjYk1P\nVDRjOFVEMHFXS3BMQ3VzU1lkY0x2T3MKiu0sKs3nNAdW1cZQD3j8QMPi8gDpxuR9\n5+Pc6yyPwitVQ9MfJPJkKd4I+CGL/B+/DXjSeN8m1LzGvmENiVmgRA==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1kfcggatwrwslka8sssdw2sy05jwntft84cw979gkvzp9wksnyy0qllsz8s
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkYWpwcGhadjc1ZE1jZU1K\nWElZdEtzajZoY013eDVBODltdnFxT2lHaFVRClBXNGN1emUyalN3c3FqN241em00\nY0NNVFA2TnZYYmgrL0NBTGJyRFFjR28KLS0tIFFKT05sdm1lYTB6SmV5ckVUbDkx\nQWFOM2FvUCs3WmoraTBpYklwcnQzSmMK+V65RjE39mqx2/Vt0/rvD1pNYMfHoZfG\nChAOCZLt9Hws6rPyVOHXiXiAEEI8DwFDgyB1M8+ZeM1+gggBzkjJ6A==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_recipient=age10x4xtzptvjztg9jkxr4m5luw3mfyqwww499lgnnqx32h2xytu5nqkjwqaq
+sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBERXA5MG1VRGR5MnVUOExJ\nM3pSa3dmYkV6ejJSdE0vb0ZtVElXSG1wMEg0CkZTQ0FtT0VFU252VjlxVVVLcGZG\nSDlGQkVGdDR4YzJxOFMySzd5UG9mQkUKLS0tIEFPazdicW9BM3NYUTZNMjVrQTlU\nOWdVV0ViYVV6emQrZHc3ZkN6WWNYSjAKHDj5vRFQbFnGWPJL0mRO0nIS0g8lGKlf\nWMg6rqZLBvHbiffD9Q4DQhYB4/Ndt6izPJ6ZEdkmztDtJKKL6A3KHA==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_2__map_recipient=age1rrus5c38flq6yg6l56d0cecgzap0fhdew64n7ygz7lngjwpzws4qcnge3x
+sops_lastmodified=2026-08-16T21:50:12Z
+sops_mac=ENC[AES256_GCM,data:Edxaxh/cBUm0JpAFonZWQZppmgFNWStDc49P4qVUi08L7LCe3f7f0PdIuoDy7PLAzh71xpFWKWguumepTIbhdexzYjOM4skj2J/I5oY2RmdXdcv3NCbOH604BikNZcT3tI3VWPOOqiOxSeDS5Uk97yfNKzG+Us0XS6+QY08p/18=,iv:YnaRWoAnuzA6VoiAgETbi7r6+pk8XGtM6mbtpwx+8aE=,tag:0llGjQsw+FNcmX9ukOu34w==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3


### PR DESCRIPTION
Gives Sentry a Discord application of its own for alert routing.

## A separate app on purpose

Not the existing `discordbot`. Discord allows **one interactions endpoint per application**, so sharing one would make the two integrations fight over it.

## Everything in the secret

Including the application id — which differs from the GitHub wiring, where `appId` and `appName` sit openly in the values. There they are public through `/apps/<slug>` anyway; Discord's id is paired with a bot token whose leak would let someone act as the bot, so there is no reason to split them.

Chart-default keys: `application-id`, `public-key`, `client-secret`, `bot-token`.

## Same trap as GitHub

Setting `discord.existingSecret` makes the chart reference all four keys **unconditionally**. An incomplete secret does not disable the integration — it stops the pods from starting.

## Discord-side setup

- Redirect URL: `https://sentry.onelitefeather.net/extensions/discord/setup/`
- Interactions endpoint: `https://sentry.onelitefeather.net/extensions/discord/interactions/`
- Bot permissions: Send Messages, Embed Links

Discord verifies the interactions endpoint with a signed test request the moment you save it, so Sentry has to be reachable first — it is.

`./scripts/validate.sh` and `scripts/check-sops-encryption.py` both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)