### PR TITLE
feat(apus): one tenant application instance per tenant

### DIFF
--- a/apps/clusters/feathre-core/base-apps/apus/release-operator.yaml
+++ b/apps/clusters/feathre-core/base-apps/apus/release-operator.yaml
@@ -31,3 +31,40 @@ spec:
         # The operator exports no metrics yet -- that arrives with phase 8. Enabling this
         # now would only add a scrape target answering with connection refused.
         enabled: false
+
+    # One instance of the tenant application per tenant, at
+    # https://apus.onelitefeather.dev/t/<tenant>/. The operator creates a Deployment, a Service
+    # and an Ingress in each tenant's own namespace -- the Ingress has to live there, because an
+    # Ingress may only reference a Service in its own namespace, so a single operator-owned
+    # Ingress listing every tenant was never an option at any price.
+    #
+    # Separate Ingress objects on the same host are safe here, but not for the reason the platform
+    # chart's own ingress comment gives. This cluster's controller
+    # (strrl.dev/cloudflare-tunnel-ingress-controller) flattens every Ingress in the cluster into
+    # one tunnel rule list and sorts it by path length descending before appending its 404
+    # catch-all, so /t/<tenant> lands ahead of / on its own no matter which object declared it.
+    # Read out of sortIngressRules in the controller's source, because no host in this cluster was
+    # served by two Ingress objects before now.
+    #
+    # Every tenant instance needs two redirect URIs registered in Entra before anyone can sign in
+    # to it. A wildcard is not a shortcut: Entra strips the query string when a wildcard URI
+    # matches, and the authorization code lives in that query string. The operator cannot add
+    # them either -- that would need Graph application permissions on the app registration -- so
+    # they are reported on Tenant.status.redirectUris and shown on the console's tenant page.
+    # For onelitefeather-dev they are already registered.
+    tenantUi:
+      host: apus.onelitefeather.dev
+      ingressClassName: cloudflare-tunnel
+      # The four values below deliberately mirror ui.env in release-platform.yaml exactly. Same
+      # public OIDC client: an id that differed between the platform's own UI and a tenant's
+      # instance would produce two sessions for one person.
+      #
+      # The origin only, with no /api suffix -- every method of the typed client already asks for
+      # a path beginning with /api, so a suffix here produces /api/api/tenants, which the ingress
+      # routes to the API, which has no such route, and the security filter answers a bare 403.
+      apiBaseUrl: https://apus.onelitefeather.dev
+      oidc:
+        issuer: https://login.microsoftonline.com/1a14dfb5-0eac-41bf-94cb-195c2e387520/v2.0
+        clientId: 59a9ea74-a98c-4b6b-b60b-3a309128a1cb
+        scope: >-
+          api://59a9ea74-a98c-4b6b-b60b-3a309128a1cb/access_as_user openid profile email

--- a/infrastructure/clusters/feather-core/base-sources/apus.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/apus.yaml
@@ -15,6 +15,14 @@
 # Upgrading the operator chart before the platform chart is not required -- an older api simply
 # ignores the field -- but keeping the pins equal keeps the coupling the comment above describes.
 #
+# 0.9.0 brings the last two pieces of the per-tenant work. The operator now provisions one
+# instance of the tenant application per tenant -- a Deployment, Service and Ingress in the
+# tenant's own namespace, serving https://<host>/t/<tenant>/ -- guarded by tenantUi.host, which
+# is empty by default so the feature stays off until it is configured below. And the api module
+# gains the directory: teams, invitations, password resets and impersonation, plus
+# Tenant.spec.identity.groupId, which is what finally lets a signed-in user resolve to a tenant
+# at all (the `organization` claim it used to read was never emitted by the app registration).
+#
 # 0.7.2 is what makes any of it usable, and is the floor for this cluster. The API named
 # the JWKS endpoint `jwks-uri` in application.yml, a property Micronaut does not bind
 # (JwksSignatureConfigurationProperties has setUrl and no setJwksUri). The bean existed
@@ -33,7 +41,7 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-operator
   ref:
-    semver: "=0.8.0"
+    semver: "=0.9.0"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -47,4 +55,4 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-platform
   ref:
-    semver: "=0.8.0"
+    semver: "=0.9.0"


### PR DESCRIPTION
Apus 0.9.0, and with it one instance of the tenant application per tenant, served at
`https://apus.onelitefeather.dev/t/<tenant>/`.

One image, N deployments, one environment variable: `NUXT_APP_BASE_URL` moves the served prefix at
runtime, verified against the built image before any of this was designed. The operator creates a
Deployment, a Service and an Ingress in each tenant's own namespace.

## Why the Ingress is per-tenant, and why that is safe here

**It has to be.** An Ingress may only reference a Service in its own namespace, and each tenant's
Service is in `bluemap-<name>`. A single operator-owned Ingress listing every tenant's path was
never an option.

**Separate Ingress objects on one host are safe — but not for the reason the platform chart's own
comment gives.** That comment warns that path order within a rule list is load-bearing, which is
true of nginx. This cluster runs `strrl.dev/cloudflare-tunnel-ingress-controller`, which flattens
*every* Ingress in the cluster into one tunnel rule list and sorts it globally — non-wildcard hosts
first, then by hostname, then **by path length descending** — before appending its `http_status:404`
catch-all. So `/t/<tenant>` lands ahead of `/` on its own, regardless of which object declared it.

Read out of `sortIngressRules` in the controller's source rather than assumed, because no host in
this cluster was served by two Ingress objects before now.

## What is on and what is not

| | |
| --- | --- |
| `tenantUi.host` | set, so the feature is **on** — the operator will provision an instance for every tenant that has an identity group |
| `apus-platform`'s `directory` | untouched, so teams/invitations/password resets stay **off** |

0.9.0 also carries the directory work (teams, people, invitations, password resets,
impersonation). It stays inert until `apus-platform` is given a Graph credential, which needs
application permissions with admin consent — a separate change and a separate decision, written
up in the repo's `docs/runbooks/directory-and-impersonation-setup.md`.

## The manual step this cannot remove

Each tenant instance needs two redirect URIs registered in Entra before anyone can sign in to it:

```text
https://apus.onelitefeather.dev/t/<tenant>/auth/callback
https://apus.onelitefeather.dev/t/<tenant>/auth/silent-renew
```

A wildcard is not a shortcut — Entra strips the query string when a wildcard URI matches, and the
authorization code lives in that query string. The operator cannot add them either; that would
need Graph permissions on the app registration. So it reports them on
`Tenant.status.redirectUris`, and the console shows them on the tenant's page with a copy action.

**`onelitefeather-dev`'s two are already registered.** Any tenant created later needs its own.

## Checked before pushing

- both files parse as YAML
- the real `apus-operator` chart renders with **these exact values**, and passes its
  `values.schema.json` — which rejects an `apiBaseUrl` ending in `/api`, the mistake that cost a
  debugging session once (it produces `/api/api/tenants` and a bare 403 that reads like a missing
  role)
- the four public OIDC values are byte-identical to `ui.env` in `release-platform.yaml`; a client
  id that differed between the platform's UI and a tenant's instance would give one person two
  sessions

## After merge

```bash
kubectl get tenant onelitefeather-dev -o jsonpath='{.status.redirectUris}'
kubectl get deploy,svc,ing -n bluemap-onelitefeather-dev -l app.kubernetes.io/name=tenant-ui
curl -sI https://apus.onelitefeather.dev/t/onelitefeather-dev/ | head -1
```

The last should be `200`. A `404` from Cloudflare means the tunnel rule has not propagated yet; a
`404` served by the application itself would mean `NUXT_APP_BASE_URL` never reached it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Bff5mpWkUnZA77jys8DiR
