### PR TITLE
fix(apus): move both pins to 0.9.1

### DIFF
--- a/infrastructure/clusters/feather-core/base-sources/apus.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/apus.yaml
@@ -15,6 +15,16 @@
 # Upgrading the operator chart before the platform chart is not required -- an older api simply
 # ignores the field -- but keeping the pins equal keeps the coupling the comment above describes.
 #
+# 0.9.1 is the floor now, and 0.9.0 must not be reinstated. The 0.9.0 api image does not
+# start at all: TenantGroupIndexLoader declared @Scheduled(fixedDelay = "60s"), a spelling
+# Micronaut's converter rejects, so the context failed during start() and the single api
+# replica went into CrashLoopBackOff, taking the whole API with it. The 0.9.0 operator starts,
+# but cannot read Rook's own CephObjectStoreUser -- its status model knew only `phase` while
+# Rook had added `info` -- so every tenant reconciliation failed and no tenant ever got the
+# application instance 0.9.0 exists to provision. Both are fixed in 0.9.1, which also adds a
+# build step that boots the shipped jar, because nothing in the test suite could see the first
+# failure.
+#
 # 0.9.0 brings the last two pieces of the per-tenant work. The operator now provisions one
 # instance of the tenant application per tenant -- a Deployment, Service and Ingress in the
 # tenant's own namespace, serving https://<host>/t/<tenant>/ -- guarded by tenantUi.host, which
@@ -41,7 +51,7 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-operator
   ref:
-    semver: "=0.9.0"
+    semver: "=0.9.1"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -55,17 +65,4 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/apus/charts/apus-platform
   ref:
-    # Held one version behind the operator on purpose, which is the exception to the
-    # keep-the-pins-equal rule above. The api image in 0.9.0 does not start: its new
-    # TenantGroupIndexLoader declares @Scheduled(fixedDelay = "60s"), a spelling Micronaut's
-    # converter rejects, so the context fails at
-    #   SchedulerConfigurationException: Invalid fixed delay definition: 60s
-    # and the single api replica goes into CrashLoopBackOff -- taking the whole API down with it.
-    #
-    # The operator stays on 0.9.0: it is a separate image, it starts fine, and it is what
-    # provisions the per-tenant application instances this release is for. The 0.9.0 CRD changes
-    # are additive, so an 0.8.0 api simply ignores the new fields.
-    #
-    # Move this back to =0.9.1 once the fix is released. Do not "tidy" the two pins back into
-    # agreement before then.
-    semver: "=0.8.0"
+    semver: "=0.9.1"


### PR DESCRIPTION
Undoes the split introduced by #177 and moves both pins forward to 0.9.1, which fixes both of the reasons 0.9.0 could not stay.

## Why 0.9.0 came back out

**The `api` image did not start.** `TenantGroupIndexLoader` declared `@Scheduled(fixedDelay = "60s")`, a spelling Micronaut's converter rejects, so the context failed during `start()`. With one replica that took the whole API down until #177 rolled the chart back.

**The operator started, but could not read Rook's own resource.** `CephObjectStoreUserStatus` modelled only `phase` while Rook had added `status.info`. `TenantReconciler` reads that user before touching anything, so every tenant reconciliation threw `UnrecognizedPropertyException` and exhausted its retries — which is why no tenant got the application instance 0.9.0 exists to provision, even while the operator looked healthy.

That second one was **not new**. It had been failing silently since Rook populated the field; a tenant only reconciles when something changes, so nothing surfaced it until this release needed one.

## What 0.9.1 changes

- the index refresh schedules through `TaskScheduler` with a typed `Duration` — a constant cannot be misspelled
- all four Rook model types ignore fields they do not model, because a model of somebody else's CRD must not fail on a field it never reads
- `:api:startupSmokeTest` boots the **shadowed jar** in `check` and fails if the context does not start

That last one exists because no test could have caught the first failure: a `@MicronautTest` that boots a real context with an embedded server was tried, the bug reintroduced faithfully, and it passed. The failure only happens in the fat jar. The smoke test was verified in both directions, and CI is confirmed to run it (`startupSmokeTest: the shadowed api jar starts` in the build log).

## Checked before merging

**Do not merge until the 0.9.1 charts are actually in Harbor** — at the time this was opened they were not (`not found` from `helm show chart`), because the release build was still running. Pointing Flux at a version that does not exist leaves the OCIRepository not-ready and the HelmRelease stuck on its old chart.

- both documents parse as YAML, and the chart renders with these exact values
- the pins are equal again, which is what the file's own rule asks for

## After merge

The operator pod restarts, and JOSDK reconciles every tenant on startup — which is what will finally create the per-tenant instance. Verified on the **pod**, not the Deployment:

```bash
kubectl get pods -n bluemap-onelitefeather-dev -l app.kubernetes.io/name=tenant-ui
kubectl get tenant onelitefeather-dev -o jsonpath='{.status.redirectUris}'
curl -sI https://apus.onelitefeather.dev/t/onelitefeather-dev/ | head -1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Bff5mpWkUnZA77jys8DiR
