### PR TITLE
fix(sentry): route project ingest paths to relay

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sentry/ingress.yaml
+++ b/apps/clusters/feathre-core/base-apps/sentry/ingress.yaml
@@ -10,12 +10,37 @@ spec:
     - host: sentry.onelitefeather.net
       http:
         paths:
+          # Everything project-scoped -- SDK envelopes and the OTLP endpoints
+          # under /api/<projectId>/integration/otlp/ -- is served by Relay, not
+          # by the Django web: sentry/web/urls.py has no route for it, only
+          # relay-server/src/endpoints does. This mirrors the chart's own nginx
+          # (`location ~ ^/api/[1-9]\d*/ { proxy_pass http://relay; }`), which
+          # stays disabled so the tunnel keeps talking to the services directly.
+          #
+          # The path is a cloudflared regex, not a Kubernetes prefix: the tunnel
+          # controller hands `path` to Cloudflare unchanged, so the type has to
+          # be ImplementationSpecific -- Prefix would have the API server reject
+          # the regex characters. Ordering is not left to the manifest either;
+          # the controller sorts a host's rules by path length descending, so
+          # this one is always evaluated before the `/` catch-all below.
+          #
+          # /api/0/ is deliberately outside the match: that is the web API the
+          # frontend itself calls, and it belongs to sentry-web.
+          - path: ^/api/[1-9][0-9]*/
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                # Port 3000 is the chart default (`relay.port`), not overridden
+                # in release.yaml.
+                name: sentry-relay
+                port:
+                  number: 3000
           - path: /
             pathType: Prefix
             backend:
               service:
                 # The chart's own nginx is off; this points straight at the
-                # web service, which also serves the SDK ingest endpoints.
+                # web service, which serves the UI and the /api/0/ web API.
                 name: sentry-web
                 port:
                   number: 9000


### PR DESCRIPTION
## Problem

The tunnel currently sends **every** path on `sentry.onelitefeather.net` to `sentry-web:9000`. The project-scoped ingest paths `/api/<projectId>/…` — SDK envelopes and the OTLP endpoints under `integration/otlp/` — do not exist there at all: they are registered only in `relay-server/src/endpoints` (`.nest("/api/{project_id}/integration/otlp", …)`), not in `sentry/web/urls.py`. Ingest therefore never reaches Relay.

The chart's own nginx normally performs this split (`location ~ ^/api/[1-9]\d*/ { proxy_pass http://relay; }`), but it is deliberately disabled here (`nginx.enabled: false`), so the split moves into the Ingress.

## Solution

An additional rule on the same host that routes project-scoped paths to `sentry-relay:3000`:

- **Regex, not prefix:** the tunnel controller passes `path` through to Cloudflare unchanged (`pkg/cloudflare-controller/transform.go`), and cloudflared matches `path` as a regular expression. That forces `pathType: ImplementationSpecific` — the API server would reject the regex characters on a `Prefix` path.
- **Ordering** does not come from the manifest but from the controller, which sorts a host's rules by path length descending (`sortIngressRules`), so the ingest rule is always evaluated before the `/` catch-all.
- **`/api/0/` stays with the web service:** that is the web API the frontend itself calls.
- Port 3000 is the chart default (`relay.port`), not overridden in the overlay.

## Verification

- `./scripts/validate.sh` passes. A first run aborted with a 27s timeout on `git fetch` for the metallb remote base — a network flake unrelated to this change; the second run was clean.
- `kubectl kustomize apps/clusters/feathre-core/base-apps/sentry` renders both rules in the expected order.
- Checkable after the merge: `curl -i https://sentry.onelitefeather.net/api/1/envelope/` must be answered by Relay (400/401) rather than a Django 404, and `/api/0/organizations/` must still come from the web service.

## Context

Groundwork for wiring apps up to Sentry (Outline and n8n both support a DSN) and, later, for sending OTLP traces from `alloy-receiver`. Without this change every DSN is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
