### PR TITLE
feat(sturnus): add sturnus with cnpg database, dedicated ceph s3 bucket and link ingress

### DIFF
--- a/apps/base/sturnus/kustomization.yaml
+++ b/apps/base/sturnus/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sturnus
+resources:
+  - namespace.yaml
+  - release.yaml

--- a/apps/base/sturnus/namespace.yaml
+++ b/apps/base/sturnus/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sturnus

--- a/apps/base/sturnus/release.yaml
+++ b/apps/base/sturnus/release.yaml
@@ -1,0 +1,21 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: sturnus
+  namespace: sturnus
+spec:
+  releaseName: sturnus
+  chart:
+    spec:
+      chart: ./charts/sturnus
+      sourceRef:
+        kind: GitRepository
+        name: sturnus
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  interval: 1m0s
+  # Default values
+  #
+  values: {}

--- a/apps/clusters/feathre-core/base-apps/kustomization.yaml
+++ b/apps/clusters/feathre-core/base-apps/kustomization.yaml
@@ -23,3 +23,4 @@ resources:
   - alloy-receiver
   - apus
   - vikunja
+  - sturnus

--- a/apps/clusters/feathre-core/base-apps/sturnus/audio-lifecycle-job.yaml
+++ b/apps/clusters/feathre-core/base-apps/sturnus/audio-lifecycle-job.yaml
@@ -1,0 +1,87 @@
+# ============================================================================
+# Sturnus audio bucket — S3 lifecycle rule (Spec 12.2 second line of defence)
+# ----------------------------------------------------------------------------
+# Ceph RGW on this cluster (Ceph Squid 19.2.5) implements the S3 Bucket
+# Lifecycle API (PutBucketLifecycleConfiguration and friends), but Rook
+# 1.20's ObjectBucketClaim has no field for it -- additionalConfig only
+# exposes bucket quotas (maxObjects/maxSize), never lifecycle rules -- and no
+# other Kubernetes CRD in this cluster covers it either (grep this repo for
+# "lifecycle": nothing else configures one). The only way to set one is a
+# direct S3 API call against the bucket after it exists. That is what this
+# Job does.
+#
+# This Job is NOT wired into any kustomization -- apply it manually, once,
+# after buckets/sturnus.yaml (the ObjectBucketClaim) has reconciled and the
+# sturnus-audio bucket exists, and after sturnus-secrets holds real S3
+# credentials (see sturnus-secrets.sops.env.TEMPLATE). It expires objects 90
+# days after creation: deliberately well past the application's default
+# 30-day `audio_retention_days` sweep (Sturnus docs/operations.md section 6),
+# since this rule exists only to catch what that sweep misses if the worker
+# is down for weeks -- it is a backstop, not the real retention mechanism,
+# and is not wired to the runtime-configurable `audio_retention_days` value
+# at all. If that default is ever raised to something closer to 90 days,
+# revisit the number below too. Re-run this Job if the bucket is ever
+# recreated -- the lifecycle configuration lives on the bucket itself, not in
+# this cluster's state, and is not restored by re-applying kustomize.
+#
+# ---- USAGE -----------------------------------------------------------------
+#   kubectl apply -f audio-lifecycle-job.yaml
+#   kubectl -n sturnus logs -f job/sturnus-audio-lifecycle-apply
+#   kubectl -n sturnus delete job sturnus-audio-lifecycle-apply   # before re-running
+# ============================================================================
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sturnus-audio-lifecycle-apply
+  namespace: sturnus
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sturnus
+        app.kubernetes.io/component: audio-lifecycle-apply
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: apply-lifecycle
+          image: amazon/aws-cli:2.36.27
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: sturnus-secrets
+                  key: STURNUS_S3_ACCESS_KEY
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: sturnus-secrets
+                  key: STURNUS_S3_SECRET_KEY
+            - name: AWS_DEFAULT_REGION
+              # RGW ignores the value but the CLI refuses to run without one.
+              value: us-east-1
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              cat > /tmp/lifecycle.json <<'EOF'
+              {
+                "Rules": [
+                  {
+                    "ID": "expire-audio-90d",
+                    "Filter": {},
+                    "Status": "Enabled",
+                    "Expiration": { "Days": 90 }
+                  }
+                ]
+              }
+              EOF
+              aws --endpoint-url http://rook-ceph-rgw-feather-s3.rook-ceph-fr01.svc:80 \
+                s3api put-bucket-lifecycle-configuration \
+                --bucket sturnus-audio \
+                --lifecycle-configuration file:///tmp/lifecycle.json
+              echo "Applied. Current configuration:"
+              aws --endpoint-url http://rook-ceph-rgw-feather-s3.rook-ceph-fr01.svc:80 \
+                s3api get-bucket-lifecycle-configuration --bucket sturnus-audio

--- a/apps/clusters/feathre-core/base-apps/sturnus/ingress.yaml
+++ b/apps/clusters/feathre-core/base-apps/sturnus/ingress.yaml
@@ -1,0 +1,30 @@
+# Exposes the `link` component ONLY (the OAuth account-link callback) via
+# Cloudflare Tunnel -- same pattern as outline/ingress.yaml. `bot` and
+# `worker` hold the Discord token, the S3 credentials and the audio master
+# key and must never be reachable from outside the cluster; the chart's own
+# httpRoute stays disabled (see release.yaml) precisely so nothing but this
+# Ingress, pointed at the link Service alone, is ever exposed.
+#
+# Hostname is this task's choice, following the app-name.onelitefeather.dev
+# convention (see outline.onelitefeather.dev) -- confirm it against the real
+# DNS record and the Discord OAuth app's registered redirect URI
+# (https://sturnus.onelitefeather.dev/oauth/callback) before relying on it.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sturnus-link-cloudflare-tunnel
+  annotations:
+    cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol: http
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+    - host: sturnus.onelitefeather.dev
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sturnus-link
+                port:
+                  number: 80

--- a/apps/clusters/feathre-core/base-apps/sturnus/kustomization.yaml
+++ b/apps/clusters/feathre-core/base-apps/sturnus/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sturnus
+generatorOptions:
+  disableNameSuffixHash: true
+resources:
+  - ../../../../../apps/base/sturnus/
+  - ingress.yaml
+patches:
+  - path: release.yaml
+
+# secretGenerator is deliberately omitted for now: sturnus-secrets.sops.env
+# does not exist in this repo yet -- SOPS-encrypted secrets cannot be
+# produced by this task (see sturnus-secrets.sops.env.TEMPLATE in this
+# directory and the task-9-report.md it was written for). `kubectl kustomize`
+# on this directory builds cleanly without it; the HelmRelease will simply
+# fail to start pods (CrashLoopBackOff / ContainerCreating on the missing
+# Secret) until the real file exists. Once it does, add:
+#
+# secretGenerator:
+#   - name: sturnus-secrets
+#     envs:
+#       - sturnus-secrets.sops.env

--- a/apps/clusters/feathre-core/base-apps/sturnus/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/sturnus/release.yaml
@@ -1,0 +1,48 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: sturnus
+  namespace: sturnus
+spec:
+  # The chart has no top-level priorityClassName value (unlike outline's/
+  # vikunja's chart) -- inject it post-render the same way bluemap/
+  # dependency-track/grafana/penpot/reposilite/sentry/shlink already do for
+  # their own charts. Applies to all three Deployments (bot, link, worker).
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+            patch: |
+              - op: add
+                path: /spec/template/spec/priorityClassName
+                value: feather-standard
+  values:
+    podLabels:
+      logs.onelitefeather.net/env: prod
+
+    commonEnv:
+      # Internal RGW Service, not the public s3.onelitefeather.net endpoint
+      # (same endpoint the CNPG barman ObjectStore and the bluemap render Job
+      # use -- see infrastructure/clusters/feather-core/configs/postgresql/object-store.yaml).
+      # bot uploads whole recordings and worker downloads+decrypts them; the
+      # public route runs through the Cloudflare Tunnel, which caps request
+      # bodies at 100 MB (see rook-fr01/s3-external-tunnel.yaml) -- staying
+      # in-cluster avoids that cap entirely. The chart's own default
+      # (s3.onelitefeather.dev) is a placeholder, not this cluster's real
+      # domain.
+      STURNUS_S3_ENDPOINT: "http://rook-ceph-rgw-feather-s3.rook-ceph-fr01.svc:80"
+      STURNUS_S3_BUCKET: "sturnus-audio"
+
+    # Chart default (eu-central-1) is a placeholder the chart's own comment
+    # says to override per-cluster. Every other region-pinned pod/PVC here
+    # uses fr-rosenau (see outline's release.yaml `regionAffinity` anchor and
+    # storageclasses/rbd.yaml's allowedTopologies).
+    region:
+      key: topology.kubernetes.io/region
+      value: fr-rosenau
+
+    # Exposed via Cloudflare Tunnel (see ingress.yaml) for the link component
+    # only; the chart's own HTTPRoute stays off, same as outline's httpRoute.
+    httpRoute:
+      enabled: false

--- a/apps/clusters/feathre-core/base-apps/sturnus/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/sturnus/release.yaml
@@ -22,6 +22,24 @@ spec:
       logs.onelitefeather.net/env: prod
 
     commonEnv:
+      # The three non-secret Outline settings every component or the OAuth
+      # flow needs. None is a credential: an OAuth client id is public by
+      # design and the other two are addresses, so they belong here rather
+      # than in the SOPS secret beside them.
+      #
+      # The redirect URI must match both the host in ingress.yaml in this
+      # directory and the redirect URI registered on the Outline OAuth
+      # application, or the flow fails on a redirect_uri mismatch after the
+      # user has already consented. The path is fixed by the link server's
+      # own route table (sturnus.infrastructure.linkserver: GET
+      # /oauth/callback).
+      STURNUS_OUTLINE_BASE_URL: "https://outline.onelitefeather.dev"
+      STURNUS_OUTLINE_REDIRECT_URI: "https://sturnus.onelitefeather.dev/oauth/callback"
+      # Fill in from the Outline OAuth application (Settings -> Applications).
+      # Public, so it stays in plain configuration -- only the matching
+      # client secret goes in the secret.
+      STURNUS_OUTLINE_CLIENT_ID: ""
+
       # Internal RGW Service, not the public s3.onelitefeather.net endpoint
       # (same endpoint the CNPG barman ObjectStore and the bluemap render Job
       # use -- see infrastructure/clusters/feather-core/configs/postgresql/object-store.yaml).

--- a/apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env.TEMPLATE
+++ b/apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env.TEMPLATE
@@ -48,28 +48,28 @@ STURNUS_S3_SECRET_KEY=
 # keeping this value. Back it up as carefully as the recordings themselves.
 STURNUS_MASTER_KEY=
 
-# --- Below this line: link component settings -------------------------------
-# As of this task, the `sturnus-link` entrypoint module and its Settings
-# class have NOT landed in the Sturnus codebase yet (confirmed against
-# src/sturnus/config.py and docs/operations.md section 1, which says
-# explicitly: "Do not configure a deployment against variable names guessed
-# from the design document; wait for the corresponding code"). The three
-# STURNUS_OUTLINE_*/STURNUS_OAUTH_* names below are THIS TASK'S BEST-GUESS
-# PLACEHOLDERS ONLY, following the existing STURNUS_ prefix convention -- NOT
-# a confirmed contract. Verify the real variable names against the landed
-# link Settings class before deploying against them, and update this
-# template (and the real encrypted file) to match if they differ.
+# --- Outline credentials ----------------------------------------------------
+# The names below are read from the landed settings classes
+# (sturnus.entrypoints.worker.WorkerSettings and
+# sturnus.entrypoints.link.LinkSettings), not guessed. An earlier revision of
+# this template predated that code and used STURNUS_OUTLINE_API_TOKEN,
+# STURNUS_OAUTH_CLIENT_ID and STURNUS_OAUTH_CLIENT_SECRET -- none of which
+# any component reads. Sturnus docs/operations.md section 1 carries the full
+# per-component table.
 
-# Outline API token used by the link component to call the Outline API as a
+# Outline API token the WORKER uses to create the protocol document, as a
 # service identity. Create it in Outline under Settings -> API & Apps -> New
 # API key, scoped to the least access needed to create documents in the
 # target collection.
-STURNUS_OUTLINE_API_TOKEN=
+STURNUS_OUTLINE_SERVICE_KEY=
 
-# OAuth client id/secret of the Outline OAuth application used for the
-# Discord<->Outline account-link flow (see src/sturnus/infrastructure/documents/outline_oauth.py).
-# Create an OAuth application in Outline (Settings -> Applications) with
-# redirect URI https://sturnus.onelitefeather.dev/oauth/callback (must match
-# ingress.yaml's host in this directory).
-STURNUS_OAUTH_CLIENT_ID=
-STURNUS_OAUTH_CLIENT_SECRET=
+# OAuth client secret of the Outline application used for the
+# Discord<->Outline account-link flow, read by the LINK component. Create the
+# application in Outline (Settings -> Applications) with the redirect URI set
+# to the host in ingress.yaml in this directory.
+#
+# The matching client id is NOT here: an OAuth client id is public by design,
+# so it belongs in the HelmRelease's commonEnv as
+# STURNUS_OUTLINE_CLIENT_ID, next to STURNUS_OUTLINE_BASE_URL and
+# STURNUS_OUTLINE_REDIRECT_URI. All three are plain configuration.
+STURNUS_OUTLINE_CLIENT_SECRET=

--- a/apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env.TEMPLATE
+++ b/apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env.TEMPLATE
@@ -1,0 +1,75 @@
+# =============================================================================
+# TEMPLATE -- NOT a real secret, NOT encrypted, NOT wired into any
+# kustomization. Fill in every value below, then encrypt it with SOPS and
+# save the result as sturnus-secrets.sops.env in this same directory (see
+# .sops.yaml at the repo root for the creation rule that matches it). Do NOT
+# commit this file, or any copy of it, with real values in plaintext.
+#
+# Once sturnus-secrets.sops.env exists, add the secretGenerator stanza shown
+# at the bottom of kustomization.yaml in this directory -- the deployment
+# will not start before both of those things are done (the chart's `bot`,
+# `link` and `worker` Deployments all read this Secret via envFrom, and pods
+# will fail to start / CrashLoopBackOff on the missing values otherwise).
+# =============================================================================
+
+# The bot's Discord token, from the application's "Bot" tab at
+# https://discord.com/developers/applications. The application needs the
+# privileged "Server Members Intent" and "Voice States Intent" enabled, or
+# the bot fails to connect (Sturnus docs/operations.md section 3.1).
+STURNUS_DISCORD_TOKEN=
+
+# SQLAlchemy async connection string for the "sturnus" CNPG database
+# (infrastructure/clusters/feather-core/configs/postgresql/database/sturnus.yaml).
+# The password must be the same one placed in
+# infrastructure/clusters/feather-core/configs/postgresql/roles/sturnus.sops.env.TEMPLATE
+# -- both come from the same generated password.
+# Format: postgresql+asyncpg://sturnus:<password>@feather-core-cluster-pg-pooler-rw.cnpg-system.svc.cluster.local:5432/sturnus
+STURNUS_DATABASE_URL=
+
+# Access key / secret key of the dedicated "sturnus" CephObjectStoreUser
+# (infrastructure/clusters/feather-core/rook-fr01/users/sturnus.yaml), which
+# owns the sturnus-audio bucket. Rook/Ceph generates these automatically once
+# that CephObjectStoreUser reconciles -- read them, do not invent them:
+#   kubectl -n rook-ceph-fr01 get secret rook-ceph-object-user-feather-s3-sturnus -o jsonpath='{.data.AccessKey}' | base64 -d
+#   kubectl -n rook-ceph-fr01 get secret rook-ceph-object-user-feather-s3-sturnus -o jsonpath='{.data.SecretKey}' | base64 -d
+STURNUS_S3_ACCESS_KEY=
+STURNUS_S3_SECRET_KEY=
+
+# Base64-encoded 32 random bytes -- the AES-256 key that wraps every
+# session's per-recording data key (sturnus.infrastructure.crypto.KeyWrapper).
+# Audio is never encrypted with this key directly; a fresh per-session data
+# key is encrypted ("wrapped") with this one and only the wrapped form is
+# ever stored (transcription_job.wrapped_data_key). Generate with:
+#   openssl rand -base64 32
+#
+# LOSING THIS KEY DESTROYS EVERY RECORDING IT WRAPPED. No database backup
+# helps -- it would contain the same unreadable wrapped bytes -- and no S3
+# backup helps either, for the same reason. There is no recovery path but
+# keeping this value. Back it up as carefully as the recordings themselves.
+STURNUS_MASTER_KEY=
+
+# --- Below this line: link component settings -------------------------------
+# As of this task, the `sturnus-link` entrypoint module and its Settings
+# class have NOT landed in the Sturnus codebase yet (confirmed against
+# src/sturnus/config.py and docs/operations.md section 1, which says
+# explicitly: "Do not configure a deployment against variable names guessed
+# from the design document; wait for the corresponding code"). The three
+# STURNUS_OUTLINE_*/STURNUS_OAUTH_* names below are THIS TASK'S BEST-GUESS
+# PLACEHOLDERS ONLY, following the existing STURNUS_ prefix convention -- NOT
+# a confirmed contract. Verify the real variable names against the landed
+# link Settings class before deploying against them, and update this
+# template (and the real encrypted file) to match if they differ.
+
+# Outline API token used by the link component to call the Outline API as a
+# service identity. Create it in Outline under Settings -> API & Apps -> New
+# API key, scoped to the least access needed to create documents in the
+# target collection.
+STURNUS_OUTLINE_API_TOKEN=
+
+# OAuth client id/secret of the Outline OAuth application used for the
+# Discord<->Outline account-link flow (see src/sturnus/infrastructure/documents/outline_oauth.py).
+# Create an OAuth application in Outline (Settings -> Applications) with
+# redirect URI https://sturnus.onelitefeather.dev/oauth/callback (must match
+# ingress.yaml's host in this directory).
+STURNUS_OAUTH_CLIENT_ID=
+STURNUS_OAUTH_CLIENT_SECRET=

--- a/infrastructure/clusters/feather-core/base-sources/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/kustomization.yaml
@@ -27,3 +27,4 @@ resources:
   - penpot.yaml
   - strimzi.yaml
   - sentry-kubernetes.yaml
+  - sturnus.yaml

--- a/infrastructure/clusters/feather-core/base-sources/sturnus.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/sturnus.yaml
@@ -1,0 +1,19 @@
+# Sturnus' Helm chart lives in the Sturnus repo itself (charts/sturnus), not
+# vendored under this repo's helm/ dir, and it is not published anywhere
+# (no OCI artifact in Harbor yet, unlike apus -- see apus.yaml in this same
+# directory). This GitRepository is the "chart living in a Git source"
+# pattern applied to a second repo, mirroring helmcharts.yml's own shape
+# (branch checkout of a whole repo, chart referenced by in-repo path from the
+# HelmRelease). Requires the chart to exist on Sturnus' `main` branch --
+# confirm that before relying on this; as of this writing Sturnus' work was
+# still on a feature branch.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: sturnus
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: https://github.com/OneLiteFeatherNET/Sturnus.git
+  ref:
+    branch: main

--- a/infrastructure/clusters/feather-core/configs/postgresql/cluster.yaml
+++ b/infrastructure/clusters/feather-core/configs/postgresql/cluster.yaml
@@ -100,6 +100,14 @@ spec:
         ensure: present
         passwordSecret:
           name: role-vikunja
+      # role-sturnus does not exist yet -- see roles/sturnus.sops.env.TEMPLATE
+      # in this directory. CNPG will fail to reconcile this role (and the
+      # sturnus Database below stays unusable) until that Secret is created.
+      - name: sturnus
+        login: true
+        ensure: present
+        passwordSecret:
+          name: role-sturnus
     services:
       additional:
         - selectorType: rw

--- a/infrastructure/clusters/feather-core/configs/postgresql/database/sturnus.yaml
+++ b/infrastructure/clusters/feather-core/configs/postgresql/database/sturnus.yaml
@@ -1,0 +1,9 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: sturnus
+spec:
+  name: sturnus
+  owner: sturnus
+  cluster:
+    name: feather-core-cluster-pg

--- a/infrastructure/clusters/feather-core/configs/postgresql/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/configs/postgresql/kustomization.yaml
@@ -24,8 +24,15 @@ resources:
   - database/penpot.yaml
   - database/sentry.yaml
   - database/vikunja.yaml
+  - database/sturnus.yaml
 
 secretGenerator:
+  # role-sturnus is deliberately omitted for now: roles/sturnus.sops.env does
+  # not exist yet -- SOPS-encrypted secrets cannot be produced by this task
+  # (see roles/sturnus.sops.env.TEMPLATE and the exact stanza to add once it
+  # is encrypted). `kubectl kustomize` on this directory builds cleanly
+  # without it; CNPG will simply fail to reconcile the "sturnus" role (see
+  # cluster.yaml) until the real file exists.
   - name: cnpg-backup
     envs:
       - s3-backup.env

--- a/infrastructure/clusters/feather-core/configs/postgresql/roles/sturnus.sops.env.TEMPLATE
+++ b/infrastructure/clusters/feather-core/configs/postgresql/roles/sturnus.sops.env.TEMPLATE
@@ -1,0 +1,25 @@
+# =============================================================================
+# TEMPLATE -- NOT a real secret, NOT encrypted, NOT wired into any
+# kustomization. Fill in, then encrypt with SOPS and save as
+# roles/sturnus.sops.env in this same directory (see .sops.yaml at the repo
+# root for the creation rule that matches it). Do NOT commit this file, or
+# any copy of it, with a real password in plaintext.
+#
+# Consumed by the CNPG "sturnus" managed role added to cluster.yaml in this
+# directory (passwordSecret: role-sturnus) as Secret role-sturnus. Once this
+# file is encrypted, add it to kustomization.yaml's secretGenerator (mirror
+# the existing role-outline entry):
+#
+# secretGenerator:
+#   - name: role-sturnus
+#     options:
+#       labels:
+#         cnpg.io/reload: "true"
+#     envs:
+#       - roles/sturnus.sops.env
+# =============================================================================
+username=sturnus
+# Generate with: openssl rand -base64 32
+# Must be the same value used in the STURNUS_DATABASE_URL connection string
+# in apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env.TEMPLATE.
+password=

--- a/infrastructure/clusters/feather-core/rook-fr01/buckets/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/rook-fr01/buckets/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
   - cygnus-pack.yaml
   - penpot.yaml
   - sentry.yaml
+  - sturnus.yaml

--- a/infrastructure/clusters/feather-core/rook-fr01/buckets/sturnus.yaml
+++ b/infrastructure/clusters/feather-core/rook-fr01/buckets/sturnus.yaml
@@ -1,0 +1,15 @@
+# Dedicated bucket + dedicated CephObjectStoreUser (users/sturnus.yaml) --
+# this bucket holds recorded speech and must not share access (or a bucket
+# owner) with anything else in the cluster, unlike buckets that reuse a
+# shared owner. bucketName matches the chart's commonEnv.STURNUS_S3_BUCKET
+# default (sturnus-audio) -- see apps/clusters/feathre-core/base-apps/sturnus/release.yaml.
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: sturnus
+  namespace: rook-ceph-fr01
+spec:
+  bucketName: sturnus-audio
+  storageClassName: ceph-bucket-fr01
+  additionalConfig:
+    bucketOwner: sturnus

--- a/infrastructure/clusters/feather-core/rook-fr01/users/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/rook-fr01/users/kustomization.yaml
@@ -19,4 +19,5 @@ resources:
   - apus.yaml
   - penpot.yaml
   - sentry.yaml
+  - sturnus.yaml
   - vikunja.yaml

--- a/infrastructure/clusters/feather-core/rook-fr01/users/sturnus.yaml
+++ b/infrastructure/clusters/feather-core/rook-fr01/users/sturnus.yaml
@@ -1,0 +1,11 @@
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: sturnus
+  namespace: rook-ceph-fr01
+spec:
+  store: feather-s3
+  displayName: sturnus
+  capabilities:
+    bucket: "*"
+    user: "*"


### PR DESCRIPTION
## What Sturnus is

Sturnus is a Discord bot that records voice-channel sessions and transcribes them, linking the result into Outline via an OAuth account-link flow. Critically: **the audio it stores is real people's speech**. That drives two deliberate design choices below, not defaults.

## What's in this PR

- **HelmRelease** (`apps/base/sturnus` base + `apps/clusters/feathre-core/base-apps/sturnus` overlay) — chart lives in the Sturnus repo itself, pulled as a `GitRepository` source off `main` (mirrors `helmcharts.yml`'s "chart living in a git source" pattern; not published to Harbor yet).
- **CloudNativePG database + role** — `sturnus` DB owned by a dedicated `sturnus` CNPG role on the shared `feather-core-cluster-pg` cluster, same shape as every other app database here (see `vikunja`/`outline`).
- **Dedicated Ceph S3 bucket + its own `CephObjectStoreUser`** — `sturnus-audio` bucket via `ObjectBucketClaim`, with its own bucket owner. Unlike buckets that reuse a shared owner, this one is isolated on purpose: it holds recorded speech, and no other workload should ever be able to read or write it.
- **Ingress for `link` only** — Cloudflare Tunnel routes only the `sturnus-link` Service (the Discord↔Outline OAuth callback) to `sturnus.onelitefeather.dev`. The `bot` and `worker` Deployments — which hold the Discord token, S3 credentials, and the audio master key — are never exposed. The chart's own `httpRoute` stays disabled for the same reason. **Closest existing analogue: Outline** — same `chart.enabled`/`httpRoute: false` + hand-written Ingress-to-one-component split, same in-cluster (not public) S3 endpoint to dodge the Cloudflare Tunnel's 100 MB body cap.
- Two plaintext `*.TEMPLATE` secret files (not encrypted, not wired into any `secretGenerator`) documenting every value an operator must supply.
- A standalone `audio-lifecycle-job.yaml` (not wired into any kustomization — apply manually once the bucket exists) that sets a 90-day S3 lifecycle expiry as a backstop behind the app's own 30-day retention sweep, since Rook's `ObjectBucketClaim` has no lifecycle field.

Every touched/added kustomize directory builds cleanly with `kubectl kustomize` as committed (verified locally, Kustomize v5.8.1).

## Nothing starts until an operator does this

No `secretGenerator` is wired anywhere yet — deliberately. Two SOPS-encrypted files must be created before the HelmRelease's pods can start (they'll otherwise sit in `CrashLoopBackOff`/`ContainerCreating` on missing Secrets), and CNPG won't reconcile the `sturnus` role without the first one:

1. **`infrastructure/clusters/feather-core/configs/postgresql/roles/sturnus.sops.env`** — from `roles/sturnus.sops.env.TEMPLATE` in that directory. Needs a generated password:
   ```
   openssl rand -base64 32
   ```
2. **`apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env`** — from `sturnus-secrets.sops.env.TEMPLATE` in that directory. Needs the Discord bot token, the DB connection string (same password as step 1), the S3 access/secret key pair (read off the `CephObjectStoreUser`-generated Secret once it reconciles — don't invent them), and the audio master key:
   ```
   openssl rand -base64 32
   ```
3. Encrypt both with SOPS, e.g.:
   ```
   sops -e -i infrastructure/clusters/feather-core/configs/postgresql/roles/sturnus.sops.env
   sops -e -i apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env
   ```
4. Add the two `secretGenerator` stanzas — each one is spelled out verbatim in a comment at the bottom of the relevant `kustomization.yaml` (`configs/postgresql/kustomization.yaml` and `apps/clusters/feathre-core/base-apps/sturnus/kustomization.yaml`).

### The master key is not backed up by anything else

`STURNUS_MASTER_KEY` wraps every session's per-recording data key. Audio is never encrypted with this key directly — a fresh per-session key is generated, encrypted ("wrapped") with the master key, and only the **wrapped form** is ever persisted. **Losing this key destroys every recording it wrapped.** No database backup helps (it holds the same unreadable wrapped bytes), and no S3 backup helps either (same reason). There is no recovery path other than keeping this value safe — back it up as carefully as the recordings themselves, outside of anything that could be lost alongside the cluster.

## What I could not verify — please check

- **The chart must exist on Sturnus' `main` branch.** As of writing this PR, Sturnus' chart work was still on a feature branch. If it hasn't merged, the `GitRepository` source will have nothing to pull.
- **`STURNUS_OUTLINE_API_TOKEN` / `STURNUS_OAUTH_CLIENT_ID` / `STURNUS_OAUTH_CLIENT_SECRET`** in the secrets template are this PR's best-guess placeholder variable names for the `link` component's config — the corresponding Settings class had not landed in the Sturnus codebase at the time of writing. Confirm the real names before deploying against them.
- **The `sturnus.onelitefeather.dev` hostname** follows the existing `app-name.onelitefeather.dev` convention but isn't confirmed against a real DNS record or against the Discord OAuth app's registered redirect URI (`https://sturnus.onelitefeather.dev/oauth/callback`).
- I ran `kubectl kustomize` locally on every added/edited directory (all built cleanly) but did **not** apply anything to a live cluster — no cluster-side validation was possible from here.