### PR TITLE
fix(sentry): drop the regex anchor the API server rejects

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sentry/ingress.yaml
+++ b/apps/clusters/feathre-core/base-apps/sentry/ingress.yaml
@@ -24,9 +24,20 @@ spec:
           # the controller sorts a host's rules by path length descending, so
           # this one is always evaluated before the `/` catch-all below.
           #
+          # No leading `^`, even though this is a regex and the chart's own
+          # nginx anchors it. The API server requires every ingress path to be
+          # absolute -- for ImplementationSpecific too -- and rejects the whole
+          # Ingress with "must be an absolute path" if it starts with `^`,
+          # which took down the entire base-apps kustomization at dry-run.
+          # Cloudflare matches `path` unanchored (Go regexp), so the leading
+          # `/` both satisfies the API server and keeps the match correct: the
+          # only requests this now catches that the anchored form would not are
+          # ones with `/api/<n>/` in the middle of a longer path, and Sentry
+          # serves none.
+          #
           # /api/0/ is deliberately outside the match: that is the web API the
           # frontend itself calls, and it belongs to sentry-web.
-          - path: ^/api/[1-9][0-9]*/
+          - path: /api/[1-9][0-9]*/
             pathType: ImplementationSpecific
             backend:
               service:


### PR DESCRIPTION
`base-apps` has been failing to reconcile, blocking every app in it — including ones added since.

```
Ingress/sentry/sentry-cloudflare-tunnel dry-run failed (Invalid):
spec.rules[0].http.paths[0].path: Invalid value: "^/api/[1-9][0-9]*/": must be an absolute path
```

The API server requires every ingress path to be absolute — **`ImplementationSpecific` included**; the pathType relaxes what the path may contain, not that it must start with `/`. The leading `^` makes it non-absolute, so the whole Ingress is rejected and Flux fails the kustomization at dry-run.

## The rule never reached the cluster

Worth knowing beyond the reconcile failure. The live Ingress today:

```console
$ kubectl get ingress -n sentry sentry-cloudflare-tunnel \
    -o jsonpath='{range .spec.rules[0].http.paths[*]}{.path}  -> {.backend.service.name}{"\n"}{end}'
/  -> sentry-web
```

Only the catch-all. So Sentry's project ingest — SDK envelopes and the OTLP endpoints under `/api/<projectId>/` — has been going to `sentry-web` rather than the relay, which is exactly what #179 added this rule to fix. This restores that routing as well as unblocking the kustomization.

## Why dropping the anchor is safe

Cloudflare matches `path` as a **Go regexp, unanchored** — the docs' own example (`\.(jpg|png|css|js)$`) matches mid-string. And the tunnel controller passes `path` through unchanged to cloudflared, so what the manifest says is what Cloudflare evaluates.

Dropping `^` therefore leaves the match correct while making the path absolute. The only requests it now catches that the anchored form would not are ones with `/api/<n>/ `in the middle of a longer path, and Sentry serves none. `/api/0/` stays outside the match either way, since `[1-9]` excludes it — that is the web API the frontend calls.

Rule ordering is unaffected: the controller sorts a host's rules by path length descending, so this one is still evaluated before `/`.

## Verification

Against the cluster's own API server, which is what rejected it:

```console
# the manifest as it is on main
$ kubectl apply --dry-run=server -n sentry -f ingress.yaml
The Ingress "sentry-cloudflare-tunnel" is invalid: spec.rules[0].http.paths[0].path:
  Invalid value: "^/api/[1-9][0-9]*/": must be an absolute path

# with this change
$ kubectl apply --dry-run=server -n sentry -f ingress.yaml
ingress.networking.k8s.io/sentry-cloudflare-tunnel configured (server dry run)
```

And the whole kustomization, to confirm nothing else is waiting behind it: `kubectl kustomize apps/clusters/feathre-core/base-apps/` builds 111 resources, and a server dry-run of all of them reports no errors.

The comment in the manifest now says why there is no anchor, so the next person to read it as a mistake finds the reason instead.
