### PR TITLE
feat(sturnus): add the encrypted secrets and wire up the generators

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sturnus/kustomization.yaml
+++ b/apps/clusters/feathre-core/base-apps/sturnus/kustomization.yaml
@@ -9,15 +9,11 @@ resources:
 patches:
   - path: release.yaml
 
-# secretGenerator is deliberately omitted for now: sturnus-secrets.sops.env
-# does not exist in this repo yet -- SOPS-encrypted secrets cannot be
-# produced by this task (see sturnus-secrets.sops.env.TEMPLATE in this
-# directory and the task-9-report.md it was written for). `kubectl kustomize`
-# on this directory builds cleanly without it; the HelmRelease will simply
-# fail to start pods (CrashLoopBackOff / ContainerCreating on the missing
-# Secret) until the real file exists. Once it does, add:
-#
-# secretGenerator:
-#   - name: sturnus-secrets
-#     envs:
-#       - sturnus-secrets.sops.env
+# The chart references this Secret by name through `existingSecret` and hands
+# each component only the keys its own settings class reads, so a key missing
+# here stops that one pod at CreateContainerConfigError rather than starting
+# it with an empty value.
+secretGenerator:
+  - name: sturnus-secrets
+    envs:
+      - sturnus-secrets.sops.env

--- a/apps/clusters/feathre-core/base-apps/sturnus/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/sturnus/release.yaml
@@ -35,10 +35,10 @@ spec:
       # /oauth/callback).
       STURNUS_OUTLINE_BASE_URL: "https://outline.onelitefeather.dev"
       STURNUS_OUTLINE_REDIRECT_URI: "https://sturnus.onelitefeather.dev/oauth/callback"
-      # Fill in from the Outline OAuth application (Settings -> Applications).
-      # Public, so it stays in plain configuration -- only the matching
-      # client secret goes in the secret.
-      STURNUS_OUTLINE_CLIENT_ID: ""
+      # From the Outline OAuth application (Settings -> Applications). Public
+      # by design, so it stays in plain configuration -- only the matching
+      # client secret goes in the SOPS secret beside it.
+      STURNUS_OUTLINE_CLIENT_ID: "kicsnq6nr7dy56efy4r9"
 
       # Internal RGW Service, not the public s3.onelitefeather.net endpoint
       # (same endpoint the CNPG barman ObjectStore and the bluemap render Job

--- a/apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env
+++ b/apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env
@@ -1,0 +1,43 @@
+#ENC[AES256_GCM,data:5oRBXJ2lmCfts/Zv2v1AKlQ16B85S0y7fp/b4kpbVgPtmw43j+8WxFwbwOW4H89TOYAqUtOyal2nTHuTYgqob+SKvzlF1lWK2iFj,iv:NbqokdflLvk6+eQ8+VSBr2m9ZYE9AlWsJYxf6hC/rxo=,tag:CdDWpLSIcQzRlQ8epryCgA==,type:comment]
+#ENC[AES256_GCM,data:2PGGRzc+MHmjq07foQan1pDnpUFhXjJ0JeGMQAxDaSrnROwSc8Guw6AuZVpN8uaSqvZwz/zg71g4dqTHFYdHOF4ibVJlRNfcrenDZ7L3T1xyrKa1Kikro1Ez67qyBlJr2F+kj5qgcG1gJidz0ssJBiQdbj6D1DbblO68,iv:5tM+P7U1v9G+70mwTooQz5ZQa60FKTiPFaS9VQLx+7Y=,tag:GYDDcunilW9o08qhoB+2LQ==,type:comment]
+#ENC[AES256_GCM,data:bIbW4N0efV567DpHDWr44kVjCz9/6QuUHaOCWa3N7LR349UrLqh47+WvqWyJC/0nWaYrETFq9SZy5m2b1R8xZ2qy4C05FOdMpaG2,iv:LWcA0yoxfrzPiVYAhJP6CrafQC825grNoirNiAL+qSY=,tag:XRe5VvzgKPh2qhp6bDbhsw==,type:comment]
+#ENC[AES256_GCM,data:9s2xzIniqxh+mHsUP/4=,iv:kznzR+sg1lI+0rzWvSNdFfa7ibqLFUcxkfYzhoaX3QQ=,tag:F19pfk9CJWhfw+/FbYWkwA==,type:comment]
+#ENC[AES256_GCM,data:8dThP9KhCn31iI7ZlW2P71C1SWIurf/3kQImIs4GM5sFWSQ1H0KKU9niXkfYnuhUvLNNixVywoJj2Ok3oWtQ0GaHwQMWTsm3sx37xuj5,iv:rPsG49zALFUOABonYYqIMnYfydxymhRY2NhCv4yTceM=,tag:W4lYjmV8PZ2khuuYqKgRYQ==,type:comment]
+#ENC[AES256_GCM,data:vY84Gv9Zbwfz4KCCcE+YzH7X4GWFI3fbrufRqvW8BQ+kd3PPWiL3H33ouoqiQATEpa8kUHGVBbRDz2+wjtD4lUD2i0uLHX8=,iv:drFsLKCad95FgdWSqJNNzadHS5MiunZ7JVeKJ9iZDig=,tag:XHticrp9abl/Q7hBVgB3dA==,type:comment]
+#ENC[AES256_GCM,data:AdGULpvsZUfXwhdLbPOAIenonehVsoHEnrPRCOs3tVtR/3RduBo9mTpllBkkirk=,iv:lQJndXCcDoIEHJn3yOZhJRZ9W25BjR1TON3ey9e0x38=,tag:tKGAzmX8VimH+anQTpFcfw==,type:comment]
+#ENC[AES256_GCM,data:Exz2/fVk9MMKS5btS6gksBXNMRsDJZZvPVA1L1FMpT47WM+Qhc5UObCLHGeEBm1KDUoqvNAoVOwKt2YwSJRCX7A+0mq+qS7MoA==,iv:scygBH9mYEm8eUpNAMlSO57nerLVjBBu5qYr0tyL4LA=,tag:XRiypb5R51T6bjTwgmBS4Q==,type:comment]
+STURNUS_S3_ACCESS_KEY=ENC[AES256_GCM,data:DhYjd82FLdFntw9ffs6xPvVFvA4=,iv:JsQH4dikxv959tKqCjDwN58/ZpJ/zLVAbVHh/Kp+sKg=,tag:RmBZTxPZzk5FiUDmmOEYmg==,type:str]
+STURNUS_S3_SECRET_KEY=ENC[AES256_GCM,data:8e848LIt6tzd3PYde3e/7ATQnhY7lgK6WnHLIlsduNypY+LOEUoM+w==,iv:Xtaz/QOOqGn7nndKkqcw3UccAe/7fnuvoAQ3av/N46Q=,tag:Vysp069aoDJGn4ciLP4pgw==,type:str]
+#ENC[AES256_GCM,data:4g4c9q9WtjzfBI46t0/5rv6q7GBOVkukD4P5wbM91DsUt3ZOwmPsrt8IGUpcu5IvkFLYHoR5,iv:m6haruIfDbGDcFPnrccFh5LjdztflNpUJ7qXGaVcHoM=,tag:DIgkx8tOholBz76RPDa3nw==,type:comment]
+#ENC[AES256_GCM,data:XmI6mG2NxWk80lMRmlFMndPaMlfIuoJpx4ePHdlyhQK2IIoW5eEnVylOJNxoBpA1aMSWmKIFchZdgQv6+1fxDNv9cArXi2YFliwZQAr+xms=,iv:CAZSv0pJOEEOuNdutSNfs3/7vy0KKZkPgX5T4b0e7jk=,tag:A9W0JTlHRLS1SODSxacEAA==,type:comment]
+#ENC[AES256_GCM,data:S5moA4pTMA1/CY448WlDUG7/ymMm0Kkv01RQl1MPy5odx9RvbnZFQyDpyuAjFeiogmYtfmSmUOo/rFGYnd7NlXKQVa+wVwHGOY0=,iv:p6zYuNvuV0yI6rRkD9Wf8+zIuSBwdP3FB8N0BbnSW8o=,tag:pGVx7EY+zk757SzKOAdZcA==,type:comment]
+#ENC[AES256_GCM,data:RM93+V9ejDChooDZwhnwvxmi65yG4bEslRrtcSTUqTVFQC0XphFuYwgKY9sP3JO1Plv6364JGYe9L+0=,iv:SLV7BMVSY8ZA5utLAAiqNsuM2nYJ5GkKAkSp8/vcdgs=,tag:8L+u1W8p7ZgacaD3cxb4aA==,type:comment]
+STURNUS_DATABASE_URL=ENC[AES256_GCM,data:i1miO2v9LKjHcJOA6t94LvQ5Pzv6HJMoWDnQPy5Sw/N0zZwIZVNPBeP1hoavJYjRUSdbIrOgrFl+ZQzqyrCT+hd8diz9NzoxLxik4ExY8cZOTVcSkQoqXqcCcReOdpAvdCbJ9hTEC0ETC60NG2tXeewzPwdq1253S77lqVmH8IW/Kpf3hgjUmw==,iv:B+/A2tM6pLEZBj3zbUUDaaRDSXbF6kmt4cPIWAHl4vM=,tag:K/a1HguiFYVCHt1DJFFbWw==,type:str]
+#ENC[AES256_GCM,data:A8S5pf0IxsXTvDXSSi4KRe/zAwIK1VFQql2YM+ezH/qUwC+y/Mk5WL3AYxQN+WetOzHjaw5/zrWpyi2bDCBb1H04lZFh6tc=,iv:3yN1opCErnooBGdIrj+2c43sBOdL2qa7b7CCKG97L3k=,tag:3b714MJH0ZWPlN5pdtV5YA==,type:comment]
+#ENC[AES256_GCM,data:PHZ92JyjOaIV2r5Zk0FBuO+VF4CmDVbTg9twpmiETVXGcLVu+LPOkzaXSB+IKJW/4pb1XmWx7fjIbyPfa2EX433AmSFT,iv:AAN2oWg7F5JkBOrBS3d86B+X09h04mdPqS92ujhFY0U=,tag:JG8rrQnU+R9yAwLgxc8lew==,type:comment]
+#ENC[AES256_GCM,data:A3bRbhwtRHfE4KLlilD8J4cbNJ7fowUh4G/BZf+GgfkcG0qHO1oAXlG55zMC2YPznA25mScQKlaU8LHF6rwxawLLGjl+OfOTs1c=,iv:KeAIOFkFRoa6MenNwr17bnjjbZAZPUg/renEbEHArhA=,tag:FGZcnyzhpQibVUnvg+htOA==,type:comment]
+#ENC[AES256_GCM,data:mckjK3jmsyrg+3R1WE1vKUIYh5QgCiKAMU3XiCFSpYK5FLVs2pO4oHn/ORCRbP+NDgUJ/5w443nhMQXLZqs2ZvYsqc32ibis,iv:UUn0+naRtiuYuoJuZkakeMT99zIkpb9RAqJpI3qACNo=,tag:Hbd9TE9Fz2cUhq+Cgs6GHg==,type:comment]
+#ENC[AES256_GCM,data:DtdB/Cc253988ysefExPq5sBef+FBUpEDiAv5E7jFy8SsWyH13IkHETSQFX4T+ro2z00M6hwxbkxh4UfU+APK67WcjwKJBaMd1CpwRfqXn9BBMWZxE16tPYEH+3Wqu6D6MjQ+dFEZkTVrIo=,iv:cPHes+WbS5KeMfdT1rfPr1CKXsioW/mnQG8CF8SAcE0=,tag:7eUsM9Gft0T2mXse86IHSQ==,type:comment]
+STURNUS_MASTER_KEY=ENC[AES256_GCM,data:j5dBFMpF7DB9gOo/pvkU98jlJwmfLOdFTMySOz5M6RQTNX/7X6y3emN3iLA=,iv:lthd09FaHdbMvDWsKL/sfu9iiV0OUiO20Din7tzGo2I=,tag:dyMkmYZ/0WzRPqZPQ5EJOg==,type:str]
+#ENC[AES256_GCM,data:KyDnRVdPGOrvLtduQqptM0n5tnVh1UHDe6vCJInh078c3YG6EYdH/DYayF9+Er6Kh0cp1T1VlOI0zbdCITxomV3Ei9EPyb8P/vZrMdFJ,iv:9GWTCkUZTpYfJeEi+Ybgw/g43H/5jaa2CzrEfzInp9k=,tag:rHwhEtn1zmv3F2E72VKspA==,type:comment]
+#ENC[AES256_GCM,data:Y993Relhb5UBx5MqPoJvLXGCGb12sF9S1ia+EaSrQTQmTT3v24YwSk3jlYFmL6P0d6olyCcPtjOwdUinZjheIQQ/Z/U=,iv:tQ3PjLlYYMAERmCJZSAOw3EPOHsPmpNJf5MZXf+UWpo=,tag:+nUiQiPlKhEB6cAjtdgK5g==,type:comment]
+#ENC[AES256_GCM,data:wiVg/xFc3a/aio/SUTDwDMrgFPzJWBiL0hgNKSmlMqT25iG3NxtvjvxlQkAE5uUbO1ChDgheTNSiQmtuET4PtjQ4WHMMDGPc,iv:Xxm5yrbICoAb0LAYnEsJhqpf/vo+DcfiRl9NxEyWuko=,tag:xDrpOPl2eDu1R6JjNu6nmQ==,type:comment]
+STURNUS_DISCORD_TOKEN=
+#ENC[AES256_GCM,data:9MTp+ahUzY6hwSjboc4xOjy+HYdowwGiRLRDnvx0alxU9OwBgwzOd3OpcJiGCK0s0UHA6ufyO3boHwaPyHG0f9u5CBL7fUK+,iv:P032xDpb59yUjq4wyrGRexoUnL6JS6+a78h1BdbldwU=,tag:eyYsI3Fjma0lKLlvPBE9hw==,type:comment]
+#ENC[AES256_GCM,data:lcpoF8YWC7+PDrvcTP7ReN6vM1nvB41N56JqibsmRUS2wDEEaSJX3gOcx1mipC9oMb+HWoED0HPq4VT0lJH7YJpMt9l8tXjTC54=,iv:ouryd1FGNjCrNe36ASRL0ey6asyNt2TuE7WywR+WKxs=,tag:mk+VzPLcEe2SYs5lZMTjPw==,type:comment]
+#ENC[AES256_GCM,data:C+5sIPL79I2Difr+GQmD7TfJ,iv:Yhuzf2gchalEscmXN0QQwexHU9GbUHoKVZUCRvp9Gaw=,tag:bvmcrMlgO9PhpgaW6IOLLw==,type:comment]
+STURNUS_OUTLINE_SERVICE_KEY=
+#ENC[AES256_GCM,data:uuLqPJVHBzSMBtyaY/VvH0uMBd1FlaYeE6TRbEWohHRhLM8AXevLa7M/yDFGZNSNkxd6z/hyW8HjngP0HvEiupxvxiMnW+5i,iv:dhtvJfxBTJd0Ta1YDF3Py143BPfcgrUE1HV/4jfmP7Q=,tag:dwY8YRJYEPGSvdRRDF6hnA==,type:comment]
+#ENC[AES256_GCM,data:VOfczebRONQNbvkXRDAr1W4ZR+uWlcN8+BR6K5Q6AU6zh8XaCyse1vQK3eJ7bUdJ0fvlx9mAIW92J7Hod+XAoYrghndmnAXX8/8=,iv:H6CxjktTm/v9MFNVZAjWMigLr/MDgMneMz/totl4mlg=,tag:IPEIYbX615vDVnVQnYCKsA==,type:comment]
+#ENC[AES256_GCM,data:eclEuyMvHYK4yFte2Ue+fAZMoPwr2RpDf8adeJr+btN18xAoBZ2Kv8B9FbeeaPm0HOz9Ut2s3LqcfNu0AIe3dDlfvCzR,iv:+IuR08aJhFyMzgz/Ck1DWVXGSks9tmcvg/fqTS4tUPo=,tag:LolRrFtRLk4xL6IrWjyfAA==,type:comment]
+STURNUS_OUTLINE_CLIENT_SECRET=
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUN0xZTU9UWGY4UjV6dmU2\nMG13TGFqd0JrRnY5TU4wbkFFQjI0MXVzc21ZCkJrcEJ5MTB5Q1gyUFBaL2pSbjh1\neGQrdWdUT3ZLOU81STFxWlRtdW5nbUUKLS0tIDhwODlDZytpUHBhQ1A2ZDZaUzVS\najlyNzdzVWV2bXNrN1Z4Q3ZNVWROOXMK2n85nr/fN1oWU3Jt7zFHoQMRsg2dFAJe\n56SfAq7mASAQwaP0PtUru+Trnvts6eqlGAfzXaZ0ze2f7o/+onofZA==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1kfcggatwrwslka8sssdw2sy05jwntft84cw979gkvzp9wksnyy0qllsz8s
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPMmsrSG0rbnhpcUN5RFhp\nRVhPZ1Z6bWNucmJYbGcvWklKYmZQaTNrU0RzCnRjRFpPQnZvbWgzeEhWVFpwMFh5\nN3N2ZHhhN2w5ejAyb25oY0V6M1ZIeVEKLS0tIDdaMVdQNm5iT0tmU2x5VHl5RXZB\nai9xQ01sM3FGTkl4K2NsaEdtdHNBTjAKljBYMMRNuV3wMjmI8m3YU/5LgdmUBCKk\nv84boSBb28xNj3MZ+qPyG+UZclZ1yq7YGPqu/NHvu0rXBQGdNK6YUA==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_recipient=age10x4xtzptvjztg9jkxr4m5luw3mfyqwww499lgnnqx32h2xytu5nqkjwqaq
+sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwb0o1QXlCVktKNUtiSzkr\nZFUzaEZsaTdURmFZazZobmRmS1IrazBuUTFrCmMxTUpIMXlHV3ZvZ256MGxWR2tN\na05xWEIwTkZybmZCaDFBSWQyN3RQU3MKLS0tIEIvdU9aU0VmbnZrYm5QNmdHZElT\nU1V5NWhKUWt0ZEVJZHM3RU94MXZrRncKwulWLIxgxOK2z6YrOc6DlzqDeD5piZTQ\n2SKEvwhBCKVnqhTBIKGDBGbBRa/hoZql+qDgl/Go3HKlwPEC9WJo6A==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_2__map_recipient=age1rrus5c38flq6yg6l56d0cecgzap0fhdew64n7ygz7lngjwpzws4qcnge3x
+sops_lastmodified=2026-08-20T12:31:11Z
+sops_mac=ENC[AES256_GCM,data:aJxcKpHTWsdtvqHX26SxN/0R/tuJMLQEBmBdu72NA2XiM6VMLGhCzt05fAt3VXT2ScDQPXtW7jgOxRRda03GLWvn3cE3g1TkkuK/16UvuXZc9YjD4ffXifVpqoIVf+VnaXJdBZCF/QXUxxudV4YQTHsJ+7TwoBHb36G65LEqnXk=,iv:t5/CJ/0CN1MmHW6PyFSh3Q0rATK7G6MWgOYkTgzMoMs=,tag:pJ8L8/aZPNzwvK+3YN8Ivw==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3

--- a/infrastructure/clusters/feather-core/configs/postgresql/cluster.yaml
+++ b/infrastructure/clusters/feather-core/configs/postgresql/cluster.yaml
@@ -100,9 +100,6 @@ spec:
         ensure: present
         passwordSecret:
           name: role-vikunja
-      # role-sturnus does not exist yet -- see roles/sturnus.sops.env.TEMPLATE
-      # in this directory. CNPG will fail to reconcile this role (and the
-      # sturnus Database below stays unusable) until that Secret is created.
       - name: sturnus
         login: true
         ensure: present

--- a/infrastructure/clusters/feather-core/configs/postgresql/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/configs/postgresql/kustomization.yaml
@@ -27,12 +27,12 @@ resources:
   - database/sturnus.yaml
 
 secretGenerator:
-  # role-sturnus is deliberately omitted for now: roles/sturnus.sops.env does
-  # not exist yet -- SOPS-encrypted secrets cannot be produced by this task
-  # (see roles/sturnus.sops.env.TEMPLATE and the exact stanza to add once it
-  # is encrypted). `kubectl kustomize` on this directory builds cleanly
-  # without it; CNPG will simply fail to reconcile the "sturnus" role (see
-  # cluster.yaml) until the real file exists.
+  - name: role-sturnus
+    options:
+      labels:
+        cnpg.io/reload: "true"
+    envs:
+      - roles/sturnus.sops.env
   - name: cnpg-backup
     envs:
       - s3-backup.env

--- a/infrastructure/clusters/feather-core/configs/postgresql/roles/sturnus.sops.env
+++ b/infrastructure/clusters/feather-core/configs/postgresql/roles/sturnus.sops.env
@@ -1,0 +1,17 @@
+#ENC[AES256_GCM,data:qLQY2QElQTjewF/O691AzvEezRhRuGo6hz9SNgdVX0/9uUu1QtzbiRJ6/PfU4mroldOsfYGtAWNhcn630R1F+pixjyW4qP6om3Gc,iv:EptbExw391orqLBq66JTIC+xjKvPUnWak0tpq09EiMo=,tag:zvfXRwkY7EYdj7IykrUutQ==,type:comment]
+#ENC[AES256_GCM,data:3mK7hD0YSR9O5XsYu9D69nxzXkgOSvx6Az7O1ukrZQ==,iv:UpJZGuH+t3mlqA2rRK95+8QoR/BIlm70Y3vnfzq1J5U=,tag:sqihGaPzKZROIrZGrZSICg==,type:comment]
+#ENC[AES256_GCM,data:GON+fYlwF1AOqnZTwqaDakufRaL72KGZq93OEw9uMituQIU0iW0sUL0njfua/bsKibnFblbcaYg9EAflVSCftlbbI0qNtUEfRQ==,iv:ITk88aMN6JlnImB9m4mArJ4Cbu2fUaIx1ZPzScBBoDo=,tag:wfJkKXh6vUbJ84ix6WevCQ==,type:comment]
+#ENC[AES256_GCM,data:F94p6Z2OtIbIBvbIPL+818h/aSZ86zxt0+4AWV0IvVTt6do/+2v6M9w3YhOuYmgW0b9cfUahQ5jiO6I/QA==,iv:JPhAsEJlnIExQ/FO4URBcqm6vF4MZnyyVMwcjBGIuYs=,tag:LAZ21UbY/np7YUPrXVft4g==,type:comment]
+#ENC[AES256_GCM,data:CeAu8GlfC8KJklY+8U6QCJS5M7vkRaTOivDM35JrmB0ZJmw77g/k/6PRIjoO0BWl,iv:9fU7KN5jwyw0FQKjoG8Uzc/EIwW9EmMNbhvWfcaeBXE=,tag:NWJEw0Mh78QzLmLsuGzAvQ==,type:comment]
+username=ENC[AES256_GCM,data:HKuEJSkAaA==,iv:ctGnJb9a2J+sx+EAe9r/DiKEoOtxUxa7VD6sS7EZpyo=,tag:U6Pi18miCYn8yhSH2zCABw==,type:str]
+password=ENC[AES256_GCM,data:Hp9zIsMLxhpXsQSc+lcMZJYsN3HrcKxmTuIjOAAI,iv:pD7YLM5pK1bYSdK5iwLnf9RUHoxoti1a5lGvUb5USnY=,tag:MSpODmIvLXAqkFpyZCZ0Tg==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaMm9scHJlUWVZaVVIVDdp\nNHloL0xCT1I5Q0pjY1lsajd6QXNmU0NMT1JVCldvbkVXMlNsNUcrZ2UwK2Q4bVdN\nWXc3VjlKdFhsTHZhdlhEdGJSU0F2TjgKLS0tIEt5NXkzbHc0bnJ0VC9Yc1JYRVpn\nMDV6eUpJekpSUUxJUXRLMk40d3d6Vk0KPBpxLU1aAn9ubmJNC/eY5YP2Idp4XyOK\no+fpkVJ3Srw20TKvKRMMVbdf5OF2XTbny6djErt0YkfcoyIoYx6rsQ==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1kfcggatwrwslka8sssdw2sy05jwntft84cw979gkvzp9wksnyy0qllsz8s
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByM2RJS1dPSW40YWNYOW9H\nUFg2dDlyQ3l6UVJ0bWhEK2FRTkdHQ3JYVmo4CmNPR0VsUmYrUlhPQzRwcnl0OGRJ\nUlhEMlU5dWEyYUlPZnhvR2FYTXVxTmsKLS0tIDU5azFvZy9zaTUwWGFmUFZteDhC\nTUpRNWt0SkhuR09Oby81UFAyNWFYaWsKQKmNU99uCitTQHiR0YlPV4OgWW82jyga\nacKZx+u+NYqZFWWxJFhT6qJn1bwrQs1BOKlzsWOUQunfazTnzyFXDQ==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_recipient=age10x4xtzptvjztg9jkxr4m5luw3mfyqwww499lgnnqx32h2xytu5nqkjwqaq
+sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSMzdqZmIwOWdQTHFzNjJ0\nbHNwc0lhUk1USUdSWW9WYVBKWnFLU1lKekhjCk1yRmc5SXFjcTYwZGI5RHdxWWZE\ndnFpeHFkZWJqVFRFVWdDUEhZTU9wZ3MKLS0tIHQ1L2x4Y1RiUkNRN3pHTTJQN3FE\nOVJpREF2ZEd2UzVvNGtpeG5uNXlZSWcKpG3Y/hQH2S6PyF7WHw816w9D1Ej1AWWw\n2T7fMxtxMQqD40qVseBQp1w0AKEFEDi7yv3g5d+VkwyEzGhBRXssuQ==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_2__map_recipient=age1rrus5c38flq6yg6l56d0cecgzap0fhdew64n7ygz7lngjwpzws4qcnge3x
+sops_lastmodified=2026-08-20T12:31:26Z
+sops_mac=ENC[AES256_GCM,data:8UvoeyxHG2/4eZYkl26cPCwDTIl185BflTeV7Vv5/b4jYdriirpN0bWn/HMYxzPxE9LrEVzUv1nXZTGYyzf7mIQNZLCrgRduXvIANeXUN+GMKQoLrF+3nYA+sA2S/Qh+2sn9xn7wtrvvBYLciiWC42cYWm+TsiRnFtUp3y4Pcos=,iv:Vbuniz/ld/Q8RwvsxhSHB1J99icONUOm0gtCdp2izxQ=,tag:m/vjUQCC7BchSO8hFPCe7Q==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3


### PR DESCRIPTION
Prepares the Sturnus secrets so that finishing the deployment is three values in an editor rather than an afternoon of assembling them.

## Four of seven are filled in

| | |
|---|---|
| `STURNUS_S3_ACCESS_KEY` / `STURNUS_S3_SECRET_KEY` | Read from the `CephObjectStoreUser` Rook reconciled for this bucket. **Not invented** — Rook generates these, and a made-up pair produces a bucket nobody can write to. |
| `STURNUS_DATABASE_URL` | Password generated once and written to **both** places that have to agree: the connection string here, and the CloudNativePG role in `roles/sturnus.sops.env`. A mismatch fails with an authentication error naming neither file. |
| `STURNUS_MASTER_KEY` | 32 random bytes, base64. |

## Three still need a person

```
STURNUS_DISCORD_TOKEN          Discord developer portal -> Bot -> Reset Token
STURNUS_OUTLINE_SERVICE_KEY    Outline -> Settings -> API & Apps
STURNUS_OUTLINE_CLIENT_SECRET  Outline -> Settings -> Applications
```

Edit with `sops apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env` — it decrypts into an editor and re-encrypts on save, so no plaintext copy is ever written. The file itself names each one and where it comes from.

The OAuth **client id** is not among them: it is public by design and now sits in `release.yaml`'s `commonEnv`, next to the base URL and redirect URI.

## Back up the master key before the first recording

It wraps every session's per-recording data key. Losing it destroys every recording it wrapped — a database backup does not help and neither does an S3 backup, because both hold the same unreadable bytes. To read it back out for safekeeping:

```bash
sops -d apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env | grep STURNUS_MASTER_KEY=
```

Everything else in the file can be regenerated.

## Generators activated

Both `secretGenerator` stanzas are now live, exactly as their own comments described, and the "does not exist yet" notes in `cluster.yaml` and both kustomizations are gone since they no longer describe reality.

## Verification

- Both kustomizations build.
- The two files are SOPS-encrypted and not gitignored — checked, since an ignored secret would leave Flux with nothing to decrypt.
- The connection string's password and the CNPG role's password are confirmed identical, without printing either.
- Rendering the chart with this release's actual values and this secret's actual key list leaves **bot, worker and link each with nothing missing**.

Depends on #188 — `base-apps` cannot reconcile until the Sentry ingress path is fixed, so nothing here takes effect before that lands.
