### PR TITLE
feat(sentry): send mail through mail.onelitefeather.net

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sentry/kustomization.yaml
+++ b/apps/clusters/feathre-core/base-apps/sentry/kustomization.yaml
@@ -51,3 +51,9 @@ secretGenerator:
   - name: sentry-discord
     envs:
       - sentry-discord.sops.env
+  # SMTP password for system@onelitefeather.net. The chart wires this through
+  # the shared `sentry.env` helper, so every component gets it -- mail is sent
+  # by the workers, not the web pods.
+  - name: sentry-mail
+    envs:
+      - sentry-mail.sops.env

--- a/apps/clusters/feathre-core/base-apps/sentry/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/sentry/release.yaml
@@ -43,6 +43,22 @@ spec:
       adminEmail: "themeinerlp@onelitefeather.net"
       public: false
 
+    # The chart writes every mail.* option into SENTRY_OPTIONS unconditionally,
+    # which makes them all immutable in the admin UI ("configured on disk").
+    # Mail is therefore only configurable from here.
+    #
+    # Submission port with STARTTLS -- mail.onelitefeather.net advertises
+    # AUTH PLAIN/LOGIN only after the TLS upgrade, so useTls is not optional.
+    mail:
+      backend: smtp
+      host: mail.onelitefeather.net
+      port: 587
+      useTls: true
+      useSsl: false
+      username: "system@onelitefeather.net"
+      existingSecret: sentry-mail
+      from: "system@onelitefeather.net"
+
     config:
       # Makes SAML with Entra ID possible at all.
       #

--- a/apps/clusters/feathre-core/base-apps/sentry/sentry-mail.sops.env
+++ b/apps/clusters/feathre-core/base-apps/sentry/sentry-mail.sops.env
@@ -1,0 +1,11 @@
+mail-password=ENC[AES256_GCM,data:CwdbLQK6ol/lSUQS0GcWmsYr5NyUpBjLkSUvstU+Ui8=,iv:oq4397OtzfUsQnVVZUQmPGURXHQO7CiyE8yJk2BLiAs=,tag:ug4AEabaMoL0SzFiad2/cQ==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBka3RZa2pJYzVHNDRJQ3lU\nT3AxQmludEtERFgvdEMwTUZONysvbFZCOW1zCjc2eEExMm9mMFJRc1p2ekNHUHlu\nb296QVNzN3FkVVlEd0k1TEpMcFJWNDgKLS0tIHVwR1hCYmdXalBockY4S01TMGsr\nL1lxVzNJM3pLMTVQaGcvSEw2MEE5bkUKv/D9zttALDtX9eqAmuWsg/hkEWwlI5V3\ng3AzomAnaqDAiK3qQdC1cInWSc3Q5kr/JoUtBkWzds/x4t6lomH/cQ==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1kfcggatwrwslka8sssdw2sy05jwntft84cw979gkvzp9wksnyy0qllsz8s
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCRk5DK0pqYUtlaVdLdnhN\nSTd0U0trSm9qYmp1d1ZmVjc0WHFHTm05MEVZClVYMVZ3TWpIbk5sUVkzcDlhZCtE\nZzVFM09kSUxqUHhYMUxrNVprUS94Uk0KLS0tIGV0Z0pPUDl5UGc3dXBXN3F0NXRP\nU2psaHZoenRhVWx3TDhzQ2hWZHJBeVUKocrMMQRgN5M76OX+EbUgQ4g2QVyelOsP\ne8IfiEupfjD3zkeUI+61ze41QEmJdB0Fa1KNvMPCvfvNltOpKt7w5g==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_recipient=age10x4xtzptvjztg9jkxr4m5luw3mfyqwww499lgnnqx32h2xytu5nqkjwqaq
+sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGSlZtcU5Va0g1TkxoVVk0\nN1hpU1pHMHVUajhPanFLWlozeVVVTUFvOWpVCmtIK1VCeVRsODdLSFpXZ2VCKzl2\nU3lBNFloWCtXUk5XdVBYbHlrTFlQYUkKLS0tIFJiY2ZlQ2cyam5PZVlVN1NOVXBI\nQ2UxbXRnZW5zK2RTWklyMTBUR0N4K28KAillFY7XSpHlKsS61ME/jNH8cbjacfWk\naH07K9wT4XMGLvMY9NyEQ1e6niK/BGPFzQwiZQndScB7mlUWrJWUEw==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_2__map_recipient=age1rrus5c38flq6yg6l56d0cecgzap0fhdew64n7ygz7lngjwpzws4qcnge3x
+sops_lastmodified=2026-08-20T16:25:22Z
+sops_mac=ENC[AES256_GCM,data:rCYHeXuyLkCSg+lWuC+2/h0IzPDu9VSkeXQdLRCOPfyRSckaYKJD+4FZyx4ognQ2oY0Y/Hm2qXBzfEouB4Etkpo0td47SJAn2I3d5Mi1+S0MD/bb/LL9qWq5/cTxqLDJBzip+Dy/nc0sVd4zV2j6+tIxO47DfF4kw1RiabBsvx8=,iv:3wyUfsYRf9AtKIrAGcj50AxuYTtSc1srq9WpwebYGSM=,tag:CyI0Y+DngI+tEiKGu+nxVQ==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3


### PR DESCRIPTION
## What and why

Sentry has not sent a **single mail** so far. The chart writes all eight `mail.*` options into `SENTRY_OPTIONS` unconditionally in `templates/sentry/_helper-sentry.tpl` — even when we supply no `mail:` block at all. Sentry's options manager therefore treats every one of them as *configured on disk* and locks them in the admin UI:

```json
{"error":"immutable_option","errorDetail":{"option":"mail.use-tls",
 "message":"'mail.use-tls' cannot be changed at runtime because it is configured on disk"}}
```

So the chart defaults were law: backend `dummy`, no host, no sender. `dummy` silently discards every mail. Configuring this in the HelmRelease is the only place where it can be changed at all.

## Details

- **Port 587 with STARTTLS.** Verified against the server: `mail.onelitefeather.net` advertises `AUTH PLAIN LOGIN` only after the TLS upgrade. That makes `useTls: true` a precondition for authenticating at all, not optional hardening.
- **Password via `mail.existingSecret`** from the new SOPS secret `sentry-mail`. It is read by the shared `sentry.env` helper rather than by a single deployment template, so every component picks it up. That is exactly what we need here: mail is sent by the workers and the cleanup cron, not by the web pods.
- Host, port, username and from stay plaintext values — the chart offers no `existingSecret` path for those.

## Validation

- `./scripts/validate.sh` → exit 0
- `scripts/check-sops-encryption.py` → 88 files, all three age recipients present on the new secret

## After the merge

The Helm upgrade rolls the pods. Test via `/manage/mail/` → *Send test email*. The input fields there stay locked (see above — that is the chart's doing and cannot be changed), but the test button works regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)