### PR TITLE
feat(sturnus): supply the Sentry DSN through the encrypted Secret

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env
+++ b/apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env
@@ -31,13 +31,23 @@ STURNUS_OUTLINE_SERVICE_KEY=ENC[AES256_GCM,data:5GO9vfSfYvnpcj5QRinfpgMR3darwwmx
 #ENC[AES256_GCM,data:VOfczebRONQNbvkXRDAr1W4ZR+uWlcN8+BR6K5Q6AU6zh8XaCyse1vQK3eJ7bUdJ0fvlx9mAIW92J7Hod+XAoYrghndmnAXX8/8=,iv:H6CxjktTm/v9MFNVZAjWMigLr/MDgMneMz/totl4mlg=,tag:IPEIYbX615vDVnVQnYCKsA==,type:comment]
 #ENC[AES256_GCM,data:eclEuyMvHYK4yFte2Ue+fAZMoPwr2RpDf8adeJr+btN18xAoBZ2Kv8B9FbeeaPm0HOz9Ut2s3LqcfNu0AIe3dDlfvCzR,iv:+IuR08aJhFyMzgz/Ck1DWVXGSks9tmcvg/fqTS4tUPo=,tag:LolRrFtRLk4xL6IrWjyfAA==,type:comment]
 STURNUS_OUTLINE_CLIENT_SECRET=ENC[AES256_GCM,data:kMIytB2cy3FIkNeUcYIIPfeiPaRqZ2iBji74kgF8BNqGsh4iF+k=,iv:OmTb0IyQRte7Fs6/7XcqIHeOg0NKdk9w1YZBBVZxMko=,tag:kDbxmQFdXJSmawRqU9VtYg==,type:str]
+#ENC[AES256_GCM,data:Rklw1Q6uh24C1KDk8oksWfPmFGg+JyD7CSD9riSqzpe9zxe4Q5jKdfU4h22fsGNODmsZOJX60qwgrcUdsFYQEvn7flqmXzhb,iv:WqcNlFM0aYRJVag2yuc02l/qPDtVu/txF9I0KALn29A=,tag:B2kkyJpiINfTyNw9+BdvpQ==,type:comment]
+#ENC[AES256_GCM,data:YXz37czDalTgh7yb54K03xxHmzx49j0R8HsKrg3XKLlMo6DxN8MAGICfXep4sBGwWVBYQwxe8Cake+3XMOyYTU508tkn,iv:3sT+/nDwUjvX1qDveqL8dgFaLN1KFbaI5GfPM4bnPFo=,tag:xg7mKmYmUcE9nWhpTErrug==,type:comment]
+#ENC[AES256_GCM,data:BbMa85ty8ajc/8pgr+i5l8Fx//Db4e0zbcTfVTg0RoyMaOZVR47bh6sZsJDJYE7EOthLqbh6W5IvRcLpOtP3h/61yRX4fJqKtZ8=,iv:weVMbsNdIRWbWYnREpC/AvuGy620sM6+eBYKwcPqLXo=,tag:1e0wMjfwsMU3AAduDnyF4w==,type:comment]
+#ENC[AES256_GCM,data:GUTVs46aQ/z+LO9efIuExSa9IoZ34vEhG9KldIVTidjkC786miP+m7M/FywlPbIW85ir6ijOSsPRQewL4SSViSOqsGlvu910,iv:coQG70KtAUP3j6+bd/VuR6JktoegkH16IV0+J3Y4ZYk=,tag:F9H8YRlsUtaklfI09PH7ug==,type:comment]
+#ENC[AES256_GCM,data:GlDcAB9/P+ukZzRo+42r8cqL5D4mMuqAym7sOZpZTow=,iv:Tq4CZ2Pdt/+CIfJ7onM4MmhfiOOVD0PWEyakPL/m7u0=,tag:QJ1N7VJrJdrVQINDPykTMw==,type:comment]
+#
+#ENC[AES256_GCM,data:C8DN/iJF8Nn/+KZ25KoiYGhCoCNazNgBuRdNgjQ2Oc/eQFl7hhQkGi4PF+AuxOWXnUBh1aisWrLzDnXKZA/zrnjJlhZwaK0naGpo,iv:Lk8qBjeD6rIXB9p+iO+r9hhVj+szUvnlCIxkH6rsfcQ=,tag:yYN0UwIO4txgwm7oe5oFww==,type:comment]
+#ENC[AES256_GCM,data:SECdDZspDrhcQzMeBQShZ41uA6/aJn4GmvMgxdCWkTqaWb2XIJG/ozTt9IYfzGe9xfDDQhkWGIMqJNVgsPpdKZnMK8NFRx339rrH,iv:VGUHxlG6lqYVWMhGOumNYDiYGaOLe+sEiJNOD8tdRCY=,tag:QizDM3DpWITH38j8jA+zpw==,type:comment]
+#ENC[AES256_GCM,data:mgcJPGCmthyXkbcEdHqzVTh/f5KfFA27qR99Obn8Vfusbc0UvuP5jD884TRWag==,iv:ug2vLfkeGlMUPpmDNBzbm4vCADyF4Q0Uj2ejjWxDXTc=,tag:EXMYSIZ9RFVWpQ1hqNJVdA==,type:comment]
+STURNUS_SENTRY_DSN=ENC[AES256_GCM,data:yc5cXFBx8/ALICizCpgg+LNzOmZCw0dG14FwGWU54gqNIYM2CqSRn2JmL1PxfCzLWx2ffnYufYh6ORlYqWbGsae19Cg=,iv:fIQbhk8yXpXO25JLCDW6lrrgwIWHgEtUQngBeGWG45o=,tag:K7KLZ+p4FYqukDMbEFY4Gg==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUN0xZTU9UWGY4UjV6dmU2\nMG13TGFqd0JrRnY5TU4wbkFFQjI0MXVzc21ZCkJrcEJ5MTB5Q1gyUFBaL2pSbjh1\neGQrdWdUT3ZLOU81STFxWlRtdW5nbUUKLS0tIDhwODlDZytpUHBhQ1A2ZDZaUzVS\najlyNzdzVWV2bXNrN1Z4Q3ZNVWROOXMK2n85nr/fN1oWU3Jt7zFHoQMRsg2dFAJe\n56SfAq7mASAQwaP0PtUru+Trnvts6eqlGAfzXaZ0ze2f7o/+onofZA==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1kfcggatwrwslka8sssdw2sy05jwntft84cw979gkvzp9wksnyy0qllsz8s
 sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPMmsrSG0rbnhpcUN5RFhp\nRVhPZ1Z6bWNucmJYbGcvWklKYmZQaTNrU0RzCnRjRFpPQnZvbWgzeEhWVFpwMFh5\nN3N2ZHhhN2w5ejAyb25oY0V6M1ZIeVEKLS0tIDdaMVdQNm5iT0tmU2x5VHl5RXZB\nai9xQ01sM3FGTkl4K2NsaEdtdHNBTjAKljBYMMRNuV3wMjmI8m3YU/5LgdmUBCKk\nv84boSBb28xNj3MZ+qPyG+UZclZ1yq7YGPqu/NHvu0rXBQGdNK6YUA==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_1__map_recipient=age10x4xtzptvjztg9jkxr4m5luw3mfyqwww499lgnnqx32h2xytu5nqkjwqaq
 sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwb0o1QXlCVktKNUtiSzkr\nZFUzaEZsaTdURmFZazZobmRmS1IrazBuUTFrCmMxTUpIMXlHV3ZvZ256MGxWR2tN\na05xWEIwTkZybmZCaDFBSWQyN3RQU3MKLS0tIEIvdU9aU0VmbnZrYm5QNmdHZElT\nU1V5NWhKUWt0ZEVJZHM3RU94MXZrRncKwulWLIxgxOK2z6YrOc6DlzqDeD5piZTQ\n2SKEvwhBCKVnqhTBIKGDBGbBRa/hoZql+qDgl/Go3HKlwPEC9WJo6A==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_2__map_recipient=age1rrus5c38flq6yg6l56d0cecgzap0fhdew64n7ygz7lngjwpzws4qcnge3x
-sops_lastmodified=2026-08-20T12:39:28Z
-sops_mac=ENC[AES256_GCM,data:bcWJC+2FHswNY9SdI0M5375myNI3AtNfF+On0Cz7fjIrEJc0VFzwaqeQWqLiIy+ZmvTxuHA8txGV4mofOwFPdPbzFq9MryOxjSo29Ylg6KE4hAabF9suCK1ZJJxVgFt9IPQjZc9Os1Vc2ENCEo2l1Mav+Fh24j/LcQxv+51/ZVw=,iv:yg7OVB8DKPEpLxxw8WMAhdbnVLi8pk8+xUduY6GjwZg=,tag:XSyWQMV6AZur1JTUCXHCEQ==,type:str]
+sops_lastmodified=2026-08-20T16:45:47Z
+sops_mac=ENC[AES256_GCM,data:YWH6ZmJPL80Aw34cFT/KOSwWHI4z+xu94n043EqnZLPsT+AEOpzjh4m+kf4PLD1nUQvb1XM9EuFNG195yikGbVP/5T9mTenlT58SQ9OfvSFdSvQ6XIV1KGRbeTtyztynKz4Be+u0c9pChF82LqP0xBeFRawgncXrhK8Xh9XV0sw=,iv:prN2JhwxUJhuJdfnJQzyriMhY9PU+WaupZHf41XHXOo=,tag:G5Nedr+NunVUfq5Xoqsp5A==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.13.3

--- a/apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env.TEMPLATE
+++ b/apps/clusters/feathre-core/base-apps/sturnus/sturnus-secrets.sops.env.TEMPLATE
@@ -7,9 +7,11 @@
 #
 # Once sturnus-secrets.sops.env exists, add the secretGenerator stanza shown
 # at the bottom of kustomization.yaml in this directory -- the deployment
-# will not start before both of those things are done (the chart's `bot`,
-# `link` and `worker` Deployments all read this Secret via envFrom, and pods
-# will fail to start / CrashLoopBackOff on the missing values otherwise).
+# will not start before both of those things are done. The chart hands each
+# Deployment only the keys its own settings class reads, one secretKeyRef at
+# a time and never `envFrom`, so a key missing here stops exactly the pods
+# that need it at CreateContainerConfigError rather than starting them with
+# an empty value.
 # =============================================================================
 
 # The bot's Discord token, from the application's "Bot" tab at
@@ -73,3 +75,21 @@ STURNUS_OUTLINE_SERVICE_KEY=
 # STURNUS_OUTLINE_CLIENT_ID, next to STURNUS_OUTLINE_BASE_URL and
 # STURNUS_OUTLINE_REDIRECT_URI. All three are plain configuration.
 STURNUS_OUTLINE_CLIENT_SECRET=
+
+# --- Error reporting --------------------------------------------------------
+
+# Sentry DSN, read by all three components (each calls init_sentry before
+# reading its own settings, so a configuration failure is itself reported).
+#
+# Not a credential in the usual sense: the key inside a DSN is Sentry's
+# *public* key, write-only to one project and granting no read access, and
+# Sentry documents putting one in browser JavaScript. It is stored here
+# anyway because THIS REPOSITORY IS PUBLIC, and GitHub is continuously
+# scraped for this shape of string -- a DSN found there lets a stranger fill
+# the project with events. Being unable to read anything is not the same as
+# being harmless to publish. Sturnus docs/operations.md section 1.4.
+#
+# Leave it blank to switch error reporting off. The line must still be here:
+# the chart wires every key with optional: false, so a missing key stops the
+# pod rather than injecting an empty value that pydantic would accept.
+STURNUS_SENTRY_DSN=


### PR DESCRIPTION
Adds `STURNUS_SENTRY_DSN` to the encrypted Secret, so Sturnus can report errors to the newly created Sentry project.

**Why the Secret and not `commonEnv`.** The key inside a DSN is Sentry's *public* key — write-only to one project, granting no read access — so it is not a credential in the usual sense, and Sturnus' chart documented putting it in plain configuration for exactly that reason. That reasoning missed where this DSN would be written down: **this repository is public**, and GitHub is continuously scraped for this shape of string. A browser DSN is unavoidably public — the code holding it runs on the reader's machine. A server-side one is not, and publishing it anyway invites a stranger to fill the project with events. Being unable to *read* anything is not the same as being harmless to publish.

**Ordering is deliberate.** The matching chart change is OneLiteFeatherNET/Sturnus#40, and it must land *after* this. The chart wires every key it hands a component with `optional: false`, so requiring the key before the Secret carries it would put all three Deployments into `CreateContainerConfigError`. An unreferenced extra key in the Secret, meanwhile, costs nothing — which is why this side goes first.

Also corrects a leftover in the template: it claimed the Deployments read this Secret via `envFrom`. They have not since the per-key wiring landed; each gets only the keys its own settings class reads.

### Verified

- The DSN is SOPS-encrypted — `git diff` on the secret shows no plaintext.
- The endpoint was tested from inside the cluster before committing, with the real SDK rather than a hand-built request: `POST /api/3/envelope/` → `HTTP 200`. The relay ingress rule (`/api/[1-9][0-9]*/` → `sentry-relay`) routes it correctly.
- `send_default_pii` stays **off**. Sentry's setup snippet suggests turning it on; Sturnus deliberately does the opposite (`send_default_pii=False`, `include_local_variables=False`, every data-bearing integration disabled), and for a bot handling voice recordings and consent that is the right default.
