### PR TITLE
fix(sturnus): repackage the chart on every commit, not only on a release

### DIFF
--- a/apps/base/sturnus/release.yaml
+++ b/apps/base/sturnus/release.yaml
@@ -8,6 +8,19 @@ spec:
   chart:
     spec:
       chart: ./charts/sturnus
+      # The chart is read from a *branch* (see base-sources/sturnus.yaml), and
+      # the default reconcileStrategy for that is ChartVersion: source-controller
+      # only repackages when Chart.yaml's version changes. Every chart edit that
+      # is not itself a release therefore never reaches the cluster -- silently,
+      # because the GitRepository does fetch the commit and the HelmRelease
+      # reports Ready with the old artifact. That is how a change routing the
+      # Sentry DSN through the Secret sat in main for an hour without any pod
+      # seeing it.
+      #
+      # Revision repackages on every commit to the branch instead, appending the
+      # revision to the chart version (0.4.0+<sha>). The image tag is unaffected:
+      # it comes from .Chart.AppVersion, which release-please still owns.
+      reconcileStrategy: Revision
       sourceRef:
         kind: GitRepository
         name: sturnus


### PR DESCRIPTION
Sturnus' chart is read from a **branch** (`base-sources/sturnus.yaml` tracks `main`), and the default `reconcileStrategy` for a `HelmChart` is `ChartVersion`: source-controller repackages only when `Chart.yaml`'s `version` changes.

So every chart edit that is not itself a release never reaches the cluster — **silently**. The GitRepository fetches the commit, the HelmChart stays on its old artifact, and the HelmRelease reports `Ready` the whole time.

This is not hypothetical. It happened while deploying OneLiteFeatherNET/Sturnus#40, which routes the Sentry DSN through the Secret:

```
$ flux reconcile source git sturnus -n flux-system
✔ fetched revision main@sha1:dc4e4fb…

$ flux reconcile helmrelease sturnus -n sturnus --with-source --force
✔ applied revision 0.4.0

$ kubectl get helmchart -n flux-system sturnus-sturnus \
    -o jsonpath='{.status.artifact.lastUpdateTime}'
2026-08-20T16:12:49Z          # ← 50 minutes before the commit it claims to have applied
```

Three green checkmarks and the rendered Deployments still carried the previous chart. `--force` does not help: it forces the *Helm upgrade*, not the repackaging, and the upgrade is a no-op against an unchanged artifact.

`Revision` repackages on every commit to the branch, appending the revision to the chart version (`0.4.0+<sha>`), which gives helm-controller a version change to act on.

**The image tag is unaffected.** It comes from `.Chart.AppVersion` (`_helpers.tpl`: `.Values.image.tag | default .Chart.AppVersion`), which release-please still owns — so images continue to move only on a real release, while chart edits stop being silently dropped.

Verified with `kubectl apply --dry-run=server -k` against the cluster and by rendering the overlay to confirm the field survives the kustomize patch.
