### PR TITLE
feat(sturnus): transcribe this cluster's meetings with large-v3

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sturnus/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/sturnus/release.yaml
@@ -72,6 +72,50 @@ spec:
       key: topology.kubernetes.io/region
       value: fr-rosenau
 
+    # Brought forward from Sturnus PR #44 ahead of that PR landing, because
+    # it can be: `worker.env` and `worker.resources` touch only the worker
+    # Deployment, so the bot's pod spec renders byte-identical and its
+    # gateway connection -- and any recording in progress with it -- is not
+    # disturbed. Verified by rendering the chart both ways and comparing
+    # each Deployment's pod template.
+    #
+    # `large-v3-turbo` is a distilled decoder, four layers where large-v3
+    # has thirty-two, and what it trades away lands outside English --
+    # which is where these meetings happen. Measured on the same 4.7
+    # minutes of German speech, four CPU threads:
+    #
+    #   large-v3-turbo  int8  beam 5    61.6s  1.96GB  "Der Ender laeuft
+    #                                                   auf dem Kluster"
+    #   large-v3        int8  beam 8   145.0s  4.11GB  "Der Renderer laeuft
+    #                                                   auf dem Cluster"
+    #
+    # 4.11GB is why the memory below moves: the chart's 2560Mi limit was
+    # sized for turbo and would OOMKill this mid-transcription. The
+    # startupProbe budget doubles because the first start after this
+    # re-downloads the checkpoint (~2.8GB, float16) and the health server
+    # only comes up after the engine is built.
+    #
+    # Delete this block once PR #44 is merged -- it sets the same values as
+    # the chart's own defaults will, so leaving it would be a second place
+    # to keep in step.
+    worker:
+      env:
+        STURNUS_MODEL_CACHE_DIR: /data/model-cache
+        STURNUS_WHISPER_MODEL: large-v3
+      resources:
+        requests:
+          cpu: "4"
+          memory: 4Gi
+        limits:
+          cpu: "4"
+          memory: 6Gi
+      startupProbe:
+        httpGet:
+          path: /healthz
+          port: health
+        periodSeconds: 10
+        failureThreshold: 120 # 20 minutes: this checkpoint is ~2.8GB
+
     # Exposed via Cloudflare Tunnel (see ingress.yaml) for the link component
     # only; the chart's own HTTPRoute stays off, same as outline's httpRoute.
     httpRoute:


### PR DESCRIPTION
Brings forward the model half of OneLiteFeatherNET/Sturnus#44, ahead of that PR landing, so a recording in progress right now is transcribed with `large-v3` instead of `large-v3-turbo`.

**Why this half can move early.** `worker.env` and `worker.resources` touch only the worker Deployment. Rendering the chart both ways and comparing each Deployment's pod template:

```
sturnus-bot      Pod-Spec unchanged: True
sturnus-link     Pod-Spec unchanged: True
sturnus-worker   Pod-Spec unchanged: False
```

So the bot is not restarted and its gateway connection — with the open session held in its memory — survives. The worker holds no session state; it takes jobs off a queue.

**Why the model.** Measured on the same 4.7 minutes of German speech, four CPU threads:

| model | compute | beam | transcribe | peak RSS |
|---|---|---|---|---|
| large-v3-turbo | int8 | 5 | 61.6s | 1.96 GB |
| large-v3 | int8 | 8 | 145.0s | 4.11 GB |

> turbo: *"Der **Ender** läuft inzwischen auf dem **Kluster**, aber die Speicherlimits sind noch zu knapp **gemessen**."*
> large-v3: *"Der **Renderer** läuft inzwischen auf dem **Cluster**, aber die Speicherlimits sind noch zu knapp **bemessen**."*

The memory move follows from that 4.11 GB: the chart's 2560Mi limit was sized for turbo and would OOMKill this mid-transcription. The startupProbe budget doubles because the first start re-downloads the checkpoint (~2.8 GB float16) and the health server only comes up after the engine is built.

**Not included here**, because they are code and would need a release — and a release changes the image, which restarts the bot and would cost the recording in progress: `initial_prompt`, `beam_size=8`, `condition_on_previous_text=False`, `int8_float32`, and the per-guild language key. They arrive with #44.

**To be deleted when #44 lands** — it sets the same values as the chart's own defaults will, and two places to keep in step is one too many.