### PR TITLE
fix(sturnus): give the worker room for log-mel over an unshrunk track

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sturnus/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/sturnus/release.yaml
@@ -124,13 +124,37 @@ spec:
         # worker waits longer before being retried, which at `replicas: 1`
         # is the only thing the lease actually guards.
         STURNUS_JOB_LEASE_SECONDS: "10800"
+      # Raised again, and the reason is not the model. Since 0.5.0 the worker
+      # passes `clip_timestamps` instead of `vad_filter=True`, and those two
+      # take different paths through faster-whisper: the VAD branch shrinks
+      # the array with `collect_chunks`/`np.concatenate` *before*
+      # `feature_extractor` runs, while the clip_timestamps branch skips that
+      # and extracts log-mel features over the whole padded file.
+      #
+      # Measured on this machine, feature extraction alone:
+      #
+      #     10 min audio ->  0.55 GB peak
+      #     50 min audio ->  2.52 GB peak
+      #    100 min audio ->  4.94 GB peak
+      #
+      # plus ~1.6GB of resident large-v3 weights, so a 100-minute recording
+      # needs about 6.5GB and the previous 6Gi limit would OOMKill it in the
+      # middle of a transcription. It scales linearly with the *padded*
+      # length of a speaker's track, not with how much of it is speech, so a
+      # four-hour session would need more again.
+      #
+      # This is a stopgap. The real fix is to concatenate the gated speech
+      # before handing it over -- exactly what the VAD branch does -- and map
+      # the segment timestamps back afterwards, which bounds the memory by
+      # the speech rather than by the session length. Until that lands, buy
+      # the headroom: the node has 64GB and is under half allocated.
       resources:
         requests:
           cpu: "4"
-          memory: 4Gi
+          memory: 5Gi
         limits:
           cpu: "4"
-          memory: 6Gi
+          memory: 12Gi
       startupProbe:
         httpGet:
           path: /healthz


### PR DESCRIPTION
Found by an adversarial review of the 0.5.0 fix, then measured. **This is live risk on the current deployment.**

Since 0.5.0 the worker passes `clip_timestamps` instead of `vad_filter=True`, and those take different paths through faster-whisper (`transcribe.py`):

```python
if vad_filter and clip_timestamps == "0":
    ...
    audio = np.concatenate(audio_chunks, axis=0)   # <- array shrunk here
features = self.feature_extractor(audio, chunk_length=chunk_length)
```

With `clip_timestamps` set, that branch is skipped, so log-mel extraction runs over the **whole padded file**. Before 0.5.0 it ran over whatever Silero kept — which was about one second, which is why nobody noticed.

Measured, feature extraction alone:

| audio | peak RSS |
|---|---|
| 10 min | 0.55 GB |
| 50 min | 2.52 GB |
| 100 min | **4.94 GB** |

Plus ~1.6 GB of resident large-v3 weights. The 100-minute recording already sitting in S3 needs about 6.5 GB against the previous 6Gi limit — the next long session would have OOMKilled mid-transcription.

It scales with the **padded** length of a track, not with how much of it is speech, so a four-hour session needs more again.

**This is a stopgap.** The real fix is to concatenate the gated speech before handing it over — exactly what the VAD branch does — and restore the segment timestamps afterwards, which bounds memory by the speech instead of by the session length. Buying headroom now because the node has 64 GB and is under half allocated, and a meeting could start at any time.