### PR TITLE
feat(grafana): a resources dashboard for Sturnus, cross-linked with the transcription one

### DIFF
--- a/apps/clusters/feathre-core/base-apps/grafana/dashboards/applications/sturnus-resources.json
+++ b/apps/clusters/feathre-core/base-apps/grafana/dashboards/applications/sturnus-resources.json
@@ -1,0 +1,517 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [
+        "sturnus"
+      ],
+      "targetBlank": false,
+      "title": "Sturnus",
+      "tooltip": "Alle Sturnus-Dashboards",
+      "type": "dashboards",
+      "url": ""
+    },
+    {
+      "icon": "external link",
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Sturnus — Transkription",
+      "tooltip": "Durchsatz, Fortschritt, Warteschlange",
+      "type": "link",
+      "url": "/d/sturnus-transcription"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 1,
+      "title": "Speicher gegen Limit — das, was heute schiefging",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "title": "Speicher je Komponente, mit Limit",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Arbeitsspeicher gegen das gesetzte Limit.\n\nDas Panel existiert wegen eines konkreten Vorfalls: Das Worker-Limit wurde von 12Gi auf 6Gi verengt, gestützt auf eine Messung von 2441 MB — die allerdings mit dem **tiny**-Modell lief. In Produktion läuft `large-v3`, das rund 2 GB Gewichte mehr hält. 18 Minuten nach dem nächsten Job kam der OOMKill.\n\nDer Abstand zwischen Kurve und Limit ist das Einzige, was diese Art Fehler vorher sichtbar macht.",
+      "gridPos": {
+        "h": 9,
+        "w": 16,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (container) (container_memory_working_set_bytes{namespace=\"sturnus\",container!=\"\"})",
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum by (container) (kube_pod_container_resource_limits{namespace=\"sturnus\",resource=\"memory\"})",
+          "legendFormat": "Limit {{container}}",
+          "range": true,
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "links": [
+        {
+          "title": "Sturnus — Transkription",
+          "type": "link",
+          "url": "/d/sturnus-transcription",
+          "icon": "external link",
+          "targetBlank": false,
+          "tooltip": "Durchsatz, Fortschritt, Warteschlange"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Ausgenutztes Limit",
+      "type": "bargauge",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Wie nah die Komponenten an ihrem Limit stehen. Über 80 % ist ein Grund, vor dem nächsten langen Job hinzusehen.",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "100 * max by (container) (container_memory_working_set_bytes{namespace=\"sturnus\",container!=\"\"}) / max by (container) (kube_pod_container_resource_limits{namespace=\"sturnus\",resource=\"memory\"})",
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 10,
+      "title": "Neustarts und Abbrüche",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "panels": []
+    },
+    {
+      "id": 11,
+      "title": "Neustarts",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Der einzige Verlauf, der Abbrüche zuverlässig festhält.\n\n`container_oom_events_total` **nicht** benutzen: Der Zähler stand nach dem OOMKill von heute 11:30 weiterhin auf 0. Und `kube_pod_container_status_last_terminated_reason` beschreibt nur den *laufenden* Pod — ist er ersetzt, ist der Grund fort.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (container) (increase(kube_pod_container_status_restarts_total{namespace=\"sturnus\"}[1h]))",
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 12,
+      "title": "Letzter Abbruchgrund (laufende Pods)",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Warum der Vorgänger des jetzt laufenden Containers starb — `OOMKilled`, `Error`, `Completed`.\n\nMomentaufnahme, keine Historie: Wird der Pod ersetzt, verschwindet der Eintrag. Für den Verlauf das Panel links.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "kube_pod_container_status_last_terminated_reason{namespace=\"sturnus\"} > 0",
+          "legendFormat": "{{container}} / {{reason}}",
+          "range": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 20,
+      "title": "CPU",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "panels": []
+    },
+    {
+      "id": 21,
+      "title": "CPU je Komponente, mit Limit",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Der Worker soll beim Transkribieren nahe an seinem Limit stehen — das ist gesund und heißt, dass er rechnet. Interessant ist der umgekehrte Fall: niedrige CPU **und** stehende Stillstandsuhr auf dem Transkriptions-Dashboard bedeutet, dass er hängt.",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 20
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"sturnus\",container!=\"\"}[5m]))",
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum by (container) (kube_pod_container_resource_limits{namespace=\"sturnus\",resource=\"cpu\"})",
+          "legendFormat": "Limit {{container}}",
+          "range": true,
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "links": [
+        {
+          "title": "Sturnus — Transkription",
+          "type": "link",
+          "url": "/d/sturnus-transcription",
+          "icon": "external link",
+          "targetBlank": false,
+          "tooltip": "Durchsatz, Fortschritt, Warteschlange"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "title": "CPU-Drosselung",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Anteil der Zeitscheiben, in denen der Kernel den Container ausgebremst hat.\n\nDauerhaft hoch heißt: Das CPU-Limit ist die Bremse, nicht die Arbeit. Beim Worker verlängert das jede Transkription direkt — und die Job-Lease läuft unterdessen weiter.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 20
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "100 * sum by (container) (rate(container_cpu_cfs_throttled_periods_total{namespace=\"sturnus\",container!=\"\"}[5m])) / clamp_min(sum by (container) (rate(container_cpu_cfs_periods_total{namespace=\"sturnus\",container!=\"\"}[5m])), 1)",
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 30,
+      "title": "Volumes",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "panels": []
+    },
+    {
+      "id": 31,
+      "title": "Belegung der Volumes",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "`sturnus-worker` hält den Modell-Cache — `large-v3` belegt dort rund 2,8 GB als float16-Checkpoint. `sturnus-bot` hält die laufenden Aufnahmen, bis sie verschlüsselt und hochgeladen sind; eine 100-Minuten-Spur sind rund 190 MB je Sprecher.\n\nLäuft das Bot-Volume voll, bricht die laufende Aufnahme ab — deshalb steht es hier und nicht nur im Speicher-Dashboard des Clusters.",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 29
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "100 * (kubelet_volume_stats_capacity_bytes{namespace=\"sturnus\"} - kubelet_volume_stats_available_bytes{namespace=\"sturnus\"}) / kubelet_volume_stats_capacity_bytes{namespace=\"sturnus\"}",
+          "legendFormat": "{{persistentvolumeclaim}}",
+          "range": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 32,
+      "title": "Freier Platz",
+      "type": "bargauge",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Absolut, weil der Prozentwert bei einem 10Gi-Volume anders zu lesen ist als bei einem kleinen.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 29
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "kubelet_volume_stats_available_bytes{namespace=\"sturnus\"}",
+          "legendFormat": "{{persistentvolumeclaim}}",
+          "range": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {}
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "sturnus"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Sturnus — Ressourcen",
+  "uid": "sturnus-resources",
+  "version": 1,
+  "weekStart": ""
+}

--- a/apps/clusters/feathre-core/base-apps/grafana/dashboards/applications/sturnus.json
+++ b/apps/clusters/feathre-core/base-apps/grafana/dashboards/applications/sturnus.json
@@ -5,7 +5,31 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [
+        "sturnus"
+      ],
+      "targetBlank": false,
+      "title": "Sturnus",
+      "tooltip": "Alle Sturnus-Dashboards",
+      "type": "dashboards",
+      "url": ""
+    },
+    {
+      "icon": "external link",
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Sturnus — Ressourcen",
+      "tooltip": "Speicher, CPU, Neustarts, Volumes",
+      "type": "link",
+      "url": "/d/sturnus-resources"
+    }
+  ],
   "liveNow": false,
   "panels": [
     {
@@ -228,7 +252,17 @@
         },
         "overrides": []
       },
-      "options": {}
+      "options": {},
+      "links": [
+        {
+          "title": "Sturnus — Ressourcen",
+          "type": "link",
+          "url": "/d/sturnus-resources",
+          "icon": "external link",
+          "targetBlank": false,
+          "tooltip": "Speicher, CPU, Neustarts"
+        }
+      ]
     },
     {
       "id": 13,
@@ -265,7 +299,17 @@
         },
         "overrides": []
       },
-      "options": {}
+      "options": {},
+      "links": [
+        {
+          "title": "Sturnus — Ressourcen",
+          "type": "link",
+          "url": "/d/sturnus-resources",
+          "icon": "external link",
+          "targetBlank": false,
+          "tooltip": "Speicher, CPU, Neustarts"
+        }
+      ]
     },
     {
       "id": 20,

--- a/apps/clusters/feathre-core/base-apps/grafana/kustomization.yaml
+++ b/apps/clusters/feathre-core/base-apps/grafana/kustomization.yaml
@@ -19,6 +19,7 @@ configMapGenerator:
     files:
       - dashboards/applications/harbor.json
       - dashboards/applications/sturnus.json
+      - dashboards/applications/sturnus-resources.json
     options:
       labels:
         grafana_dashboard: "1"


### PR DESCRIPTION
Built from the incidents of the last two days rather than from a template. Every query was run against Mimir before it was written down; ten of eleven return live data, and the eleventh is empty for a documented reason.

### Memory against limit is the first row, because that is what went wrong

The worker's limit was narrowed from 12Gi to 6Gi on the strength of a measured **2441 MB** peak — taken with the **tiny** model, while production runs `large-v3`, which holds roughly 2 GB more in weights before a single frame is extracted. The OOMKill came 18 minutes into the next job.

The distance between the usage curve and the limit line is the only thing that shows that class of mistake *before* it lands.

### Two metrics are deliberately not used, and the panels say why

- **`container_oom_events_total` read 0** for every container after today's OOMKill. It does not capture kubelet memory-limit kills here, so trusting it would mean a silent dashboard during exactly the incident it appears to cover.
- **`kube_pod_container_status_last_terminated_reason` describes only the running pod.** Once it is replaced, the reason is gone. It still earns a panel as a snapshot — "why did the current pod's predecessor die" — but the history is the restart counter, and that is a separate panel.

Writing this down in the panel description rather than quietly picking the working query is the point: the next person will otherwise reach for `oom_events` and believe the zero.

### CPU throttling next to CPU usage

For the worker they mean opposite things. Sitting near the limit while transcribing is health — it means the thing is computing. Throttling means the limit has become the brake, and the **job lease keeps running** while the kernel holds the process back, so throttling quietly eats the budget that decides whether a job survives.

### Volumes

A full bot volume aborts a recording in progress. That is a Sturnus failure long before it is a storage one, so it belongs here and not only on the cluster storage board. `sturnus-worker` holds the model cache (~2.8 GB for the large-v3 float16 checkpoint), `sturnus-bot` the recordings in flight (~190 MB per speaker per 100 minutes).

### Cross-linking, both ways

- A **dashboards-by-tag** link on both boards, so every future `sturnus`-tagged dashboard appears automatically without editing anything.
- Direct links between the two, keeping the selected time range.
- **Panel links** from the *stall clock* and *worker CPU* panels on the transcription board straight to this one — because "stalled or just slow" is a question you answer by reading both, and today it took me a manual `kubectl top` to answer it.