### PR TITLE
feat(grafana): rewrite the Sturnus dashboards in English and aggregate per pod

### DIFF
--- a/apps/clusters/feathre-core/base-apps/grafana/dashboards/applications/sturnus-resources.json
+++ b/apps/clusters/feathre-core/base-apps/grafana/dashboards/applications/sturnus-resources.json
@@ -16,7 +16,7 @@
       ],
       "targetBlank": false,
       "title": "Sturnus",
-      "tooltip": "Alle Sturnus-Dashboards",
+      "tooltip": "All Sturnus dashboards",
       "type": "dashboards",
       "url": ""
     },
@@ -24,17 +24,36 @@
       "icon": "external link",
       "keepTime": true,
       "targetBlank": false,
-      "title": "Sturnus — Transkription",
-      "tooltip": "Durchsatz, Fortschritt, Warteschlange",
+      "title": "Sturnus — Transcription",
+      "tooltip": "Progress, throughput, queue, job stages",
       "type": "link",
       "url": "/d/sturnus-transcription"
     }
   ],
   "liveNow": false,
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "sturnus"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Sturnus — Resources",
+  "uid": "sturnus-resources",
+  "version": 1,
+  "weekStart": "",
   "panels": [
     {
-      "id": 1,
-      "title": "Speicher gegen Limit — das, was heute schiefging",
+      "id": 2,
+      "title": "Memory against the limit",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -46,38 +65,28 @@
       "panels": []
     },
     {
-      "id": 2,
-      "title": "Speicher je Komponente, mit Limit",
-      "type": "timeseries",
+      "id": 3,
+      "title": "Peak memory in range",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Arbeitsspeicher gegen das gesetzte Limit.\n\nDas Panel existiert wegen eines konkreten Vorfalls: Das Worker-Limit wurde von 12Gi auf 6Gi verengt, gestützt auf eine Messung von 2441 MB — die allerdings mit dem **tiny**-Modell lief. In Produktion läuft `large-v3`, das rund 2 GB Gewichte mehr hält. 18 Minuten nach dem nächsten Job kam der OOMKill.\n\nDer Abstand zwischen Kurve und Limit ist das Einzige, was diese Art Fehler vorher sichtbar macht.",
+      "description": "The highest working set each container reached over the selected range.\n\nThis is the number a memory limit has to be set from, and the reason this panel exists: a limit is an absolute, so it can only be narrowed from an absolute measured under the real workload. A figure measured with a smaller Whisper model carries the *delta* over to production, never the level -- large-v3 holds roughly 2 GB more weights than `tiny`, and a limit narrowed on `tiny` numbers is what OOM-killed the worker 18 minutes into a job.",
       "gridPos": {
-        "h": 9,
-        "w": 16,
+        "h": 6,
+        "w": 12,
         "x": 0,
         "y": 1
       },
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (container) (container_memory_working_set_bytes{namespace=\"sturnus\",container!=\"\"})",
+          "expr": "max by (container) (max_over_time(container_memory_working_set_bytes{namespace=\"sturnus\",container!=\"\"}[$__range]))",
           "legendFormat": "{{container}}",
-          "range": true,
+          "range": false,
+          "instant": true,
           "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          }
-        },
-        {
-          "editorMode": "code",
-          "expr": "sum by (container) (kube_pod_container_resource_limits{namespace=\"sturnus\",resource=\"memory\"})",
-          "legendFormat": "Limit {{container}}",
-          "range": true,
-          "refId": "B",
           "datasource": {
             "type": "prometheus",
             "uid": "mimir"
@@ -87,43 +96,62 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "unit": "bytes"
+          "unit": "bytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
         },
         "overrides": []
       },
-      "options": {},
-      "links": [
-        {
-          "title": "Sturnus — Transkription",
-          "type": "link",
-          "url": "/d/sturnus-transcription",
-          "icon": "external link",
-          "targetBlank": false,
-          "tooltip": "Durchsatz, Fortschritt, Warteschlange"
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "orientation": "auto",
+        "text": {
+          "valueSize": 28
         }
-      ]
+      }
     },
     {
-      "id": 3,
-      "title": "Ausgenutztes Limit",
+      "id": 4,
+      "title": "Peak against limit",
       "type": "bargauge",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Wie nah die Komponenten an ihrem Limit stehen. Über 80 % ist ein Grund, vor dem nächsten langen Job hinzusehen.",
+      "description": "The peak above, as a share of the limit. This is the headroom question in one picture: what is left before the kernel starts killing.\n\nRed starts at 90% because a container that touched 90% of its limit under one workload has no margin for a larger one -- and the workload here is set by whoever joins the next meeting, not by us.",
       "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 16,
+        "h": 6,
+        "w": 12,
+        "x": 12,
         "y": 1
       },
       "targets": [
         {
           "editorMode": "code",
-          "expr": "100 * max by (container) (container_memory_working_set_bytes{namespace=\"sturnus\",container!=\"\"}) / max by (container) (kube_pod_container_resource_limits{namespace=\"sturnus\",resource=\"memory\"})",
+          "expr": "100 * max by (container) (max_over_time(container_memory_working_set_bytes{namespace=\"sturnus\",container!=\"\"}[$__range])) / max by (container) (kube_pod_container_resource_limits{namespace=\"sturnus\",resource=\"memory\"})",
           "legendFormat": "{{container}}",
-          "range": true,
+          "range": false,
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -143,12 +171,94 @@
                 "value": null
               },
               {
-                "color": "yellow",
-                "value": 70
+                "color": "orange",
+                "value": 75
               },
               {
                 "color": "red",
-                "value": 85
+                "value": 90
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "max": 100,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "showUnfilled": true
+      }
+    },
+    {
+      "id": 5,
+      "title": "Memory per component, with its limit",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Working set over time against the configured limit. The gap between a line and its dashed limit is the margin; a line that walks up to its limit and stops is a container about to be killed, not one that settled.",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (container) (container_memory_working_set_bytes{namespace=\"sturnus\",container!=\"\"})",
+          "legendFormat": "{{container}}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum by (container) (kube_pod_container_resource_limits{namespace=\"sturnus\",resource=\"memory\"})",
+          "legendFormat": "Limit {{container}}",
+          "range": true,
+          "instant": false,
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "bytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -156,44 +266,82 @@
             "mode": "thresholds"
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "Limit.*"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
       },
-      "options": {}
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     },
     {
-      "id": 10,
-      "title": "Neustarts und Abbrüche",
+      "id": 6,
+      "title": "Restarts and kills",
       "type": "row",
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 16
       },
       "panels": []
     },
     {
-      "id": 11,
-      "title": "Neustarts",
-      "type": "timeseries",
+      "id": 7,
+      "title": "OOM kills in range",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Der einzige Verlauf, der Abbrüche zuverlässig festhält.\n\n`container_oom_events_total` **nicht** benutzen: Der Zähler stand nach dem OOMKill von heute 11:30 weiterhin auf 0. Und `kube_pod_container_status_last_terminated_reason` beschreibt nur den *laufenden* Pod — ist er ersetzt, ist der Grund fort.",
+      "description": "Containers whose last termination was the kernel reclaiming memory.\n\nDistinct from a restart: a crash-looping process and an OOM-killed one look the same in a restart count, and only one of them is fixed by changing a number.",
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 6,
+        "w": 6,
         "x": 0,
-        "y": 11
+        "y": 17
       },
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (container) (increase(kube_pod_container_status_restarts_total{namespace=\"sturnus\"}[1h]))",
-          "legendFormat": "{{container}}",
-          "range": true,
+          "expr": "count(kube_pod_container_status_last_terminated_reason{namespace=\"sturnus\",reason=\"OOMKilled\"} > 0) or vector(0)",
+          "legendFormat": "oom",
+          "range": false,
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -220,33 +368,121 @@
           },
           "color": {
             "mode": "thresholds"
+          },
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "orientation": "auto",
+        "text": {
+          "valueSize": 48
+        }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Restarts",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Restarts per container over the last hour. A deploy shows up here as a single step; a crash loop as a staircase.",
+      "gridPos": {
+        "h": 6,
+        "w": 10,
+        "x": 6,
+        "y": 17
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (container) (increase(kube_pod_container_status_restarts_total{namespace=\"sturnus\"}[1h]))",
+          "legendFormat": "{{container}}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
           }
         },
         "overrides": []
       },
-      "options": {}
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     },
     {
-      "id": 12,
-      "title": "Letzter Abbruchgrund (laufende Pods)",
+      "id": 9,
+      "title": "Last termination reason (running pods)",
       "type": "table",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Warum der Vorgänger des jetzt laufenden Containers starb — `OOMKilled`, `Error`, `Completed`.\n\nMomentaufnahme, keine Historie: Wird der Pod ersetzt, verschwindet der Eintrag. Für den Verlauf das Panel links.",
+      "description": "Why each container last died, for the pods alive now. `OOMKilled` means the limit; `Error` means the process; `Completed` means it was asked to stop.",
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 11
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 17
       },
       "targets": [
         {
           "editorMode": "code",
           "expr": "kube_pod_container_status_last_terminated_reason{namespace=\"sturnus\"} > 0",
           "legendFormat": "{{container}} / {{reason}}",
-          "range": true,
+          "range": false,
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -257,14 +493,28 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "unit": "none"
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
         },
         "overrides": []
       },
-      "options": {}
+      "options": {
+        "showHeader": true
+      }
     },
     {
-      "id": 20,
+      "id": 10,
       "title": "CPU",
       "type": "row",
       "collapsed": false,
@@ -272,24 +522,24 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 23
       },
       "panels": []
     },
     {
-      "id": 21,
-      "title": "CPU je Komponente, mit Limit",
+      "id": 11,
+      "title": "CPU per component, with its limit",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Der Worker soll beim Transkribieren nahe an seinem Limit stehen — das ist gesund und heißt, dass er rechnet. Interessant ist der umgekehrte Fall: niedrige CPU **und** stehende Stillstandsuhr auf dem Transkriptions-Dashboard bedeutet, dass er hängt.",
+      "description": "The worker's limit is 4 cores, and transcription will use every one of them. Sitting at the limit is expected here; what is not expected is sitting at the limit with nothing being decoded.",
       "gridPos": {
         "h": 8,
-        "w": 16,
+        "w": 12,
         "x": 0,
-        "y": 20
+        "y": 24
       },
       "targets": [
         {
@@ -297,6 +547,7 @@
           "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"sturnus\",container!=\"\"}[5m]))",
           "legendFormat": "{{container}}",
           "range": true,
+          "instant": false,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -308,6 +559,7 @@
           "expr": "sum by (container) (kube_pod_container_resource_limits{namespace=\"sturnus\",resource=\"cpu\"})",
           "legendFormat": "Limit {{container}}",
           "range": true,
+          "instant": false,
           "refId": "B",
           "datasource": {
             "type": "prometheus",
@@ -317,37 +569,83 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "custom": {},
-          "unit": "none"
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "Limit.*"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
       },
-      "options": {},
-      "links": [
-        {
-          "title": "Sturnus — Transkription",
-          "type": "link",
-          "url": "/d/sturnus-transcription",
-          "icon": "external link",
-          "targetBlank": false,
-          "tooltip": "Durchsatz, Fortschritt, Warteschlange"
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
         }
-      ]
+      }
     },
     {
-      "id": 22,
-      "title": "CPU-Drosselung",
+      "id": 12,
+      "title": "CPU throttling",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Anteil der Zeitscheiben, in denen der Kernel den Container ausgebremst hat.\n\nDauerhaft hoch heißt: Das CPU-Limit ist die Bremse, nicht die Arbeit. Beim Worker verlängert das jede Transkription direkt — und die Job-Lease läuft unterdessen weiter.",
+      "description": "Share of scheduling periods in which the kernel took the CPU away because the limit was reached. Sustained throttling on the worker means a transcription is running slower than the hardware could -- and, unlike a crash, it says nothing at all in the logs.",
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 20
+        "w": 12,
+        "x": 12,
+        "y": 24
       },
       "targets": [
         {
@@ -355,6 +653,7 @@
           "expr": "100 * sum by (container) (rate(container_cpu_cfs_throttled_periods_total{namespace=\"sturnus\",container!=\"\"}[5m])) / clamp_min(sum by (container) (rate(container_cpu_cfs_periods_total{namespace=\"sturnus\",container!=\"\"}[5m])), 1)",
           "legendFormat": "{{container}}",
           "range": true,
+          "instant": false,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -364,7 +663,13 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "custom": {},
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
           "unit": "percent",
           "thresholds": {
             "mode": "absolute",
@@ -374,21 +679,40 @@
                 "value": null
               },
               {
-                "color": "yellow",
-                "value": 25
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
               }
             ]
           },
           "color": {
             "mode": "thresholds"
-          }
+          },
+          "decimals": 1
         },
         "overrides": []
       },
-      "options": {}
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     },
     {
-      "id": 30,
+      "id": 13,
       "title": "Volumes",
       "type": "row",
       "collapsed": false,
@@ -396,24 +720,24 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 32
       },
       "panels": []
     },
     {
-      "id": 31,
-      "title": "Belegung der Volumes",
+      "id": 14,
+      "title": "Volume usage",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "`sturnus-worker` hält den Modell-Cache — `large-v3` belegt dort rund 2,8 GB als float16-Checkpoint. `sturnus-bot` hält die laufenden Aufnahmen, bis sie verschlüsselt und hochgeladen sind; eine 100-Minuten-Spur sind rund 190 MB je Sprecher.\n\nLäuft das Bot-Volume voll, bricht die laufende Aufnahme ab — deshalb steht es hier und nicht nur im Speicher-Dashboard des Clusters.",
+      "description": "The recording volume fills while a session is being captured and drains when the audio has been uploaded. A level that only ever climbs means something is not being cleaned up.",
       "gridPos": {
         "h": 8,
-        "w": 16,
+        "w": 12,
         "x": 0,
-        "y": 29
+        "y": 33
       },
       "targets": [
         {
@@ -421,6 +745,7 @@
           "expr": "100 * (kubelet_volume_stats_capacity_bytes{namespace=\"sturnus\"} - kubelet_volume_stats_available_bytes{namespace=\"sturnus\"}) / kubelet_volume_stats_capacity_bytes{namespace=\"sturnus\"}",
           "legendFormat": "{{persistentvolumeclaim}}",
           "range": true,
+          "instant": false,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -430,7 +755,13 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "custom": {},
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
           "unit": "percent",
           "thresholds": {
             "mode": "absolute",
@@ -440,7 +771,7 @@
                 "value": null
               },
               {
-                "color": "yellow",
+                "color": "orange",
                 "value": 75
               },
               {
@@ -451,33 +782,51 @@
           },
           "color": {
             "mode": "thresholds"
-          }
+          },
+          "decimals": 1,
+          "max": 100,
+          "min": 0
         },
         "overrides": []
       },
-      "options": {}
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     },
     {
-      "id": 32,
-      "title": "Freier Platz",
+      "id": 15,
+      "title": "Free space",
       "type": "bargauge",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Absolut, weil der Prozentwert bei einem 10Gi-Volume anders zu lesen ist als bei einem kleinen.",
+      "description": "What is left, in bytes. A recording writes one file per consenting speaker for as long as the meeting runs, so the figure that matters is not today's usage but whether the longest plausible meeting still fits.",
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 29
+        "w": 12,
+        "x": 12,
+        "y": 33
       },
       "targets": [
         {
           "editorMode": "code",
           "expr": "kubelet_volume_stats_available_bytes{namespace=\"sturnus\"}",
           "legendFormat": "{{persistentvolumeclaim}}",
-          "range": true,
+          "range": false,
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -488,30 +837,34 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "unit": "bytes"
+          "unit": "bytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
         },
         "overrides": []
       },
-      "options": {}
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "showUnfilled": true
+      }
     }
-  ],
-  "refresh": "1m",
-  "schemaVersion": 39,
-  "style": "dark",
-  "tags": [
-    "sturnus"
-  ],
-  "templating": {
-    "list": []
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "",
-  "title": "Sturnus — Ressourcen",
-  "uid": "sturnus-resources",
-  "version": 1,
-  "weekStart": ""
+  ]
 }

--- a/apps/clusters/feathre-core/base-apps/grafana/dashboards/applications/sturnus.json
+++ b/apps/clusters/feathre-core/base-apps/grafana/dashboards/applications/sturnus.json
@@ -4,7 +4,7 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "links": [
     {
       "asDropdown": false,
@@ -16,7 +16,7 @@
       ],
       "targetBlank": false,
       "title": "Sturnus",
-      "tooltip": "Alle Sturnus-Dashboards",
+      "tooltip": "All Sturnus dashboards",
       "type": "dashboards",
       "url": ""
     },
@@ -24,17 +24,36 @@
       "icon": "external link",
       "keepTime": true,
       "targetBlank": false,
-      "title": "Sturnus — Ressourcen",
-      "tooltip": "Speicher, CPU, Neustarts, Volumes",
+      "title": "Sturnus — Resources",
+      "tooltip": "Memory, CPU, restarts, volumes",
       "type": "link",
       "url": "/d/sturnus-resources"
     }
   ],
   "liveNow": false,
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "sturnus"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Sturnus — Transcription",
+  "uid": "sturnus-transcription",
+  "version": 1,
+  "weekStart": "",
   "panels": [
     {
-      "id": 1,
-      "title": "Durchsatz — ist das Ergebnis überhaupt plausibel?",
+      "id": 2,
+      "title": "Right now — is anything running?",
       "type": "row",
       "collapsed": false,
       "gridPos": {
@@ -46,26 +65,27 @@
       "panels": []
     },
     {
-      "id": 2,
-      "title": "Echtzeitfaktor",
-      "type": "timeseries",
+      "id": 3,
+      "title": "Worker state",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Dekodierte Audiosekunden je Wanduhrsekunde.\n\nDie wichtigste Zahl auf dieser Seite. Gemessen liegt large-v3 auf dieser Hardware bei etwa 0,5 (also rund zweimal langsamer als Echtzeit).\n\n**Über 10 ist physikalisch unmöglich** und bedeutet, dass nichts dekodiert wurde. Genau so sah der Defekt aus, der dieses Projekt zwei Tage gekostet hat: 100 Minuten Audio in 43 Sekunden \"erledigt\", Ergebnis ein leeres Transkript, das von einem stillen Teilnehmer nicht zu unterscheiden war.",
+      "description": "Whether a transcription is in flight at this moment.\n\nThe instruments deliberately report nothing while idle, so that a finished transcription cannot be mistaken for a running one. No series therefore means idle, and this panel turns that absence into a word.",
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 5,
+        "w": 4,
         "x": 0,
         "y": 1
       },
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model) (rate(sturnus_transcription_decoded_seconds_total[5m]))",
-          "legendFormat": "{{model}}",
-          "range": true,
+          "expr": "count(sturnus_transcription_position_seconds) or vector(0)",
+          "legendFormat": "state",
+          "range": false,
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -83,92 +103,72 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 10
               }
             ]
           },
           "color": {
             "mode": "thresholds"
-          }
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "Idle",
+                  "color": "text",
+                  "index": 0
+                },
+                "1": {
+                  "text": "Transcribing",
+                  "color": "green",
+                  "index": 1
+                }
+              }
+            }
+          ]
         },
         "overrides": []
       },
-      "options": {}
-    },
-    {
-      "id": 3,
-      "title": "Dekodiertes Audio (kumuliert)",
-      "type": "timeseries",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
-      "description": "Wie viel Audio im gewählten Zeitraum tatsächlich durch den Decoder ging.",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 1
-      },
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "sum by (model) (increase(sturnus_transcription_decoded_seconds_total[$__range]))",
-          "legendFormat": "{{model}}",
-          "range": true,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          }
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "orientation": "auto",
+        "text": {
+          "valueSize": 32
         }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "options": {}
+      }
     },
     {
-      "id": 10,
-      "title": "Laufender Job — läuft er langsam oder gar nicht?",
-      "type": "row",
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 9
-      },
-      "panels": []
-    },
-    {
-      "id": 11,
-      "title": "Fortschritt",
+      "id": 4,
+      "title": "Progress",
       "type": "gauge",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Position im Audio, geteilt durch die Sprache, die das Gatter übergeben hat.\n\nKeine Serie heißt: gerade läuft kein Job. Die Instrumente melden im Leerlauf bewusst nichts, damit eine abgeschlossene Transkription nicht für immer als \"fertig\" stehen bleibt.",
+      "description": "Position in the audio, over the speech the gate handed to the decoder.\n\nNot over the file's length: the gate drops silence before the decoder ever sees it, so 100% here means the speech is done, not that the whole recording was decoded.\n\nAggregated across pods with `max`: the worker runs a single replica, so a second series only ever appears while a rollout has both pods alive. Without this, one job is drawn as two identically-labelled lines.",
       "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 10
+        "h": 5,
+        "w": 6,
+        "x": 4,
+        "y": 1
       },
       "targets": [
         {
           "editorMode": "code",
-          "expr": "100 * sturnus_transcription_position_seconds / clamp_min(sturnus_transcription_total_seconds, 1)",
+          "expr": "100 * max by (model) (sturnus_transcription_position_seconds) / clamp_min(max by (model) (sturnus_transcription_total_seconds), 1)",
           "legendFormat": "{{model}}",
-          "range": true,
+          "range": false,
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -184,40 +184,54 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "green",
                 "value": null
               }
             ]
           },
           "color": {
             "mode": "thresholds"
-          }
+          },
+          "decimals": 1,
+          "max": 100,
+          "min": 0
         },
         "overrides": []
       },
-      "options": {}
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      }
     },
     {
-      "id": 12,
-      "title": "Stillstandsuhr",
-      "type": "timeseries",
+      "id": 5,
+      "title": "Estimated time remaining",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Sekunden seit dem letzten gemeldeten Segment.\n\n**Diese Zahl allein genügt nicht.** Ein Prozess, der ein 30-Sekunden-Fenster mit beam_size 8 dekodiert, meldet minutenlang nichts und ist trotzdem gesund — beobachtet: 250 s ohne Meldung bei 3462m CPU-Last.\n\nErst zusammen mit dem CPU-Panel rechts wird es eindeutig: hohe Uhr **und** niedrige CPU heißt hängen, hohe Uhr **und** hohe CPU heißt langsam.",
+      "description": "Speech still to decode, divided by the rate it is currently being decoded at.\n\nHonest only while the decoder is actually moving. When it stalls, the divisor collapses and this number runs away into days -- which is deliberate: an ETA of sixty hours is the plainest way of saying that nothing is progressing.",
       "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 10
+        "h": 5,
+        "w": 5,
+        "x": 10,
+        "y": 1
       },
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sturnus_transcription_seconds_since_progress",
-          "legendFormat": "{{model}}",
-          "range": true,
+          "expr": "max(sturnus_transcription_total_seconds - sturnus_transcription_position_seconds) / clamp_min(sum(rate(sturnus_transcription_decoded_seconds_total[10m])), 0.01)",
+          "legendFormat": "remaining",
+          "range": false,
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -237,7 +251,81 @@
                 "value": null
               },
               {
-                "color": "yellow",
+                "color": "orange",
+                "value": 3600
+              },
+              {
+                "color": "red",
+                "value": 21600
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "orientation": "auto",
+        "text": {
+          "valueSize": 32
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Since last segment",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Wall-clock seconds since the decoder last reported a finished segment.\n\n**This number alone is not enough.** A process decoding a 30-second window with beam_size 8 reports nothing for minutes at a time and is perfectly healthy. Read it next to worker CPU: silent and busy means working, silent and idle means stuck.",
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 15,
+        "y": 1
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(sturnus_transcription_seconds_since_progress)",
+          "legendFormat": "idle",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
                 "value": 300
               },
               {
@@ -252,39 +340,46 @@
         },
         "overrides": []
       },
-      "options": {},
-      "links": [
-        {
-          "title": "Sturnus — Ressourcen",
-          "type": "link",
-          "url": "/d/sturnus-resources",
-          "icon": "external link",
-          "targetBlank": false,
-          "tooltip": "Speicher, CPU, Neustarts"
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "orientation": "auto",
+        "text": {
+          "valueSize": 32
         }
-      ]
+      }
     },
     {
-      "id": 13,
-      "title": "CPU des Workers",
-      "type": "timeseries",
+      "id": 7,
+      "title": "Worker CPU",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Die Gegenprobe zur Stillstandsuhr links. Das CPU-Limit des Workers ist 4.",
+      "description": "The cross-check for the clock to its left, in the same glance: a worker burning CPU while reporting no segments is decoding a hard window, not hanging. The CPU limit is 4 cores.",
       "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 10
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
       },
       "targets": [
         {
           "editorMode": "code",
           "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"sturnus\",pod=~\"sturnus-worker-.*\",container!=\"\"}[5m]))",
-          "legendFormat": "worker",
-          "range": true,
+          "legendFormat": "cores",
+          "range": false,
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -295,56 +390,80 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "unit": "none"
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.5
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2
         },
         "overrides": []
       },
-      "options": {},
-      "links": [
-        {
-          "title": "Sturnus — Ressourcen",
-          "type": "link",
-          "url": "/d/sturnus-resources",
-          "icon": "external link",
-          "targetBlank": false,
-          "tooltip": "Speicher, CPU, Neustarts"
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "orientation": "auto",
+        "text": {
+          "valueSize": 32
         }
-      ]
+      }
     },
     {
-      "id": 20,
-      "title": "Warteschlange",
+      "id": 8,
+      "title": "Throughput — is the result even plausible?",
       "type": "row",
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 6
       },
       "panels": []
     },
     {
-      "id": 21,
-      "title": "Jobs nach Status",
+      "id": 9,
+      "title": "Real-time factor",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Achtung beim Namen: die Metrik heißt `sturnus_queue_depth_ratio`, ist aber eine **Anzahl**, kein Verhältnis. Das `_ratio` hängt der OTel-Prometheus-Export an, weil die Metrik die Einheit `1` deklariert. In Sturnus zu korrigieren, nicht hier zu umschiffen.\n\n`pending` dauerhaft über null bei untätigem Worker ist der Alarm.",
+      "description": "Decoded audio seconds per wall-clock second.\n\nThe most important number on this page. Measured, large-v3 on this hardware sits around 0.5 -- roughly twice slower than real time.\n\n**Anything above 10 is physically impossible** and means nothing was decoded. That is exactly what the defect that cost this project two days looked like: 100 minutes of audio \"finished\" in 43 seconds, producing an empty transcript indistinguishable from a participant who never spoke.",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 7
       },
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (status) (sturnus_queue_depth_ratio)",
-          "legendFormat": "{{status}}",
+          "expr": "sum by (model) (rate(sturnus_transcription_decoded_seconds_total[5m]))",
+          "legendFormat": "{{model}}",
           "range": true,
+          "instant": false,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -354,34 +473,431 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "custom": {},
-          "unit": "none"
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2
         },
         "overrides": []
       },
-      "options": {}
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     },
     {
-      "id": 22,
-      "title": "Wartende und laufende Jobs",
-      "type": "stat",
+      "id": 10,
+      "title": "Decoded audio (cumulative)",
+      "type": "timeseries",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Was gerade aussteht. Null bei leerer Warteschlange ist der Normalfall.",
+      "description": "How much audio actually went through the decoder over the selected range. Flat means nothing is being decoded, whatever the queue says.",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 18
+        "y": 7
       },
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(sturnus_queue_depth_ratio{status=~\"pending|running\"})",
-          "legendFormat": "offen",
+          "expr": "sum by (model) (increase(sturnus_transcription_decoded_seconds_total[$__range]))",
+          "legendFormat": "{{model}}",
           "range": true,
+          "instant": false,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 11,
+      "title": "Is it stuck?",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "panels": []
+    },
+    {
+      "id": 12,
+      "title": "Seconds since last segment",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "The stall clock over time. A sawtooth is healthy -- it climbs while a window is decoded and drops to zero when the segment lands. A single unbroken climb is not.\n\n**This number alone is not enough.** A process decoding a 30-second window with beam_size 8 reports nothing for minutes at a time and is perfectly healthy. Read it next to worker CPU: silent and busy means working, silent and idle means stuck.\n\nAggregated across pods with `max`: the worker runs a single replica, so a second series only ever appears while a rollout has both pods alive. Without this, one job is drawn as two identically-labelled lines.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max by (model) (sturnus_transcription_seconds_since_progress)",
+          "legendFormat": "{{model}}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 900
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 13,
+      "title": "Worker CPU, against its limit",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Read together with the stall clock to its left. Sustained CPU at the limit while the clock climbs is a slow decode; CPU at zero while the clock climbs is a job that has stopped.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"sturnus\",pod=~\"sturnus-worker-.*\",container!=\"\"}[5m]))",
+          "legendFormat": "used",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        },
+        {
+          "editorMode": "code",
+          "expr": "max(kube_pod_container_resource_limits{namespace=\"sturnus\",container=\"worker\",resource=\"cpu\"})",
+          "legendFormat": "limit",
+          "range": true,
+          "instant": false,
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "limit"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 14,
+      "title": "Queue",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "panels": []
+    },
+    {
+      "id": 15,
+      "title": "Jobs by status",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "**These values freeze while a job is running.** The worker samples the queue in `database_ping`, which runs once per pass of the claim loop -- so during a two-hour transcription the last sample stands unchanged, and the panel is at its least trustworthy exactly when the backlog matters most. Fixing that belongs in Sturnus.\n\n`max`, not `sum`: the depth is a global count of rows in one table, and every worker reports the whole of it. Summing would double the queue for as long as a rollout has two pods alive.\n\nMind the name too: the metric is called `sturnus_queue_depth_ratio` but is a **count**, not a ratio. The `_ratio` suffix is appended by the OTel Prometheus exporter because the instrument declares unit `1`. Renaming it belongs in Sturnus, not here.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max by (status) (sturnus_queue_depth_ratio)",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false,
+            "lineInterpolation": "stepAfter"
+          },
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 16,
+      "title": "Job outcomes in range",
+      "type": "bargauge",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "How the jobs that finished in the selected range ended.\n\nUp to 0.6.0 this metric reported every failed job as a success, because it read the return value of `process_one` -- which means \"a job was claimed\", not \"the job succeeded\".",
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 12,
+        "y": 25
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (outcome) (increase(sturnus_job_outcome_total[$__range]))",
+          "legendFormat": "{{outcome}}",
+          "range": true,
+          "instant": false,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -399,10 +915,189 @@
               {
                 "color": "green",
                 "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "done"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "failed|dead|error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "showUnfilled": true
+      }
+    },
+    {
+      "id": 17,
+      "title": "Waiting and running",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "What is outstanding right now. Zero on an empty queue is the normal case.\n\nDeliberately without an `or vector(0)` fallback: the metric stops being sampled while a job runs (see the panel to the left), and a panel that renders a stale or absent queue as a confident `0` is worse than one that shows no data.",
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 19,
+        "y": 25
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (status) (max by (status, instance) (sturnus_queue_depth_ratio{status=~\"pending|running\"}))",
+          "legendFormat": "{{status}}",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
               },
               {
-                "color": "yellow",
-                "value": 5
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "orientation": "auto",
+        "text": {
+          "valueSize": 48
+        }
+      }
+    },
+    {
+      "id": 18,
+      "title": "Job stages",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "panels": []
+    },
+    {
+      "id": 19,
+      "title": "Average stage duration",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Where the time goes: claim, download, decrypt, transcribe, complete. `transcribe` dominating is expected; anything else dominating is not.\n\nA mean over the selected range rather than a p95: this system finishes a handful of jobs a day, and at that count a quantile over a rate window is NaN far more often than it is a fact.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (stage) (increase(sturnus_job_stage_duration_seconds_sum[$__range])) / sum by (stage) (increase(sturnus_job_stage_duration_seconds_count[$__range]))",
+          "legendFormat": "{{stage}}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -412,72 +1107,36 @@
         },
         "overrides": []
       },
-      "options": {}
-    },
-    {
-      "id": 30,
-      "title": "Job-Stufen",
-      "type": "row",
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 26
-      },
-      "panels": []
-    },
-    {
-      "id": 31,
-      "title": "Dauer je Stufe (p95)",
-      "type": "timeseries",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
-      "description": "Wo die Zeit hingeht: claim, download, decrypt, transcribe, upload.",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 27
-      },
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, stage) (rate(sturnus_job_stage_duration_seconds_bucket[10m])))",
-          "legendFormat": "{{stage}}",
-          "range": true,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "unit": "s"
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
         },
-        "overrides": []
-      },
-      "options": {}
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     },
     {
-      "id": 32,
-      "title": "Ausgänge je Stufe",
+      "id": 20,
+      "title": "Stage outcomes",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
         "uid": "mimir"
       },
-      "description": "Ein anderer Ausgang als `ok` ist der Grund, hier hinzusehen.\n\nBis 0.6.0 meldete die Ausgangsmetrik jeden fehlgeschlagenen Job als erfolgreich, weil sie den Rückgabewert von `process_one` las — der bedeutet \"es wurde gearbeitet\", nicht \"es hat geklappt\".",
+      "description": "An outcome other than `ok` is the reason to look here.",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 34
       },
       "targets": [
         {
@@ -485,6 +1144,7 @@
           "expr": "sum by (stage, outcome) (rate(sturnus_job_stage_duration_seconds_count[10m]))",
           "legendFormat": "{{stage}} / {{outcome}}",
           "range": true,
+          "instant": false,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -494,31 +1154,201 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "custom": {},
-          "unit": "none"
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
         },
         "overrides": []
       },
-      "options": {}
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 21,
+      "title": "Per job",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "panels": []
+    },
+    {
+      "id": 22,
+      "title": "Track length handed to the decoder",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "How long the speech in a single job is. Sets the scale for everything above: a two-hour track at a real-time factor of 0.5 is four hours of decoding, and no amount of staring at the stall clock changes that.\n\n`mean` is the average over finished jobs in the selected range; `current job` is what the running one was handed, which is the number the ETA divides.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(sturnus_transcription_audio_duration_seconds_sum[$__range])) / sum(increase(sturnus_transcription_audio_duration_seconds_count[$__range]))",
+          "legendFormat": "mean",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        },
+        {
+          "editorMode": "code",
+          "expr": "max(sturnus_transcription_total_seconds)",
+          "legendFormat": "current job",
+          "range": true,
+          "instant": false,
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 23,
+      "title": "Average document creation",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "The last step: writing the protocol into Outline. Fast and boring when it works; this panel exists so that a session which transcribed fine but never reached a document is visible as itself rather than as a missing link.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (outcome) (increase(sturnus_document_create_duration_seconds_sum[$__range])) / sum by (outcome) (increase(sturnus_document_create_duration_seconds_count[$__range]))",
+          "legendFormat": "{{outcome}}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     }
-  ],
-  "refresh": "1m",
-  "schemaVersion": 39,
-  "style": "dark",
-  "tags": [
-    "sturnus"
-  ],
-  "templating": {
-    "list": []
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "",
-  "title": "Sturnus — Transkription",
-  "uid": "sturnus-transcription",
-  "version": 1,
-  "weekStart": ""
+  ]
 }


### PR DESCRIPTION
Both Sturnus dashboards were German; everything else in this cluster is English, and a dashboard is read by whoever is on call. While translating them, three things turned out to be wrong rather than merely untranslated.

## The two pods

Every worker-side series carries `instance`, which is the pod name. A rollout therefore left the old pod's series beside the new one for as long as the time range reached back — one job drawn as two identically labelled lines, and two progress gauges reading `1.21%` and `38.1%` for what was the same job.

- Instantaneous panels (state, progress, ETA, stall clock) are now `instant` queries, so a stale pod drops out entirely.
- Time series aggregate with `max by (model)`, exact while the worker Deployment runs one replica.
- If it is ever scaled out, these panels will show the furthest-along job rather than each of them, and will need an `instance` split back. The panel descriptions say so, rather than leaving the next reader to find out.

## Queue depth was double-counted

The depth is a global count of rows in one table, and every worker reports the whole of it. `sum by (status)` across two pods reported twice the queue. Now `max by (status)`.

The larger problem is that the figure **freezes while a job runs**: the worker samples it in `database_ping`, which runs once per pass of the claim loop, so a two-hour transcription leaves the last sample standing untouched — the panel is least trustworthy exactly when the backlog matters most. That is a defect in Sturnus, not in this dashboard, and until it is fixed the panel says so.

Related: the "waiting and running" stat deliberately has **no** `or vector(0)` fallback. Rendering an absent queue as a confident `0` is worse than showing no data.

## Quantiles replaced by means

This system finishes a handful of jobs a day. `histogram_quantile` over a rate window rendered `NaN` far more often than it rendered a fact. Stage duration, track length and document creation are now means over the selected range.

## New — transcription page

A first row that answers the actual question in one glance: **is anything running, how far along, when is it done, and is it moving?**

| Panel | Why |
|---|---|
| Worker state | The instruments report nothing while idle, so absence *is* the answer — this turns it into a word instead of an empty gauge. |
| Progress | Over the speech the gate handed to the decoder, not over the file. |
| Estimated time remaining | Remaining speech over current decode rate. Runs away into days when the decoder stalls, which is deliberate: a 60-hour ETA is the plainest way of saying nothing is progressing. |
| Since last segment | The stall clock. |
| Worker CPU | Right beside it, because the stall clock alone cannot tell a hard decode from a hang. |

Plus job outcomes (`sturnus_job_outcome_total` existed and nothing displayed it), track length handed to the decoder, and document creation.

## New — resources page

**Peak memory in range** per container, and that peak as a share of its limit.

This is the measurement the memory limit has to be set from, and the one this project has been missing. A figure measured with `tiny` carries its *delta* to production but never its *level* — large-v3 holds roughly 2 GB more weights — and a limit narrowed on `tiny` numbers is what OOM-killed the worker 18 minutes into a job.

Also an explicit **OOM-kill count**, kept apart from the restart count: a crash loop and an OOM kill look identical there, and only one of them is fixed by changing a number.

## Verification

Every query in both files was run against Mimir before committing — 18 targets on the transcription page, 16 on the resources page, all returning `success`. `kubectl kustomize` builds. Panel ids are unique and no two panels overlap in the grid.
