### PR TITLE
fix(trivy-operator): stop the OOMKill loop and harden its own pods

### DIFF
--- a/infrastructure/clusters/feather-core/security/trivy-operator/release.yaml
+++ b/infrastructure/clusters/feather-core/security/trivy-operator/release.yaml
@@ -11,9 +11,21 @@ spec:
     resources:
       requests:
         cpu: 100m
-        memory: 128Mi
+        # The operator sits at ~400Mi steady-state with this many reports.
+        memory: 384Mi
       limits:
-        memory: 512Mi
+        # 512Mi OOMKilled it in a loop (119 restarts/7d), which silently
+        # truncated the reports it had already written.
+        memory: 1Gi
+
+    # The image already declares USER 10000; this only states it so the
+    # admission-level checks (KSV-0012/0118) can see it.
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 10000
+      runAsGroup: 10000
+      seccompProfile:
+        type: RuntimeDefault
 
     trivy:
       # ClientServer, not Standalone: a Standalone scan job runs one trivy
@@ -37,6 +49,24 @@ spec:
           # 512Mi OOMKilled the scans of larger images (reposilite, bluemap,
           # dependency-track). Requests stay low — this is a burst ceiling.
           memory: 2Gi
+
+      server:
+        # Restates the chart defaults (runAsUser/fsGroup 65534) so the added
+        # keys don't drop them — Helm replaces the whole map.
+        podSecurityContext:
+          runAsNonRoot: true
+          runAsUser: 65534
+          runAsGroup: 65534
+          fsGroup: 65534
+          seccompProfile:
+            type: RuntimeDefault
+        securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
 
     operator:
       builtInTrivyServer: true


### PR DESCRIPTION
## Why

The trivy-operator pod had **119 restarts in seven days**, all `exitCode 137 / OOMKilled`. It sits at ~400Mi steady-state against a 512Mi limit:

```
trivy-operator-6c9cbf6fb4-4r6h5   6m   397Mi
```

Every kill truncated the report set mid-write, so the findings it published were an incomplete picture of the cluster. This is the prerequisite for acting on anything else Trivy reports.

## What changed

`infrastructure/clusters/feather-core/security/trivy-operator/release.yaml`:

- **Memory**: limit 512Mi → 1Gi, request 128Mi → 384Mi (so the scheduler places it against its real footprint).
- **Operator podSecurityContext**: `runAsNonRoot` / `runAsUser: 10000` / `runAsGroup: 10000` / `seccompProfile: RuntimeDefault`.
- **trivy-server**: `podSecurityContext` restates the chart's `runAsUser`/`fsGroup` 65534 defaults (Helm replaces the whole map) plus `runAsGroup` and seccomp; `securityContext` restates `privileged: false` / `readOnlyRootFilesystem: true` plus `allowPrivilegeEscalation: false` and `capabilities.drop: [ALL]`.

## Risk

Low. The values are descriptive, not behavioural:

- `kubectl exec deploy/trivy-operator -- id` -> `uid=10000(trivyoperator)`, so the image already runs as that user. Stating it changes nothing at runtime, it only makes the setting visible to the admission-level checks.
- `trivy-server-0 -- id` -> `uid=65534(nobody)`, likewise. It already runs with `readOnlyRootFilesystem: true` and needs no capabilities.
- Blast radius is the `security` Flux layer only. Nothing depends on it.

## Findings closed

`AVD-KSV-0012`, `AVD-KSV-0118`, `AVD-KSV-0104`, `AVD-KSV-0030`, `AVD-KSV-0001`, `AVD-KSV-0003`, `AVD-KSV-0004`, `AVD-KSV-0106` in `trivy-system`.

`AVD-KSV-0020`/`0021` (UID/GID must be > 10000) stay open deliberately — moving off the image's built-in user for two LOW findings is not worth the risk.

## Verification

`./scripts/validate.sh` passes.