### PR TITLE
feat(security): enforce the baseline Pod Security Standard per namespace

### DIFF
--- a/apps/base/apus/namespace.yaml
+++ b/apps/base/apus/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: apus-system
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/bluemap/namespace.yaml
+++ b/apps/base/bluemap/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: bluemap
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/dependency-track/namespace.yaml
+++ b/apps/base/dependency-track/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: dependency-track
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/grafana/namespace.yaml
+++ b/apps/base/grafana/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: grafana
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/harbor/namespace.yaml
+++ b/apps/base/harbor/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: harbor
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/loki/namespace.yaml
+++ b/apps/base/loki/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: grafana
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/metabase/namespace.yaml
+++ b/apps/base/metabase/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: metabase
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/n8n/namespace.yaml
+++ b/apps/base/n8n/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: n8n
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/node-red/namespace.yaml
+++ b/apps/base/node-red/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: node-red
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/ollama/namespace.yaml
+++ b/apps/base/ollama/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ollama
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/otis/namespace.yaml
+++ b/apps/base/otis/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: otis
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/outline/namespace.yaml
+++ b/apps/base/outline/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: outline
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/penpot/namespace.yaml
+++ b/apps/base/penpot/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: penpot
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/reposilite/namespace.yml
+++ b/apps/base/reposilite/namespace.yml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: reposilite
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/sentry/namespace.yaml
+++ b/apps/base/sentry/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: sentry
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/shlink/namespace.yaml
+++ b/apps/base/shlink/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: shlink
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/sturnus/namespace.yaml
+++ b/apps/base/sturnus/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: sturnus
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/uptime-kuma/namespace.yaml
+++ b/apps/base/uptime-kuma/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: uptime-kuma
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/vikunja/namespace.yaml
+++ b/apps/base/vikunja/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: vikunja
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/base/vulpes-backend/namespace.yaml
+++ b/apps/base/vulpes-backend/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: vulpes
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/clusters/feathre-core/apps/otis-dev/namespace.yaml
+++ b/apps/clusters/feathre-core/apps/otis-dev/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: otis-dev
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/clusters/feathre-core/apps/vulpes-backend-dev/namespace.yaml
+++ b/apps/clusters/feathre-core/apps/vulpes-backend-dev/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: vulpes-dev
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/clusters/feathre-core/base-apps/reposilite/namespace.yml
+++ b/apps/clusters/feathre-core/base-apps/reposilite/namespace.yml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: reposilite
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/infrastructure/base/controllers/cert-manager/namespace.yaml
+++ b/infrastructure/base/controllers/cert-manager/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/infrastructure/base/controllers/cloudflare-tunnel-ingress-controller/namespace.yaml
+++ b/infrastructure/base/controllers/cloudflare-tunnel-ingress-controller/namespace.yaml
@@ -8,5 +8,5 @@ metadata:
     # token — do not widen it. Set explicitly so the intent survives a change
     # to the Talos cluster-wide default.
     pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/warn: baseline
-    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/infrastructure/base/controllers/cnpg-operator/namespace.yaml
+++ b/infrastructure/base/controllers/cnpg-operator/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cnpg-system
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/infrastructure/base/controllers/descheduler/namespace.yaml
+++ b/infrastructure/base/controllers/descheduler/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: descheduler
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/infrastructure/base/controllers/envoy/namespace.yaml
+++ b/infrastructure/base/controllers/envoy/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: envoy
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/infrastructure/base/controllers/mariadb-operator-crds/namespace.yaml
+++ b/infrastructure/base/controllers/mariadb-operator-crds/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: mariadb-operator
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/infrastructure/base/controllers/step-certificates/namespace.yml
+++ b/infrastructure/base/controllers/step-certificates/namespace.yml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: step-ca
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/infrastructure/base/controllers/step-issuer/namespace.yaml
+++ b/infrastructure/base/controllers/step-issuer/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: step-issuer
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/infrastructure/base/controllers/strimzi-operator/namespace.yaml
+++ b/infrastructure/base/controllers/strimzi-operator/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: strimzi-system
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/infrastructure/base/controllers/trivy-operator/namespace.yaml
+++ b/infrastructure/base/controllers/trivy-operator/namespace.yaml
@@ -5,3 +5,7 @@ metadata:
   # hostPID/hostPath, and it is disabled here (see release.yaml) — the
   # operator, trivy-server and scan jobs all run fine under `baseline`.
   name: trivy-system
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/infrastructure/clusters/feather-core/base-configs/s3-proxy.yaml
+++ b/infrastructure/clusters/feather-core/base-configs/s3-proxy.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: storage-proxy
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
 ---
 # ReferenceGrant: allows HTTPRoute in storage-proxy to use service in rook-ceph-fr01
 apiVersion: gateway.networking.k8s.io/v1beta1

--- a/infrastructure/clusters/feather-core/configs/kafka/namespace.yaml
+++ b/infrastructure/clusters/feather-core/configs/kafka/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kafka
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/infrastructure/clusters/feather-core/configs/mariadb-galera/namespace.yaml
+++ b/infrastructure/clusters/feather-core/configs/mariadb-galera/namespace.yaml
@@ -4,5 +4,5 @@ metadata:
   name: mariadb-galera
   labels:
     pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/warn: baseline
-    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/infrastructure/clusters/feather-core/controllers/dragonfly/namespace.yaml
+++ b/infrastructure/clusters/feather-core/controllers/dragonfly/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: dragonfly
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted


### PR DESCRIPTION
## What

Adds the three Pod Security Admission labels to all 35 namespaces this repo owns:

```yaml
labels:
  pod-security.kubernetes.io/enforce: baseline
  pod-security.kubernetes.io/warn: restricted
  pod-security.kubernetes.io/audit: restricted
```

`baseline` is the level that rejects what nothing here legitimately does: privileged containers, host namespaces, hostPath volumes, dangerous capabilities. `restricted` stays advisory — the gap surfaces as a kubectl warning and in the audit log, but never blocks a rollout.

## Risk: verified, not assumed

Applying a PSA label with `--dry-run=server` makes the API server evaluate every **running** pod in the namespace and warn about violations. I ran that for all 35 namespaces:

```
=== DRY-RUN FERTIG ===   # zero warnings
```

To prove the check was live rather than silently passing, the same command against a namespace that *does* violate:

```
$ kubectl label ns grafana pod-security.kubernetes.io/enforce=restricted --dry-run=server
Warning: existing pods in namespace "grafana" violate the new PodSecurity enforce level "restricted:latest"
Warning: alloy-logs-2dw8m (and 7 other pods): allowPrivilegeEscalation != false, ...

$ kubectl label ns rook-ceph-fr01 pod-security.kubernetes.io/enforce=baseline --dry-run=server
Warning: existing pods in namespace "rook-ceph-fr01" violate the new PodSecurity enforce level "baseline:latest"
Warning: node-debugger-... (and 14 other pods): host namespaces, hostPath volumes, privileged
```

So: no running workload breaks on merge.

## What this does change

From merge on, a **future** pod that violates baseline is rejected at admission — a chart upgrade that introduces a privileged sidecar would fail to schedule rather than silently gaining host access. That is the point of the change, and it is the one thing to keep in mind when a Renovate chart bump lands.

## Deliberately excluded

`rook-ceph`, `rook-ceph-fr01`, `kube-system`, `metallb-system` — these genuinely need privileged pods and host namespaces. Labelling them would break storage and networking.

`default` is left unlabelled so `kubectl debug node/...` keeps working.

## Note

`apps/base/grafana/namespace.yaml` and `apps/base/loki/namespace.yaml` both declare the `grafana` namespace (pre-existing, they live in different Flux layers). Both got identical labels so the two layers do not fight over the object.

## Verification

`./scripts/validate.sh` passes.