### PR TITLE
feat(micronaut): run as uid 1000 and harden the otel init container

### DIFF
--- a/helm/micronaut/Chart.yaml
+++ b/helm/micronaut/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/micronaut/templates/deployment.yaml
+++ b/helm/micronaut/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
         - name: otel-agent
           image: {{ .Values.tracing.image }}
           command: ["cp", "/javaagent.jar", "/otel/javaagent.jar"]
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext:
+            {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.tracing.resources | nindent 12 }}
           volumeMounts:
@@ -134,6 +138,10 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
+            # The root filesystem is read-only; the JVM still wants a scratch
+            # dir (java.io.tmpdir, Netty, JIT dumps).
+            - name: tmp
+              mountPath: /tmp
             - name: config
               mountPath: /config
             {{- if and .Values.secrets.enabled .Values.secrets.files }}
@@ -146,6 +154,8 @@ spec:
               readOnly: true
             {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: config
           configMap:
             name: {{ include "micronaut.fullname" . }}-config

--- a/helm/micronaut/values.yaml
+++ b/helm/micronaut/values.yaml
@@ -63,16 +63,17 @@ podAnnotations: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
-
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# Pod-level. Verified against the otis and vulpes-backend images with a probe
+# pod: both reach Micronaut context startup as uid 1000 with a read-only root
+# filesystem, so nothing here depends on running as root.
+securityContext:
+  enabled: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:


### PR DESCRIPTION
Covers all four releases on the in-repo `micronaut` chart: **otis, otis-dev, vulpes, vulpes-dev**.

## What was actually open

The app container was already fine — live `otis` shows:

```json
app: {"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}
```

Two gaps remained:

1. **No pod-level securityContext** (`pod: {}`) — so both containers ran as root with no seccomp profile. That is `KSV-0012`, `KSV-0104`, `KSV-0030`, `KSV-0118`.
2. **The otel-agent init container had no securityContext at all** (`init: none`). That is where the single-count `KSV-0001` / `0003` / `0004` / `0014` / `0106` findings came from — not the app container.

## Changes

- `values.yaml`: pod-level `securityContext` now `enabled` with `runAsNonRoot`, uid/gid/fsGroup 1000 and `seccompProfile: RuntimeDefault`. The dead `podSecurityContext: {}` key is removed — no template ever read it.
- `templates/deployment.yaml`: the init container reuses `containerSecurityContext`; `/tmp` becomes an emptyDir.
- `Chart.yaml`: `0.5.2` → `0.6.0` (required, or Flux serves the cached render).

## Risk: measured, not assumed

I ran probe pods against the real images before writing any of this.

**otis:latest** and **vulpes-backend:2.3.0**, as uid 1000 with `readOnlyRootFilesystem: true` and `drop: [ALL]`:

```
Caused by: java.net.ConnectException: Connection refused   # 127.0.0.1:3336
```

Both reach Micronaut context startup and fail only on the database socket — expected, since the probe mounts no config. No `read-only file system`, no `permission denied`, logback initialises and emits JSON.

**The init container**, same constraints:

```
-rw-r--r--  1 1000  1000  24665598  /otel/javaagent.jar
INIT-COPY-OK
```

**Nothing writable is lost.** All four releases mount only `["config","otel-agent"]` — a ConfigMap and the agent emptyDir. There is no PVC and no writable host path, so moving off uid 0 takes nothing away. `/tmp` as an emptyDir strictly *adds* a writable path that did not exist before (the live pods already run with a read-only rootfs as root), and makes the shipped config identical to the one I tested.

## Rollout

Four deployments roll. otis and vulpes have `otis-dev` / `vulpes-dev` twins that reconcile from the same chart, so a problem shows up in dev on the same pass.

## Verification

`./scripts/validate.sh` passes; `helm template` renders the expected pod, init and container contexts.