### PR TITLE
feat(shlink,outline): give both charts an explicit security context

### DIFF
--- a/helm/outline/Chart.yaml
+++ b/helm/outline/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/outline/values.yaml
+++ b/helm/outline/values.yaml
@@ -199,16 +199,21 @@ podAnnotations: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+# uid 1000 (node) is what the outline image already runs as; this only
+# states it so it is enforced rather than inherited.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 
 # Additional volumes on the output Deployment definition.
 volumes: []

--- a/helm/shlink/Chart.yaml
+++ b/helm/shlink/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/shlink/values.yaml
+++ b/helm/shlink/values.yaml
@@ -31,16 +31,23 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+# uid 1001 / gid 0 is what the shlink image already runs as; this only
+# states it so it is enforced rather than inherited.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 0
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# readOnlyRootFilesystem is deliberately absent: shlink writes its 63 MB
+# GeoLite2-City.mmdb, its locks and its cache into /etc/shlink/data, and the
+# chart mounts no volume there.
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## What was open

Neither in-repo chart set a `securityContext` at all — `securityContext: {}` and `podSecurityContext: {}` were still the scaffold defaults. So both workloads inherited the default context: root-capable, every capability retained, no seccomp profile. That is `KSV-0118` (HIGH), `KSV-0001`, `KSV-0012`, `KSV-0104`, `KSV-0030`, `KSV-0003`, `KSV-0004`, `KSV-0106`.

## Changes

`helm/outline/values.yaml`, `helm/shlink/values.yaml` — pod-level `runAsNonRoot` + uid/gid + `seccompProfile: RuntimeDefault`, container-level `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]`. Both `Chart.yaml` versions bumped to `0.6.0` (required, or Flux serves the cached render).

## Risk: none at runtime

The uids are not new — they are what the images already run as:

```
$ kubectl exec -n outline deploy/outline-web -- id
uid=1000(node) gid=1000(node) groups=1000(node)
$ kubectl exec -n outline deploy/outline-collaboration -- id
uid=1000(node) gid=1000(node) groups=1000(node)
$ kubectl exec -n shlink deploy/shlink -- id
uid=1001 gid=0(root) groups=0(root)
```

So `runAsUser`/`runAsGroup` restate current behaviour. Neither workload is privileged, neither binds a port below 1024 (both 8080), so `drop: [ALL]` and `allowPrivilegeEscalation: false` remove nothing they use.

`fsGroup` is set for outline and omitted for shlink — shlink mounts no volumes, so it would have been a no-op.

## What is deliberately *not* here

**`readOnlyRootFilesystem`.**

- **shlink genuinely needs a writable root.** It writes into `/etc/shlink/data`, and the chart mounts no volume there:
  ```
  $ kubectl exec -n shlink deploy/shlink -- ls -la /etc/shlink/data
  -rw-rw-rw- 1 1001 root 65926799 GeoLite2-City.mmdb    # 62.9M
  drwxr-xr-x cache  locks  log  proxies  temp-geolite
  ```
  Making that an emptyDir would mean re-downloading 63 MB of GeoLite on every pod start — a real behavioural change, not a hardening no-op.

- **outline writes nothing to its root filesystem.** Over ~8 days of pod uptime, `find / -xdev -newer /etc/hostname -type f` returns only `/etc/hosts` (kubelet-managed), and `/tmp` is empty in both deployments. But neither HelmRelease configures `upgrade.remediation`, so a bad upgrade would not roll back on its own — and outline is where this org's documentation lives. It gets its own PR with the `/tmp` emptyDir alongside, rather than riding along here.

## Verification

`./scripts/validate.sh` passes; `helm template` renders both contexts as intended.