### PR TITLE
feat(uptime-kuma): run non-root on a read-only root filesystem

### DIFF
--- a/apps/clusters/feathre-core/base-apps/uptime-kuma/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/uptime-kuma/release.yaml
@@ -59,6 +59,38 @@ spec:
       enabled: true
     volume:
       enabled: false
+
+    # Everything except dropping capabilities. Each setting was probed against
+    # louislam/uptime-kuma:2.3.2 in-cluster before being written here; the
+    # capability drop is the one that breaks ping monitors:
+    #   root + seccomp + allowPrivilegeEscalation:false   -> ping ok
+    #   root + capabilities.drop:[ALL]                    -> ping exits 126
+    #   uid 1000 + noPrivEsc + readOnly, caps untouched   -> ping ok
+    # /usr/bin/ping carries cap_net_raw=ep, so emptying the bounding set makes
+    # the exec itself fail. KSV-0003/0004/0106 stay open on purpose.
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+
+    # The read-only root filesystem needs these two writable; the chart mounts
+    # nothing itself because volume.enabled is false (state lives in MariaDB).
+    additionalVolumes:
+      - name: tmp
+        emptyDir: {}
+      - name: data
+        emptyDir: {}
+    additionalVolumeMounts:
+      - name: tmp
+        mountPath: /tmp
+      - name: data
+        mountPath: /app/data
     podEnv:
       - name: UPTIME_KUMA_DB_TYPE
         value: "mariadb"


### PR DESCRIPTION
## What was open

The deployment had no security context at all — `pod={}`, `c={}`. Root, full default capability set, no seccomp profile: `KSV-0118` (HIGH), `KSV-0014` (HIGH), `KSV-0012`, `KSV-0001`, `KSV-0104`, `KSV-0030`.

## The catch, and why this PR does not drop capabilities

uptime-kuma's ping monitors run `/usr/bin/ping`, which carries a file capability:

```
$ kubectl exec -n uptime-kuma deploy/uptime-kuma -- getcap /usr/bin/ping
/usr/bin/ping cap_net_raw=ep
```

A blanket `capabilities.drop: [ALL]` would have silently broken every ping monitor. I probed each setting separately against `louislam/uptime-kuma:2.3.2` in-cluster:

| Probe | Config | `ping -c2 1.1.1.1` |
|---|---|---|
| A | root + seccomp + `allowPrivilegeEscalation: false` | **0** ✅ |
| B | root + `capabilities.drop: [ALL]` | **126** ❌ |
| C | uid 1000 + seccomp only | **0** ✅ |
| D | uid 1000 + noPrivEsc + readOnly, caps untouched | **0** ✅ |

Emptying the bounding set makes the `exec` of a file-capability binary fail outright. So **D** is what ships. `KSV-0003`/`0004`/`0106` stay open on purpose — breaking every ping monitor to close three LOW findings is a bad trade.

## Changes

`apps/clusters/feathre-core/base-apps/uptime-kuma/release.yaml`:

- `podSecurityContext`: `runAsNonRoot`, uid/gid/fsGroup 1000, `seccompProfile: RuntimeDefault`
- `securityContext`: `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`
- `additionalVolumes` / `additionalVolumeMounts`: emptyDirs for `/tmp` and `/app/data`

## Risk

Low, and measured rather than argued.

- **No state is at risk.** `volume.enabled: false` — uptime-kuma keeps everything in the external MariaDB (`maxscale-galera`), and the namespace has no PVC at all. The two emptyDirs only give the read-only rootfs somewhere to write.
- **The full configuration was run before being written down.** A probe pod with exactly these settings came up `1/1 Running` and logged `Listening on: http://localhost:3001`.
- **Ping still works** under this exact combination (probe D above).

## Also noticed, not fixed here

The ServiceMonitor's basic auth is rejected — `curl -u metrics:… localhost:3001/metrics` returns **401**, and `monitor_status` has no series in Mimir. uptime-kuma's metrics have not been scraped for some time. Separate problem, separate change.

## Verification

`./scripts/validate.sh` passes.