### PR TITLE
feat(apps): give reposilite, metabase, bluemap and ollama a security context

### DIFF
--- a/apps/clusters/feathre-core/base-apps/bluemap/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/bluemap/release.yaml
@@ -23,6 +23,15 @@ spec:
                 path: /spec/template/spec/priorityClassName
                 value: feather-low
   values:
+    # Conservative on purpose. bluemap writes its rendered config and logs
+    # into root-owned /app/config and /app/bluemap/logs on the image layer, so
+    # runAsNonRoot and readOnlyRootFilesystem would break it. Those two
+    # findings stay open until the chart grows a writable data volume.
+    podSecurityContext:
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      allowPrivilegeEscalation: false
     podLabels:
       logs.onelitefeather.net/env: prod
     image:

--- a/apps/clusters/feathre-core/base-apps/metabase/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/metabase/release.yaml
@@ -5,6 +5,22 @@ metadata:
   namespace: metabase
 spec:
   values:
+    # Probed against metabase/metabase:v0.61.1.x in-cluster: comes up as
+    # uid 2000 with drop-ALL. /plugins is baked 0777 in the image, so the
+    # driver-plugin directory stays writable without a volume.
+    # readOnlyRootFilesystem is left out: the entrypoint writes /etc/passwd
+    # to register the runtime user.
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 2000
+      runAsGroup: 2000
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
     podLabels:
       logs.onelitefeather.net/env: prod
 

--- a/apps/clusters/feathre-core/base-apps/ollama/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/ollama/release.yaml
@@ -5,6 +5,15 @@ metadata:
   namespace: ollama
 spec:
   values:
+    # Conservative on purpose. ollama keeps 11 GB of models on a 30 Gi PVC
+    # mounted at /root/.ollama; moving off uid 0 changes HOME, so the models
+    # would be re-pulled, and fsGroup would recursively chown the volume on
+    # first start. Those findings stay open until that is done deliberately.
+    podSecurityContext:
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      allowPrivilegeEscalation: false
     podLabels:
       logs.onelitefeather.net/env: prod
     # CPU-only inference. No GPU on these nodes, so keep the GPU integration

--- a/apps/clusters/feathre-core/base-apps/reposilite/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/reposilite/release.yaml
@@ -25,6 +25,27 @@ spec:
       name: ghcr.io/onelitefeathernet/ingot
       tag: "1.1.0"
     deployment:
+      # Probed against ghcr.io/onelitefeathernet/ingot:1.1.0 in-cluster: comes
+      # up 1/1 as uid 1000 with drop-ALL and a read-only rootfs. Data is an
+      # emptyDir here (persistence is off), so there is no volume ownership to
+      # migrate.
+      podSecurityContext:
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containerSecurityContext:
+        enabled: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
       podLabels:
         logs.onelitefeather.net/env: prod
         # Reposilite's console logger emits ANSI SGR color codes with no JSON
@@ -36,6 +57,12 @@ spec:
         - name: otel-agent
           image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.30.0
           command: ["cp", "/javaagent.jar", "/otel/javaagent.jar"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           resources:
             requests:
               cpu: 10m
@@ -49,10 +76,21 @@ spec:
       additionalVolumes:
         - name: otel-agent
           emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        # tinylog's RollingFileWriter writes here; without this the read-only
+        # rootfs turns every start into a "Failed creating service
+        # implementation" error and file logging is silently lost.
+        - name: logging
+          emptyDir: {}
       additionalVolumeMounts:
         - name: otel-agent
           mountPath: /otel
           readOnly: true
+        - name: tmp
+          mountPath: /tmp
+        - name: logging
+          mountPath: /var/log/reposilite/
     ## Readiness and liveness probes
     probes:
       port: 8080 # The port Reposilite is running on inside the pod.


### PR DESCRIPTION
None of the four set a security context, so all four ran as root with the full default capability set and no seccomp profile: `KSV-0118` (HIGH), `KSV-0014` (HIGH), `KSV-0012`, `KSV-0001`, `KSV-0104`, `KSV-0030`.

How far each one goes is decided by what it actually writes — probed in-cluster, not guessed.

## reposilite — full hardening

uid 1000, `drop: [ALL]`, `readOnlyRootFilesystem: true`, seccomp. Safe because its data is an **emptyDir**, not a PVC:

```
$ kubectl get deploy -n reposilite -o json | jq '.items[0]...volumes'
[{"emptyDir":{},"name":"data"},{"emptyDir":{},"name":"otel-agent"}]
```

So there is no volume ownership to migrate. A probe pod with exactly this context came up `1/1 Running`. It surfaced one real thing:

```
LOGGER ERROR: Failed creating service implementation 'org.tinylog.writers.RollingFileWriter'
(/var/log/reposilite/log_….txt (Read-only file system))
```

— hence the `logging` emptyDir at `/var/log/reposilite/`. Without it the read-only rootfs would have silently cost the file logs. The inline `otel-agent` init container gets the same container context.

## metabase — non-root, writable root

uid 2000, `drop: [ALL]`, seccomp, no `readOnlyRootFilesystem`. Probed:

```
uid=2000 gid=2000
drwxrwxrwx 2 root root /plugins      # baked 0777 in the image
PLUGINS-WRITABLE=yes
```

`/plugins` needs no volume. The root filesystem stays writable because the entrypoint writes `/etc/passwd` to register the runtime user — `KSV-0014` stays open here on purpose.

## bluemap and ollama — seccomp and allowPrivilegeEscalation only

Both keep uid 0, deliberately:

- **bluemap** writes into root-owned `/app` on the image layer — `/app/config/webapp.conf`, `/app/bluemap/logs/*`. `runAsNonRoot` would break it; the chart has no writable data volume to move those to.
- **ollama** keeps 11 GB of models on a 30 Gi PVC at `/root/.ollama`. Moving off uid 0 changes `HOME`, so the models would be re-pulled, and `fsGroup` would recursively chown 11 GB on first start.

Both are worth doing properly later, with a volume change — not as a side effect of this.

## Risk

Low. The two settings applied everywhere (`seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`) were verified not to disturb a root container in a separate probe, and RuntimeDefault is what these images already run under outside Kubernetes. The two workloads that change user were each started under the exact shipped context first.

## Verification

`./scripts/validate.sh` passes.