### PR TITLE
feat(sentry): put a RuntimeDefault seccomp profile on every pod

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sentry/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/sentry/release.yaml
@@ -19,6 +19,39 @@ spec:
               - op: add
                 path: /spec/template/spec/priorityClassName
                 value: feather-standard
+          # The chart exposes securityContext per component - 58 separate keys,
+          # no global one - and the workloads disagree about the user they run
+          # as (sentry-web and clickhouse are root, snuba is uid 1000). A
+          # pod-level seccomp profile is the one setting that applies to all of
+          # them without touching the user or the capability set. Strategic
+          # merge, not a JSON patch: memcached and symbolicator already carry a
+          # pod securityContext and an `op: add` would replace it.
+          - target:
+              kind: Deployment
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: not-used-target-selects
+              spec:
+                template:
+                  spec:
+                    securityContext:
+                      seccompProfile:
+                        type: RuntimeDefault
+          - target:
+              kind: StatefulSet
+            patch: |
+              apiVersion: apps/v1
+              kind: StatefulSet
+              metadata:
+                name: not-used-target-selects
+              spec:
+                template:
+                  spec:
+                    securityContext:
+                      seccompProfile:
+                        type: RuntimeDefault
   values:
     # Everything stateful lives outside this release: postgres in CNPG, redis
     # in the shared Dragonfly, kafka in the Strimzi cluster, clickhouse in its


### PR DESCRIPTION
## What was open

82 workloads in the `sentry` namespace ran with **no seccomp profile at all** — `KSV-0104` (61) and `KSV-0030`. That was the single largest cluster of identical findings anywhere in the cluster.

## Why not a values block

The chart offers no global `securityContext`. It exposes one per component — **58 of them**:

```
sentry.web.securityContext           snuba.api.securityContext
sentry.taskWorker.securityContext    snuba.consumer.securityContext
relay.securityContext                symbolicator.api.securityContext
… 52 more
```

And the workloads disagree about the user they run as, so no single block fits:

```
$ kubectl exec -n sentry deploy/sentry-web       -- id  ->  uid=0(root)
$ kubectl exec -n sentry deploy/sentry-snuba-api -- id  ->  uid=1000(snuba)
$ kubectl exec -n sentry clickhouse-0            -- id  ->  uid=0(root)
```

A **pod-level seccomp profile** is the one hardening that applies uniformly to all of them without touching the user or the capability set. It goes on through the post-renderer that already sets `priorityClassName`, rather than as 58 near-identical values blocks.

## Strategic merge, not a JSON patch

Two pods already carry a pod security context:

```
sentry-memcached      pod={"fsGroup":11211}
sentry-symbolicator   pod={"fsGroup":65532,"runAsGroup":65532,"runAsUser":65532}
```

An `op: add` on `/spec/template/spec/securityContext` would **replace** that map and drop the fsGroup. A strategic merge patch merges into it instead. Verified against both shapes:

```
# had a securityContext                 # had none
securityContext:                        securityContext:
  fsGroup: 11211                          seccompProfile:
  seccompProfile:                           type: RuntimeDefault
    type: RuntimeDefault
```

## Risk

Low. `RuntimeDefault` is the profile container runtimes apply by default outside Kubernetes, so every one of these images — ClickHouse, Kafka, Zookeeper, the Python workers, the Rust relay — already runs under it in normal Docker use. Nothing about the user, the capabilities or the filesystem changes.

It does roll every pod in the namespace. The release already has a 30m timeout and 3 upgrade retries.

## Still open here

`KSV-0012` (runAsNonRoot), `KSV-0014` (readOnlyRootFilesystem) and `KSV-0118` need per-component work across those 58 keys, with each component's user established first. Not attempted here.

## Verification

`./scripts/validate.sh` passes; the rendered HelmRelease keeps both the existing `priorityClassName` patches and the two new ones.