### PR TITLE
feat(outline): make the root filesystem read-only

### DIFF
--- a/helm/outline/Chart.yaml
+++ b/helm/outline/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/outline/values.yaml
+++ b/helm/outline/values.yaml
@@ -211,19 +211,26 @@ podSecurityContext:
 
 securityContext:
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
       - ALL
 
 # Additional volumes on the output Deployment definition.
-volumes: []
+# /tmp is an emptyDir so the read-only root filesystem still leaves the
+# process a scratch dir (os.tmpdir(), attachment buffering).
+volumes:
+  - name: tmp
+    emptyDir: {}
 # - name: foo
 #   secret:
 #     secretName: mysecret
 #     optional: false
 
 # Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
+volumeMounts:
+  - name: tmp
+    mountPath: /tmp
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true


### PR DESCRIPTION
> **Not for automatic merge.** Deliberately split out and left for you to schedule — see Risk.

Closes the last config-audit finding on outline: `KSV-0014` (HIGH).

## Changes

`helm/outline/values.yaml` — `readOnlyRootFilesystem: true`, plus a `/tmp` emptyDir. `Chart.yaml` `0.6.0` → `0.7.0`.

## Evidence it writes nothing to its root filesystem

```
$ kubectl exec -n outline deploy/outline-web -- \
    find / -xdev -newer /etc/hostname -type f | grep -v ^/proc
/etc/hosts
```

Same for `outline-collaboration`, over roughly eight days of pod uptime. `/tmp` is empty in both. All persistent state lives in Postgres, Redis and S3 — the deployment mounts no PVC.

`/tmp` becomes an emptyDir regardless, so anything that does reach for `os.tmpdir()` keeps working. Attachment buffering is the realistic case, and such a temp file would have been unlinked before that `find` ran — which is exactly why the emptyDir is here rather than trusting the empty result.

## Risk — why this is separate

Outline is where this org's documentation lives, and **neither HelmRelease configures `upgrade.remediation`**:

```yaml
install:
  remediation:
    retries: 3
interval: 1m0s
```

So a failed upgrade does not roll back on its own — it would sit broken until someone reverts. The `find` evidence is strong but it is observational, not a probe of the shipped config (outline needs Postgres, Redis and S3 to start, so a throwaway probe pod cannot prove much).

Worth doing, worth doing when someone is watching. Two options if you would rather not babysit it:

1. Merge during a window and check `kubectl get pods -n outline` once.
2. Add `upgrade.remediation.remediateLastFailure: true` to both releases first, which makes this and every future outline upgrade self-healing. I did not add it here because it changes release-management behaviour beyond the scope of a hardening change.

## Verification

`./scripts/validate.sh` passes; `helm template` renders `readOnlyRootFilesystem: true` with the `/tmp` mount on both components.