### PR TITLE
feat(loki,tempo): put a RuntimeDefault seccomp profile on every pod

### DIFF
--- a/apps/clusters/feathre-core/monitoring/loki/release.yaml
+++ b/apps/clusters/feathre-core/monitoring/loki/release.yaml
@@ -13,6 +13,41 @@ spec:
       name: loki-s3
       valuesKey: secretAccessKey
       targetPath: loki.storage.s3.secretAccessKey
+  # loki and tempo already run non-root with an fsGroup per component; the one
+  # thing missing everywhere is a seccomp profile (KSV-0104, KSV-0030 across
+  # ~25 workloads). Applied by post-render rather than through the charts'
+  # securityContext values, because those are set per component with differing
+  # fsGroups (10001 for the stateful parts, 11211 for the memcached ones) and
+  # a values override would replace them. Strategic merge preserves them.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: not-used-target-selects
+              spec:
+                template:
+                  spec:
+                    securityContext:
+                      seccompProfile:
+                        type: RuntimeDefault
+          - target:
+              kind: StatefulSet
+            patch: |
+              apiVersion: apps/v1
+              kind: StatefulSet
+              metadata:
+                name: not-used-target-selects
+              spec:
+                template:
+                  spec:
+                    securityContext:
+                      seccompProfile:
+                        type: RuntimeDefault
   values:
     deploymentMode: Distributed
     # SimpleScalable targets default to 3 replicas each in this chart;

--- a/apps/clusters/feathre-core/monitoring/tempo/release.yaml
+++ b/apps/clusters/feathre-core/monitoring/tempo/release.yaml
@@ -4,6 +4,41 @@ metadata:
   name: tempo
   namespace: grafana
 spec:
+  # loki and tempo already run non-root with an fsGroup per component; the one
+  # thing missing everywhere is a seccomp profile (KSV-0104, KSV-0030 across
+  # ~25 workloads). Applied by post-render rather than through the charts'
+  # securityContext values, because those are set per component with differing
+  # fsGroups (10001 for the stateful parts, 11211 for the memcached ones) and
+  # a values override would replace them. Strategic merge preserves them.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: not-used-target-selects
+              spec:
+                template:
+                  spec:
+                    securityContext:
+                      seccompProfile:
+                        type: RuntimeDefault
+          - target:
+              kind: StatefulSet
+            patch: |
+              apiVersion: apps/v1
+              kind: StatefulSet
+              metadata:
+                name: not-used-target-selects
+              spec:
+                template:
+                  spec:
+                    securityContext:
+                      seccompProfile:
+                        type: RuntimeDefault
   values:
     global:
       podLabels:


### PR DESCRIPTION
## What was open

Across the loki and tempo stacks — roughly 25 workloads — the only config-audit findings left were `KSV-0104` and `KSV-0030`: no seccomp profile. Both stacks are otherwise in good shape already:

```
loki-compactor:      pod={"fsGroup":10001,"fsGroupChangePolicy":"OnRootMismatch",
                          "runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001}
loki-chunks-cache:   pod={"fsGroup":11211,"runAsGroup":11211,"runAsNonRoot":true,"runAsUser":11211}
```

## Why post-render and not values

The charts set `securityContext` per component, with **differing fsGroups** — 10001 for the stateful parts, 11211 for the memcached ones. A values override would replace those maps wholesale and break volume ownership.

A strategic merge patch adds the profile alongside whatever each component already carries. Same approach as #213, verified the same way with kustomize:

```
# component that had one                # component that had none
securityContext:                        securityContext:
  fsGroup: 11211                          seccompProfile:
  seccompProfile:                           type: RuntimeDefault
    type: RuntimeDefault
```

## Risk

Low. `RuntimeDefault` is what container runtimes apply by default outside Kubernetes, so these Go binaries already run under it in normal Docker use. Nothing about the user, capabilities, fsGroup or filesystem changes.

It does roll every loki and tempo pod. Both are ingest paths for observability data, not for user traffic — a rolling restart costs at most a gap in scrape/ingest, not an outage.

## Not included

- **alloy** (`alloy-logs`, `alloy-metrics`, `alloy-receiver`) — `alloy-logs` is a DaemonSet that reads host logs through a hostPath and needs to stay root. Its `KSV-0001`/`0012`/`0014`/`0118` findings need per-component work.
- **mimir** — its only finding is `KSV-0125` (untrusted registry), which is a policy-configuration matter, not a workload one.
- **grafana** itself — `KSV-0011`/`0015`/`0016`/`0018` are missing resource requests/limits, a separate concern.

## Verification

`./scripts/validate.sh` passes; both overlays render.