### PR TITLE
feat(controllers): give descheduler, step-issuer and strimzi a security context

### DIFF
--- a/infrastructure/base/controllers/descheduler/release.yaml
+++ b/infrastructure/base/controllers/descheduler/release.yaml
@@ -22,6 +22,15 @@ spec:
   interval: 1m0s
   timeout: 5m
   values:
+    # The chart already ships a fully restricted container context
+    # (drop-ALL, readOnlyRootFilesystem, runAsNonRoot, uid 1000). Only the
+    # pod-level part was missing.
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
     # Run as a CronJob (no leader election / always-on pod needed).
     kind: CronJob
     schedule: "*/15 * * * *"

--- a/infrastructure/base/controllers/step-issuer/release.yaml
+++ b/infrastructure/base/controllers/step-issuer/release.yaml
@@ -20,4 +20,18 @@ spec:
     remediation:
       retries: 3
   interval: 1m0s
-  values: {}
+  values:
+    # The chart sets only runAsUser/runAsGroup 1000 on the container. No
+    # readOnlyRootFilesystem here — untested against this image, and a broken
+    # external issuer stops certificate renewal.
+    podSecurityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL

--- a/infrastructure/clusters/feather-core/base-controllers/strimzi-operator/release.yaml
+++ b/infrastructure/clusters/feather-core/base-controllers/strimzi-operator/release.yaml
@@ -15,6 +15,21 @@ spec:
     # sentry namespace. Watching cluster-wide removes that ordering coupling.
     watchAnyNamespace: true
 
+    # Chart 1.1.0 ships `securityContext: {}`; upstream added exactly this
+    # block as the default in a later version, which is where these values
+    # come from. The operator already runs as uid 1001, so only the settings
+    # below are new.
+    podSecurityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+
     # Chart defaults are already sane here (384Mi/1000m limits, 384Mi/200m
     # requests); pinned explicitly so a chart bump cannot silently change them.
     resources:


### PR DESCRIPTION
Three control-plane operators whose pods can restart without anyone noticing — the cheapest place to close these findings.

## descheduler

The chart already ships a fully restricted **container** context:

```yaml
securityContext:
  allowPrivilegeEscalation: false
  capabilities: {drop: [ALL]}
  privileged: false
  readOnlyRootFilesystem: true
  runAsNonRoot: true
  runAsUser: 1000
```

Only the pod-level half was missing (`KSV-0030`, `KSV-0104`, `KSV-0118`). Added.

## strimzi-kafka-operator

Pinned at chart `1.1.0`, which ships `securityContext: {}` — hence `KSV-0001`, `0012`, `0014`, `0104`, `0118`.

The block added here is **upstream's own default from a later chart version**, copied verbatim rather than invented:

```yaml
securityContext:
  allowPrivilegeEscalation: false
  runAsNonRoot: true
  readOnlyRootFilesystem: true
  capabilities: {drop: [ALL]}
  seccompProfile: {type: RuntimeDefault}
```

The operator already runs as a non-root user (`uid=1001(strimzi)`), so only the capability, escalation and filesystem settings are new — and they are the settings Strimzi themselves ship.

## step-issuer

The chart sets only `runAsUser`/`runAsGroup: 1000` on the container. It gets `drop: [ALL]`, `allowPrivilegeEscalation: false` and a seccomp profile.

**No `readOnlyRootFilesystem`** — untested against this image, and a broken external issuer stops certificate renewal. `KSV-0014` stays open here on purpose.

## Deliberately not included

`cloudflare-tunnel-ingress-controller` carries live ingress traffic. It has the same findings and the same likely fix, but it does not belong in a batch merged without someone watching.

## Risk

Low. All three are controllers, not data planes: if one fails to start, the cluster keeps serving and the operator simply stops reconciling until it is reverted. `mariadb` and `kafka` clusters keep running without their operators; descheduler not running just means no rebalancing.

## Verification

`./scripts/validate.sh` passes.