### PR TITLE
feat(penpot): put a RuntimeDefault seccomp profile on every pod

### DIFF
--- a/apps/clusters/feathre-core/base-apps/penpot/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/penpot/release.yaml
@@ -15,6 +15,23 @@ spec:
               - op: add
                 path: /spec/template/spec/priorityClassName
                 value: feather-standard
+          # The chart already runs every component non-root as uid 1001 with
+          # drop-ALL and no privilege escalation; a pod-level seccomp profile
+          # was the only thing missing (KSV-0104, 5 workloads). Strategic
+          # merge rather than `op: add` so the existing fsGroup 1001 survives.
+          - target:
+              kind: Deployment
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: not-used-target-selects
+              spec:
+                template:
+                  spec:
+                    securityContext:
+                      seccompProfile:
+                        type: RuntimeDefault
   values:
     config:
       publicUri: "https://penpot.onelitefeather.net"


### PR DESCRIPTION
## What was open

penpot was already in good shape. Every one of the four components runs non-root with capabilities dropped:

```
penpot-backend:  pod={"fsGroup":1001}
                 c={"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},
                    "readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}
```

The only thing missing across the five workloads was a seccomp profile — `KSV-0104`.

## Change

Added through the post-renderer that already sets `priorityClassName`. **Strategic merge, not `op: add`** — an `op: add` on `/spec/template/spec/securityContext` would replace the whole map and drop the existing `fsGroup: 1001`. Same pattern and same verification as #213 and #215.

## Risk

Low. `RuntimeDefault` is the profile container runtimes apply by default outside Kubernetes. Nothing about the user, capabilities, fsGroup or filesystem changes. Four Deployments roll.

## Still open

`KSV-0014` — the chart sets `readOnlyRootFilesystem: false` explicitly on every component, so turning it on needs each one's write paths established first. Not attempted here.

## Verification

`./scripts/validate.sh` passes; the rendered HelmRelease keeps the `priorityClassName` patch alongside the new one.