### PR TITLE
revert(sentry): drop the seccomp post-renderer, it cannot roll symbolicator

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sentry/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/sentry/release.yaml
@@ -19,39 +19,6 @@ spec:
               - op: add
                 path: /spec/template/spec/priorityClassName
                 value: feather-standard
-          # The chart exposes securityContext per component - 58 separate keys,
-          # no global one - and the workloads disagree about the user they run
-          # as (sentry-web and clickhouse are root, snuba is uid 1000). A
-          # pod-level seccomp profile is the one setting that applies to all of
-          # them without touching the user or the capability set. Strategic
-          # merge, not a JSON patch: memcached and symbolicator already carry a
-          # pod securityContext and an `op: add` would replace it.
-          - target:
-              kind: Deployment
-            patch: |
-              apiVersion: apps/v1
-              kind: Deployment
-              metadata:
-                name: not-used-target-selects
-              spec:
-                template:
-                  spec:
-                    securityContext:
-                      seccompProfile:
-                        type: RuntimeDefault
-          - target:
-              kind: StatefulSet
-            patch: |
-              apiVersion: apps/v1
-              kind: StatefulSet
-              metadata:
-                name: not-used-target-selects
-              spec:
-                template:
-                  spec:
-                    securityContext:
-                      seccompProfile:
-                        type: RuntimeDefault
   values:
     # Everything stateful lives outside this release: postgres in CNPG, redis
     # in the shared Dragonfly, kafka in the Strimzi cluster, clickhouse in its


### PR DESCRIPTION
Reverts #213. The patch itself is correct — it is undeployable in this namespace.

## What happened

`sentry-symbolicator-api` is the one Deployment in `sentry` backed by a **ReadWriteOnce PVC**, and it uses `strategy: RollingUpdate`. Any change to its pod template deadlocks: the new pod cannot attach the volume while the old one holds it, and the old one is not torn down until the new one is ready.

```
Warning  FailedAttachVolume  pod/sentry-symbolicator-api-6f9fc8b8f7-czv82
  Multi-Attach error for volume "pvc-36e959ec-4a0b-4164-b1e6-ff2d664b9fe1"
  Volume is already used by pod(s) sentry-symbolicator-api-68db4c6985-2pqfw
```

Helm gave up:

```
$ helm history sentry -n sentry
8  Sat Aug 22 16:29:07 2026  failed    Upgrade "sentry" failed: failed early due to
                                       stalled resources: [Deployment/sentry/sentry-symbolicator-api status: 'Failed']
9  Sat Aug 22 16:39:33 2026  deployed  Rollback to 7
```

Flux rolled back to revision 7, so the seccomp profile reached **none** of the 57 workloads (`0/57`) while the release sat on `upgradeFailures=1` of 3 retries. The change bought nothing and would have kept thrashing symbolicator's ReplicaSet up and down on each retry.

## No outage occurred

The rollback held. `sentry-symbolicator-api` is `1/1 Running` on its original 29h-old pod throughout — the stalled new pod never displaced it. This revert restores the state the namespace was in beforehand.

## Why this was not caught earlier

The patch was verified against kustomize (it renders correctly, and it preserves `fsGroup` on `sentry-memcached`) and against the *other* namespaces where the identical construct works — penpot is at `4/4` and loki/tempo at `19/19` with the same patch shape. What I did not check was whether every affected Deployment is actually **capable** of a rolling update. That is the missing step: a pod-template change is only safe if the workload can roll.

## Follow-up worth doing separately

`sentry-symbolicator-api` is un-rollable as it stands — this is not specific to seccomp. Any future chart bump touching that Deployment hits the same wall. Fixing it means `strategy: Recreate` (a few seconds of symbolicator downtime per change, which is what it already effectively needs), after which the seccomp patch can go back in unchanged.

## Verification

`./scripts/validate.sh` passes.