### PR TITLE
feat(sentry): make symbolicator rollable, then put seccomp on every pod

### DIFF
--- a/apps/clusters/feathre-core/base-apps/sentry/release.yaml
+++ b/apps/clusters/feathre-core/base-apps/sentry/release.yaml
@@ -19,6 +19,57 @@ spec:
               - op: add
                 path: /spec/template/spec/priorityClassName
                 value: feather-standard
+          # sentry-symbolicator-api is the only Deployment here backed by a
+          # ReadWriteOnce PVC, and it ships with RollingUpdate. That makes it
+          # un-rollable: the new pod cannot attach the volume while the old one
+          # holds it, and the old one is not torn down until the new one is
+          # ready. It has to go first, or nothing else below can land — see
+          # PR #218 for the upgrade this deadlocked.
+          - target:
+              kind: Deployment
+              name: sentry-symbolicator-api
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: sentry-symbolicator-api
+              spec:
+                strategy:
+                  type: Recreate
+                  rollingUpdate: null
+          # The chart exposes securityContext per component - 58 separate keys,
+          # no global one - and the workloads disagree about the user they run
+          # as (sentry-web and clickhouse are root, snuba is uid 1000). A
+          # pod-level seccomp profile is the one setting that applies to all of
+          # them without touching the user or the capability set. Strategic
+          # merge, not a JSON patch: memcached and symbolicator already carry a
+          # pod securityContext and an `op: add` would replace it.
+          - target:
+              kind: Deployment
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: not-used-target-selects
+              spec:
+                template:
+                  spec:
+                    securityContext:
+                      seccompProfile:
+                        type: RuntimeDefault
+          - target:
+              kind: StatefulSet
+            patch: |
+              apiVersion: apps/v1
+              kind: StatefulSet
+              metadata:
+                name: not-used-target-selects
+              spec:
+                template:
+                  spec:
+                    securityContext:
+                      seccompProfile:
+                        type: RuntimeDefault
   values:
     # Everything stateful lives outside this release: postgres in CNPG, redis
     # in the shared Dragonfly, kafka in the Strimzi cluster, clickhouse in its


### PR DESCRIPTION
> **Not for automatic merge.** This is the second attempt at #213 after #218 reverted it. I would rather you decide on the strategy change than have me merge it unattended — see Risk.

## What went wrong the first time

The seccomp patch in #213 was correct. The namespace could not accept it.

`sentry-symbolicator-api` is the only Deployment in `sentry` backed by a **ReadWriteOnce PVC**, and it ships with `strategy: RollingUpdate`. That combination is un-rollable — the new pod cannot attach the volume while the old one holds it, and the old one is not torn down until the new one is ready:

```
Warning  FailedAttachVolume  Multi-Attach error for volume "pvc-36e959ec…"
  Volume is already used by pod(s) sentry-symbolicator-api-68db4c6985-2pqfw
```

Helm stalled, Flux rolled back to revision 7, and the profile reached `0/57` workloads.

## What this does

Two patches, in order:

1. **`sentry-symbolicator-api` → `strategy: Recreate`** (with `rollingUpdate: null` so the leftover block goes), scoped to that one Deployment by name.
2. The seccomp strategic-merge patch from #213, unchanged.

Verified with kustomize against both shapes that exist in this namespace:

```
name: sentry-symbolicator-api        name: sentry-web
strategy:                            strategy:
  type: Recreate                       type: RollingUpdate      # untouched
securityContext:                     securityContext:
  fsGroup: 65532                       seccompProfile:
  runAsUser: 65532                       type: RuntimeDefault
  seccompProfile:
    type: RuntimeDefault
```

So symbolicator keeps its fsGroup and uid, every other Deployment keeps its update strategy, and all of them gain the profile.

## Risk

**`Recreate` is not a workaround — it is what that Deployment already needs.** As it stands it cannot roll at all, so every future chart bump that touches its pod template hits the same wall. Making it explicit trades a few seconds of symbolicator unavailability per change for a Deployment that can actually be updated.

What that costs while it is down: Sentry cannot symbolicate incoming stack traces. Event ingestion is unaffected — `relay` and the consumers do not go through symbolicator.

Why I am not merging it myself: the first attempt failed on this stack, and this one changes how a production component updates. Sentry stayed up throughout that failure (the old pod served the whole time and the rollback held), so the downside is bounded — but the call is yours.

## Verification

`./scripts/validate.sh` passes; the patch chain renders as shown above.