### PR TITLE
feat(stelaris): deploy the ui next to the vulpes backend

### DIFF
--- a/apps/clusters/feathre-core/apps/kustomization.yaml
+++ b/apps/clusters/feathre-core/apps/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - otis-dev
   - vulpes-backend
   - vulpes-backend-dev
+  - stelaris
+  - stelaris-dev

--- a/apps/clusters/feathre-core/apps/stelaris-dev/harbor.onelitefeather.dev.dockerconfigjson.sops.json
+++ b/apps/clusters/feathre-core/apps/stelaris-dev/harbor.onelitefeather.dev.dockerconfigjson.sops.json
@@ -1,0 +1,28 @@
+{
+	"auths": {
+		"harbor.onelitefeather.dev": {
+			"username": "ENC[AES256_GCM,data:F7bgC6oQdAwMfOuUM2WSdY0LyOB4JUcBXQ==,iv:peyvps4t1wK4AzcsHG6CjD0boi0bLr3i3XpHqHSCVTg=,tag:OTYPfOjEIjT1c45v6RDQMQ==,type:str]",
+			"password": "ENC[AES256_GCM,data:1UuYyHgEWG5FtvB0hss4aWtCcLCC9nEMTDbptxbj794=,iv:6IHxl+dGwEwvfL4kNPd+iTYHkGTQ6jxaKA9i+oL8LF8=,tag:F2T4Niy0zTEsjpKOaw9yiQ==,type:str]"
+		}
+	},
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHYVhIbUJNRUptcisrS2JW\nV1hJQUJJaEFaV0tzcGZMKy9KY010NDE1MWxNCnFyVmFaQndtNEc4MWs4Q3F0S0da\nbEc3TzVJK0oxTDkrRG9mdjhRbkVmRE0KLS0tIGx1eDNabmh2YXhKU3BFa2YzY1hF\nWFFwdE5LMWRTZ3c0bmpwTVVjYkhCeW8KMrLYGopepDDgDF3Swz2NvBWaVRx3HyH5\nhanEHlooRxUghCX+MlwHkvCNHi38Rr338rLePWdl/wAuiAL0VxlpoA==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1kfcggatwrwslka8sssdw2sy05jwntft84cw979gkvzp9wksnyy0qllsz8s"
+			},
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWTFhZckhObVV5ME9aSlZz\ndDRZalNEQ1FNaTVwUXZnYTMwTzkvZUFPQ3gwCmFONFNyZ1hYaUtzUzFBL1ZPVVk5\nTUExaTRVSDVSU0NXSW45dmh6anFjeDAKLS0tIE5DMjZyQUpYWWUxckpUeWdzZDVH\nZEpDZmwwbDE3TFQrblJZSUsvZUxFQ0UKb2DXrMj6GgA6lLcrSzfHUaOgaRJimKCY\n7RJGVIzz6G3on9R5l7ghOsS9+1WDiMb9/gMaihxs89nH05vLWLxiOg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age10x4xtzptvjztg9jkxr4m5luw3mfyqwww499lgnnqx32h2xytu5nqkjwqaq"
+			},
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3di9qdHpWbmUvOG9lRUNH\ndXRqWG50bXRtYzhzZHRxcGU4ZFZRYjEvZXhnCnE5aVhaQlRlR3Ivb2RhOTBLMDVL\nRWVSNHdCTTdLODkzY09kUWN6QThsWHcKLS0tIFRDZkJDVlV4VURFbitLdkViakxP\ncEVxNy8veEx5T1lQc3VWMGlJekZZb1kKZycYylmaIW9PmRyb8pJYE9+FmWefRR19\nZWG4VdYGEgagHDJMLW24QiX+2HGkzWxsiWOZE8l7Spjlp/KgajP/2Q==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1rrus5c38flq6yg6l56d0cecgzap0fhdew64n7ygz7lngjwpzws4qcnge3x"
+			}
+		],
+		"lastmodified": "2026-06-20T20:14:15Z",
+		"mac": "ENC[AES256_GCM,data:37iMKEKC6t2ZYwZgAfFlIxzganU8u+J/ydV0i0++DyWm2M5zT7zhXXM6bNv2T2wtm3Plq1Oh4cTXPTnqI4gvoa5stMLmvPxbndGX4805fICGiWE9hroNmhh6Hz5Sx+akZ7AqqDiNaWXu+oWagYcyknNu2YyW2oVnl5f7x8kNsVo=,iv:YnCCRFNeN9C8i2rE7RANSwniQYQkfInkkmmHpWUPbS0=,tag:MO/eecXC663/bAy7jCa0FA==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.1"
+	}
+}

--- a/apps/clusters/feathre-core/apps/stelaris-dev/httproute.yaml
+++ b/apps/clusters/feathre-core/apps/stelaris-dev/httproute.yaml
@@ -1,0 +1,21 @@
+# The chart renders an Ingress, not an HTTPRoute; this cluster routes through
+# Envoy Gateway, so the route lives here instead (same shape as n8n/grafana).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: stelaris-ui-dev
+spec:
+  parentRefs:
+    - name: eg
+      namespace: envoy
+      sectionName: https
+  hostnames:
+    - stelaris-dev.apps.onelite.feather
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: stelaris-ui-dev
+          port: 80

--- a/apps/clusters/feathre-core/apps/stelaris-dev/kustomization.yaml
+++ b/apps/clusters/feathre-core/apps/stelaris-dev/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: stelaris-dev
+generatorOptions:
+  disableNameSuffixHash: true
+resources:
+  - namespace.yaml
+  - release.yaml
+  - httproute.yaml
+
+secretGenerator:
+  - name: harbor-pull
+    type: kubernetes.io/dockerconfigjson
+    files:
+      - .dockerconfigjson=harbor.onelitefeather.dev.dockerconfigjson.sops.json

--- a/apps/clusters/feathre-core/apps/stelaris-dev/namespace.yaml
+++ b/apps/clusters/feathre-core/apps/stelaris-dev/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stelaris-dev
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/clusters/feathre-core/apps/stelaris-dev/release.yaml
+++ b/apps/clusters/feathre-core/apps/stelaris-dev/release.yaml
@@ -1,0 +1,58 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: stelaris-ui-dev
+  namespace: stelaris-dev
+spec:
+  releaseName: stelaris-ui-dev
+  interval: 1m0s
+  install:
+    remediation:
+      retries: 3
+  # Pinned in base-sources; the chart's appVersion decides the image tag, so the
+  # source pin is the only version to bump.
+  chartRef:
+    kind: OCIRepository
+    name: stelaris-ui-dev
+    namespace: flux-system
+  values:
+    # Single replica, no PDB -> dev is best-effort and yields to prod under
+    # pressure. Only the backend it talks to and the hostname differ from prod.
+    replicaCount: 1
+    podDisruptionBudget:
+      enabled: false
+    image:
+      registry: harbor.onelitefeather.dev
+      repository: onelitefeather/stelaris
+    imagePullSecrets:
+      - name: harbor-pull
+
+    # Read by the app at startup from /config.json, which the chart mounts as a
+    # Secret. nginx serves that file per request, so changing it needs no rollout.
+    config:
+      backendUrl: https://vulpes-backend-dev.apps.onelite.feather
+      # No generator service runs in this cluster; the app falls back to its
+      # compiled-in default and the generate page stays unusable.
+      generatorUrl: ""
+
+    # The image ships connect-src 'self' https:, because an image that is built
+    # once and promoted cannot know its backend. Naming it turns "any HTTPS host"
+    # into "this one". The unsafe-* entries are Flutter's, not ours - its loader
+    # bootstraps from an inline script and compiles Wasm at runtime.
+    nginx:
+      contentSecurityPolicy: >-
+        default-src 'self'; base-uri 'self'; object-src 'none';
+        frame-ancestors 'none'; form-action 'none';
+        script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval';
+        style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;
+        font-src 'self' data:; media-src 'self' data: blob:;
+        worker-src 'self' blob:; child-src 'self' blob:; manifest-src 'self';
+        connect-src 'self' https://vulpes-backend-dev.apps.onelite.feather
+
+    # Routed through Envoy Gateway via httproute.yaml, not an Ingress.
+    ingress:
+      enabled: false
+
+    podLabels:
+      logs.onelitefeather.net/format: json
+      logs.onelitefeather.net/env: dev

--- a/apps/clusters/feathre-core/apps/stelaris/harbor.onelitefeather.dev.dockerconfigjson.sops.json
+++ b/apps/clusters/feathre-core/apps/stelaris/harbor.onelitefeather.dev.dockerconfigjson.sops.json
@@ -1,0 +1,28 @@
+{
+	"auths": {
+		"harbor.onelitefeather.dev": {
+			"username": "ENC[AES256_GCM,data:F7bgC6oQdAwMfOuUM2WSdY0LyOB4JUcBXQ==,iv:peyvps4t1wK4AzcsHG6CjD0boi0bLr3i3XpHqHSCVTg=,tag:OTYPfOjEIjT1c45v6RDQMQ==,type:str]",
+			"password": "ENC[AES256_GCM,data:1UuYyHgEWG5FtvB0hss4aWtCcLCC9nEMTDbptxbj794=,iv:6IHxl+dGwEwvfL4kNPd+iTYHkGTQ6jxaKA9i+oL8LF8=,tag:F2T4Niy0zTEsjpKOaw9yiQ==,type:str]"
+		}
+	},
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHYVhIbUJNRUptcisrS2JW\nV1hJQUJJaEFaV0tzcGZMKy9KY010NDE1MWxNCnFyVmFaQndtNEc4MWs4Q3F0S0da\nbEc3TzVJK0oxTDkrRG9mdjhRbkVmRE0KLS0tIGx1eDNabmh2YXhKU3BFa2YzY1hF\nWFFwdE5LMWRTZ3c0bmpwTVVjYkhCeW8KMrLYGopepDDgDF3Swz2NvBWaVRx3HyH5\nhanEHlooRxUghCX+MlwHkvCNHi38Rr338rLePWdl/wAuiAL0VxlpoA==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1kfcggatwrwslka8sssdw2sy05jwntft84cw979gkvzp9wksnyy0qllsz8s"
+			},
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWTFhZckhObVV5ME9aSlZz\ndDRZalNEQ1FNaTVwUXZnYTMwTzkvZUFPQ3gwCmFONFNyZ1hYaUtzUzFBL1ZPVVk5\nTUExaTRVSDVSU0NXSW45dmh6anFjeDAKLS0tIE5DMjZyQUpYWWUxckpUeWdzZDVH\nZEpDZmwwbDE3TFQrblJZSUsvZUxFQ0UKb2DXrMj6GgA6lLcrSzfHUaOgaRJimKCY\n7RJGVIzz6G3on9R5l7ghOsS9+1WDiMb9/gMaihxs89nH05vLWLxiOg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age10x4xtzptvjztg9jkxr4m5luw3mfyqwww499lgnnqx32h2xytu5nqkjwqaq"
+			},
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3di9qdHpWbmUvOG9lRUNH\ndXRqWG50bXRtYzhzZHRxcGU4ZFZRYjEvZXhnCnE5aVhaQlRlR3Ivb2RhOTBLMDVL\nRWVSNHdCTTdLODkzY09kUWN6QThsWHcKLS0tIFRDZkJDVlV4VURFbitLdkViakxP\ncEVxNy8veEx5T1lQc3VWMGlJekZZb1kKZycYylmaIW9PmRyb8pJYE9+FmWefRR19\nZWG4VdYGEgagHDJMLW24QiX+2HGkzWxsiWOZE8l7Spjlp/KgajP/2Q==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1rrus5c38flq6yg6l56d0cecgzap0fhdew64n7ygz7lngjwpzws4qcnge3x"
+			}
+		],
+		"lastmodified": "2026-06-20T20:14:15Z",
+		"mac": "ENC[AES256_GCM,data:37iMKEKC6t2ZYwZgAfFlIxzganU8u+J/ydV0i0++DyWm2M5zT7zhXXM6bNv2T2wtm3Plq1Oh4cTXPTnqI4gvoa5stMLmvPxbndGX4805fICGiWE9hroNmhh6Hz5Sx+akZ7AqqDiNaWXu+oWagYcyknNu2YyW2oVnl5f7x8kNsVo=,iv:YnCCRFNeN9C8i2rE7RANSwniQYQkfInkkmmHpWUPbS0=,tag:MO/eecXC663/bAy7jCa0FA==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.1"
+	}
+}

--- a/apps/clusters/feathre-core/apps/stelaris/httproute.yaml
+++ b/apps/clusters/feathre-core/apps/stelaris/httproute.yaml
@@ -1,0 +1,21 @@
+# The chart renders an Ingress, not an HTTPRoute; this cluster routes through
+# Envoy Gateway, so the route lives here instead (same shape as n8n/grafana).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: stelaris-ui
+spec:
+  parentRefs:
+    - name: eg
+      namespace: envoy
+      sectionName: https
+  hostnames:
+    - stelaris.apps.onelite.feather
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: stelaris-ui
+          port: 80

--- a/apps/clusters/feathre-core/apps/stelaris/kustomization.yaml
+++ b/apps/clusters/feathre-core/apps/stelaris/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: stelaris
+generatorOptions:
+  disableNameSuffixHash: true
+resources:
+  - namespace.yaml
+  - release.yaml
+  - httproute.yaml
+
+secretGenerator:
+  - name: harbor-pull
+    type: kubernetes.io/dockerconfigjson
+    files:
+      - .dockerconfigjson=harbor.onelitefeather.dev.dockerconfigjson.sops.json

--- a/apps/clusters/feathre-core/apps/stelaris/namespace.yaml
+++ b/apps/clusters/feathre-core/apps/stelaris/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stelaris
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/apps/clusters/feathre-core/apps/stelaris/release.yaml
+++ b/apps/clusters/feathre-core/apps/stelaris/release.yaml
@@ -1,0 +1,59 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: stelaris-ui
+  namespace: stelaris
+spec:
+  releaseName: stelaris-ui
+  interval: 1m0s
+  install:
+    remediation:
+      retries: 3
+  # Pinned in base-sources; the chart's appVersion decides the image tag, so the
+  # source pin is the only version to bump.
+  chartRef:
+    kind: OCIRepository
+    name: stelaris-ui
+    namespace: flux-system
+  values:
+    # HA: two replicas, spread over nodes by the chart's topology constraint, and
+    # a PDB so a node drain never takes the UI down.
+    replicaCount: 2
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+    image:
+      registry: harbor.onelitefeather.dev
+      repository: onelitefeather/stelaris
+    imagePullSecrets:
+      - name: harbor-pull
+
+    # Read by the app at startup from /config.json, which the chart mounts as a
+    # Secret. nginx serves that file per request, so changing it needs no rollout.
+    config:
+      backendUrl: https://vulpes-backend.apps.onelite.feather
+      # No generator service runs in this cluster; the app falls back to its
+      # compiled-in default and the generate page stays unusable.
+      generatorUrl: ""
+
+    # The image ships connect-src 'self' https:, because an image that is built
+    # once and promoted cannot know its backend. Naming it turns "any HTTPS host"
+    # into "this one". The unsafe-* entries are Flutter's, not ours - its loader
+    # bootstraps from an inline script and compiles Wasm at runtime.
+    nginx:
+      contentSecurityPolicy: >-
+        default-src 'self'; base-uri 'self'; object-src 'none';
+        frame-ancestors 'none'; form-action 'none';
+        script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval';
+        style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;
+        font-src 'self' data:; media-src 'self' data: blob:;
+        worker-src 'self' blob:; child-src 'self' blob:; manifest-src 'self';
+        connect-src 'self' https://vulpes-backend.apps.onelite.feather
+
+    # Routed through Envoy Gateway via httproute.yaml, not an Ingress.
+    ingress:
+      enabled: false
+
+    podLabels:
+      logs.onelitefeather.net/format: json
+      logs.onelitefeather.net/env: prod

--- a/apps/clusters/feathre-core/apps/vulpes-backend-dev/release.yaml
+++ b/apps/clusters/feathre-core/apps/vulpes-backend-dev/release.yaml
@@ -77,6 +77,15 @@ spec:
             name: Vulpes Backend
           server:
             port: 8080
+            # The Stelaris UI is served from its own host, so every call it makes
+            # is cross-origin. Allow that one origin - not '*', which would also
+            # be sent to any site that asks.
+            cors:
+              enabled: true
+              configurations:
+                stelaris-ui:
+                  allowed-origins:
+                    - https://stelaris-dev.apps.onelite.feather
             netty:
               access-logger:
                 enabled: true

--- a/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
+++ b/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
@@ -86,6 +86,15 @@ spec:
             name: Vulpes Backend
           server:
             port: 8080
+            # The Stelaris UI is served from its own host, so every call it makes
+            # is cross-origin. Allow that one origin - not '*', which would also
+            # be sent to any site that asks.
+            cors:
+              enabled: true
+              configurations:
+                stelaris-ui:
+                  allowed-origins:
+                    - https://stelaris.apps.onelite.feather
             netty:
               access-logger:
                 enabled: true

--- a/infrastructure/clusters/feather-core/base-sources/harbor.onelitefeather.dev.dockerconfigjson.sops.json
+++ b/infrastructure/clusters/feather-core/base-sources/harbor.onelitefeather.dev.dockerconfigjson.sops.json
@@ -1,0 +1,28 @@
+{
+	"auths": {
+		"harbor.onelitefeather.dev": {
+			"username": "ENC[AES256_GCM,data:F7bgC6oQdAwMfOuUM2WSdY0LyOB4JUcBXQ==,iv:peyvps4t1wK4AzcsHG6CjD0boi0bLr3i3XpHqHSCVTg=,tag:OTYPfOjEIjT1c45v6RDQMQ==,type:str]",
+			"password": "ENC[AES256_GCM,data:1UuYyHgEWG5FtvB0hss4aWtCcLCC9nEMTDbptxbj794=,iv:6IHxl+dGwEwvfL4kNPd+iTYHkGTQ6jxaKA9i+oL8LF8=,tag:F2T4Niy0zTEsjpKOaw9yiQ==,type:str]"
+		}
+	},
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHYVhIbUJNRUptcisrS2JW\nV1hJQUJJaEFaV0tzcGZMKy9KY010NDE1MWxNCnFyVmFaQndtNEc4MWs4Q3F0S0da\nbEc3TzVJK0oxTDkrRG9mdjhRbkVmRE0KLS0tIGx1eDNabmh2YXhKU3BFa2YzY1hF\nWFFwdE5LMWRTZ3c0bmpwTVVjYkhCeW8KMrLYGopepDDgDF3Swz2NvBWaVRx3HyH5\nhanEHlooRxUghCX+MlwHkvCNHi38Rr338rLePWdl/wAuiAL0VxlpoA==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1kfcggatwrwslka8sssdw2sy05jwntft84cw979gkvzp9wksnyy0qllsz8s"
+			},
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWTFhZckhObVV5ME9aSlZz\ndDRZalNEQ1FNaTVwUXZnYTMwTzkvZUFPQ3gwCmFONFNyZ1hYaUtzUzFBL1ZPVVk5\nTUExaTRVSDVSU0NXSW45dmh6anFjeDAKLS0tIE5DMjZyQUpYWWUxckpUeWdzZDVH\nZEpDZmwwbDE3TFQrblJZSUsvZUxFQ0UKb2DXrMj6GgA6lLcrSzfHUaOgaRJimKCY\n7RJGVIzz6G3on9R5l7ghOsS9+1WDiMb9/gMaihxs89nH05vLWLxiOg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age10x4xtzptvjztg9jkxr4m5luw3mfyqwww499lgnnqx32h2xytu5nqkjwqaq"
+			},
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3di9qdHpWbmUvOG9lRUNH\ndXRqWG50bXRtYzhzZHRxcGU4ZFZRYjEvZXhnCnE5aVhaQlRlR3Ivb2RhOTBLMDVL\nRWVSNHdCTTdLODkzY09kUWN6QThsWHcKLS0tIFRDZkJDVlV4VURFbitLdkViakxP\ncEVxNy8veEx5T1lQc3VWMGlJekZZb1kKZycYylmaIW9PmRyb8pJYE9+FmWefRR19\nZWG4VdYGEgagHDJMLW24QiX+2HGkzWxsiWOZE8l7Spjlp/KgajP/2Q==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1rrus5c38flq6yg6l56d0cecgzap0fhdew64n7ygz7lngjwpzws4qcnge3x"
+			}
+		],
+		"lastmodified": "2026-06-20T20:14:15Z",
+		"mac": "ENC[AES256_GCM,data:37iMKEKC6t2ZYwZgAfFlIxzganU8u+J/ydV0i0++DyWm2M5zT7zhXXM6bNv2T2wtm3Plq1Oh4cTXPTnqI4gvoa5stMLmvPxbndGX4805fICGiWE9hroNmhh6Hz5Sx+akZ7AqqDiNaWXu+oWagYcyknNu2YyW2oVnl5f7x8kNsVo=,iv:YnCCRFNeN9C8i2rE7RANSwniQYQkfInkkmmHpWUPbS0=,tag:MO/eecXC663/bAy7jCa0FA==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.1"
+	}
+}

--- a/infrastructure/clusters/feather-core/base-sources/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/kustomization.yaml
@@ -29,3 +29,15 @@ resources:
   - sentry-kubernetes.yaml
   - sturnus.yaml
   - pmint93.yml
+  - stelaris-ui.yaml
+
+# The OCIRepositories above pull from the private onelitefeather Harbor project,
+# so flux-system needs the same pull credential the workloads use.
+generatorOptions:
+  disableNameSuffixHash: true
+
+secretGenerator:
+  - name: harbor-pull
+    type: kubernetes.io/dockerconfigjson
+    files:
+      - .dockerconfigjson=harbor.onelitefeather.dev.dockerconfigjson.sops.json

--- a/infrastructure/clusters/feather-core/base-sources/stelaris-ui.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/stelaris-ui.yaml
@@ -1,0 +1,38 @@
+---
+# Stelaris UI ships its chart as an OCI artifact from our own Harbor, versioned
+# together with the image it deploys: the chart leaves image.tag empty and falls
+# back to .Chart.AppVersion, so pinning the chart pins the image.
+#
+# Unlike apus/charts, onelitefeather is a private project - hence secretRef.
+# Two repositories, not one, so dev can run a newer chart than prod.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: stelaris-ui
+  namespace: flux-system
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://harbor.onelitefeather.dev/onelitefeather/charts/stelaris-ui
+  ref:
+    semver: "=1.1.0"
+  secretRef:
+    name: harbor-pull
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: stelaris-ui-dev
+  namespace: flux-system
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://harbor.onelitefeather.dev/onelitefeather/charts/stelaris-ui
+  ref:
+    semver: "=1.1.0"
+  secretRef:
+    name: harbor-pull


### PR DESCRIPTION
## What this does

Deploys the Stelaris UI in two environments, each pointed at the matching Vulpes
backend:

| | Namespace | Host | Backend | Replicas |
| --- | --- | --- | --- | --- |
| dev | `stelaris-dev` | `stelaris-dev.apps.onelite.feather` | `vulpes-backend-dev` | 1, no PDB |
| prod | `stelaris` | `stelaris.apps.onelite.feather` | `vulpes-backend` | 2, PDB minAvailable 1 |

Image and chart are `1.1.0`, published by
[OneLiteFeatherNET/stelaris#124](https://github.com/OneLiteFeatherNET/stelaris/pull/124)
and [#125](https://github.com/OneLiteFeatherNET/stelaris/pull/125) — a hardened,
unprivileged nginx serving the Flutter web bundle, and the chart that packages
it.

## Three things that are not the obvious shape

**The chart source needs a credential.** `apus/charts` is anonymously pullable,
`onelitefeather` is not — `helm show chart` against it answers 401. So the
`OCIRepository` carries a `secretRef`, and `base-sources` grows the same
`harbor-pull` secret the workloads already use. Two sources rather than one, so
dev can run a newer chart than prod the way dev already runs a newer image tag.

**The HTTPRoute lives beside the release, not in the chart.** The chart renders
an `Ingress`; this cluster routes through Envoy Gateway. Rather than teach the
chart about Gateway API for one consumer, the route sits next to the
HelmRelease, the way n8n's and grafana's do. `ingress.enabled: false` in the
values makes that explicit.

**Vulpes gains CORS.** The UI is served from its own host, so every call it
makes is cross-origin, and `vulpes-backend` sends no CORS headers today. Without
this the UI would load and then fail every request in the browser — which reads
as a broken backend rather than a missing header. Each backend allows exactly
the matching UI origin, not `*`.

## Configuration reaches the app at runtime

The image is built once and promoted; the backend it talks to is not compiled
into the bundle. The chart renders `config.backendUrl` into a Secret and mounts
it over the server's runtime directory, and the app fetches `/config.json` when
it starts. nginx serves that file from disk per request, so **changing the
backend URL later takes effect without a rollout**.

`generatorUrl` stays empty: no generator service runs in this cluster, so the
app keeps its compiled-in default and the generate page stays unusable. That is
a known gap, not an oversight.

The CSP is narrowed per environment. The image ships
`connect-src 'self' https:` because it cannot know its backend; each release
names the one host it may talk to. The `unsafe-inline`/`unsafe-eval` entries are
Flutter's — its loader bootstraps from an inline script and compiles Wasm at
runtime — not ours to remove.

## Verified

- `./scripts/validate.sh` — every layer builds, 0 invalid, 0 errors
- `scripts/check-sops-encryption.py` — 93 files, all recipients present
- `kustomize build` of both changed layers renders what it should: 2 namespaces,
  2 HelmReleases, 2 HTTPRoutes, 2 pull secrets, plus the 2 OCIRepositories and
  the `harbor-pull` secret in `flux-system`
- The chart was rendered with **these exact values** at the real release names,
  confirming prod gets 2 replicas and a PDB, dev gets 1 and none, both resolve
  the image to `harbor.onelitefeather.dev/onelitefeather/stelaris:1.1.0` from
  the chart's `appVersion`, and the Service names (`stelaris-ui`,
  `stelaris-ui-dev`) match the `backendRefs` in the HTTPRoutes
- Both backends' `config.base` still parses as YAML with the CORS block in it

## Not verified

**That `harbor-pull` can pull the chart.** The credential is the one the
workloads use for images in the same Harbor project, so it should also cover
`onelitefeather/charts/stelaris-ui` — but Harbor permissions are per project,
not per repository, and I could not test it without decrypting the secret. If
the `OCIRepository` reports `unauthorized`, that is the thing to look at first.

**That the app works end to end.** The UI serving correctly is covered by the
image's own checks; whether it can actually talk to Vulpes through the new CORS
configuration needs the deployed environment.

`priorityClassName` is deliberately absent from the prod values: the chart does
not support it, and setting it would have been silently ignored. Worth adding to
the chart if prod should carry `feather-standard`.
