### PR TITLE
fix(stelaris): pin the ui to 1.1.1, which boots

### DIFF
--- a/infrastructure/clusters/feather-core/base-sources/stelaris-ui.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/stelaris-ui.yaml
@@ -17,7 +17,7 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/onelitefeather/charts/stelaris-ui
   ref:
-    semver: "=1.1.0"
+    semver: "=1.1.1"
   secretRef:
     name: harbor-pull
 ---
@@ -33,6 +33,6 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/onelitefeather/charts/stelaris-ui
   ref:
-    semver: "=1.1.0"
+    semver: "=1.1.1"
   secretRef:
     name: harbor-pull


### PR DESCRIPTION
## What this does

Bumps both `stelaris-ui` `OCIRepository` pins from `1.1.0` to `1.1.1`.

**1.1.0 does not start in a browser.** Two independent bugs, the second hidden behind the first:

```
Connecting to 'https://www.gstatic.com/flutter-canvaskit/…/skwasm.wasm' violates
the following Content Security Policy directive: "connect-src 'self' https://vulpes-backend…"
Failed to fetch dynamically imported module: https://stelaris.apps.onelite.feather/main.dart.mjs
```

- `flutter build web` defaults to `--web-resources-cdn`: it writes CanvasKit and Skwasm into the bundle and then has the loader fetch them from `www.gstatic.com` anyway. The CSP this deployment sets — correctly — blocks that.
- nginx ships no mapping for `.mjs`, so `main.dart.mjs` went out as `application/octet-stream`, and a browser refuses to execute an ES module without a JavaScript MIME type. The Wasm build never started. Invisible until the first bug was fixed.

Both fixed in [stelaris#128](https://github.com/OneLiteFeatherNET/stelaris/pull/128) and released as 1.1.1, verified in a real browser against the built image: the renderer now loads from the pod's own origin, `main.dart.mjs` comes back as `text/javascript`, and the app renders.

The chart's `appVersion` carries the image tag, so this one pin moves both chart and image.

## Verified

`./scripts/validate.sh` — every layer builds, no invalid resources, no errors.

Nothing else changes: this is the two `semver` lines and nothing more.