### PR TITLE
fix(stelaris): issue tls certificates for the ui hostnames

### DIFF
--- a/infrastructure/clusters/feather-core/configs/gateway/gateway.yaml
+++ b/infrastructure/clusters/feather-core/configs/gateway/gateway.yaml
@@ -65,3 +65,7 @@ spec:
             name: vikunja-apps-onelite-feather-tls
           - kind: Secret
             name: metabase-apps-onelite-feather-tls
+          - kind: Secret
+            name: stelaris-apps-onelite-feather-tls
+          - kind: Secret
+            name: stelaris-dev-apps-onelite-feather-tls

--- a/infrastructure/clusters/feather-core/internal-certs/internal-certificates.yaml
+++ b/infrastructure/clusters/feather-core/internal-certs/internal-certificates.yaml
@@ -267,3 +267,39 @@ spec:
     rotationPolicy: Always
   dnsNames:
     - metabase.apps.onelite.feather
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: stelaris-apps-onelite-feather
+  namespace: envoy
+spec:
+  secretName: stelaris-apps-onelite-feather-tls
+  issuerRef:
+    group: certmanager.step.sm
+    kind: StepClusterIssuer
+    name: step-ca-issuer
+  privateKey:
+    algorithm: RSA
+    size: 2048
+    rotationPolicy: Always
+  dnsNames:
+    - stelaris.apps.onelite.feather
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: stelaris-dev-apps-onelite-feather
+  namespace: envoy
+spec:
+  secretName: stelaris-dev-apps-onelite-feather-tls
+  issuerRef:
+    group: certmanager.step.sm
+    kind: StepClusterIssuer
+    name: step-ca-issuer
+  privateKey:
+    algorithm: RSA
+    size: 2048
+    rotationPolicy: Always
+  dnsNames:
+    - stelaris-dev.apps.onelite.feather


### PR DESCRIPTION
## What this fixes

step-ca is not broken. Nothing was asking it for these two names.

The Stelaris routes went in with #220, but without the two things every other
host on this gateway has: a `Certificate` issued by `step-ca-issuer`, and a
`certificateRefs` entry on the `https` listener. So the listener had no
certificate matching the SNI, and Envoy fell back to the first one it had.

Measured against the running gateway:

```
$ openssl s_client -connect 10.200.90.1:443 -servername stelaris-dev.apps.onelite.feather
subject=CN=*.onelitefeather.dev
X509v3 Subject Alternative Name: DNS:*.onelitefeather.dev, DNS:onelitefeather.dev
```

That mismatch is the certificate warning in the browser — which reads as
"step-ca stopped issuing", and is really "nobody asked".

## Evidence that step-ca is healthy

| | |
| --- | --- |
| Certificates cluster-wide | 22, all `Ready=True` |
| CertificateRequests | 24, none pending or failed |
| `step-issuer` logs | no error, denial or authorization line |
| Gateway `certificateRefs` before this PR | 19, none for stelaris |
| Stelaris pods | dev 1/1, prod 2/2, running |
| Stelaris HTTPRoutes | `Accepted=True`, `ResolvedRefs=True` |

Everything worked except the one thing that was never declared.

## The change

Two `Certificate` resources and two `certificateRefs`, in the same shape as
their neighbours.

The invariant that was violated is easy to state: every
`*.apps.onelite.feather` secret named in `internal-certificates.yaml` must also
appear in the gateway listener, and the reverse. After this PR both sides hold
17 entries and neither has one the other lacks — that cross-check is what I ran
instead of eyeballing the lists, and it is a cheap thing to add to
`scripts/validate.sh` if this should never slip again.

## Verified

`./scripts/validate.sh` — every layer builds, no invalid resources, no errors.

After merge, the two `Certificate` objects should reach `Ready=True` and the
same `openssl s_client` call should come back with
`CN=stelaris-dev.apps.onelite.feather`.

## Note

This is a gap in #220, which I opened. The routes were verified as `Accepted`;
the TLS side of the same hostname was not.