### PR TITLE
feat(stelaris): let the dev ui follow the newest chart release

### DIFF
--- a/apps/clusters/feathre-core/apps/stelaris-dev/release.yaml
+++ b/apps/clusters/feathre-core/apps/stelaris-dev/release.yaml
@@ -9,8 +9,9 @@ spec:
   install:
     remediation:
       retries: 3
-  # Pinned in base-sources; the chart's appVersion decides the image tag, so the
-  # source pin is the only version to bump.
+  # The source in base-sources tracks the newest release rather than an exact
+  # version, and the chart's appVersion decides the image tag - so dev follows
+  # both without anything here being bumped.
   chartRef:
     kind: OCIRepository
     name: stelaris-ui-dev

--- a/infrastructure/clusters/feather-core/base-sources/stelaris-ui.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/stelaris-ui.yaml
@@ -4,7 +4,9 @@
 # back to .Chart.AppVersion, so pinning the chart pins the image.
 #
 # Unlike apus/charts, onelitefeather is a private project - hence secretRef.
-# Two repositories, not one, so dev can run a newer chart than prod.
+# Two repositories, not one, so dev can run a newer chart than prod: prod is
+# pinned to an exact version and moved deliberately, dev follows the newest
+# release on its own.
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
@@ -21,6 +23,11 @@ spec:
   secretRef:
     name: harbor-pull
 ---
+# Dev takes whatever the newest release is, rather than being bumped by hand -
+# that is the whole point of having a second repository here. The range is open
+# upwards but floored at 1.1.1, because 1.1.0 does not start in a browser (see
+# the commit that pinned it): "newest" must never mean "back to a version known
+# not to boot".
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
@@ -33,6 +40,6 @@ spec:
     operation: copy
   url: oci://harbor.onelitefeather.dev/onelitefeather/charts/stelaris-ui
   ref:
-    semver: "=1.1.1"
+    semver: ">=1.1.1"
   secretRef:
     name: harbor-pull


### PR DESCRIPTION
`base-sources/stelaris-ui.yaml` holds two OCIRepositories pointing at one URL so that dev can run a newer chart than prod — but both were pinned to the same exact version, so the split bought nothing: every dev deployment still waited on someone editing a pin here by hand.

Dev now takes an open range. Since the chart leaves `image.tag` empty and falls back to `.Chart.AppVersion`, both the chart and the image follow a release on their own.

Floored at `>=1.1.1` rather than left fully open, because 1.1.0 does not start in a browser (see 079ecdf) — "newest" must not be able to mean "back to a version known not to boot".

Prod stays on `=1.1.1` and is still moved deliberately.

`./scripts/validate.sh` passes.