### PR TITLE
feat(vulpes): deploy the backend from its own released chart

### DIFF
--- a/apps/base/vulpes-backend/release.yaml
+++ b/apps/base/vulpes-backend/release.yaml
@@ -5,13 +5,13 @@ metadata:
   namespace: vulpes
 spec:
   releaseName: vulpes-backend
-  chart:
-    spec:
-      chart: ./helm/micronaut
-      sourceRef:
-        kind: GitRepository
-        name: helmcharts
-        namespace: flux-system
+  # The chart comes from Harbor, released together with the image it deploys
+  # (see base-sources/vulpes-backend.yaml). The exact version lives on the
+  # OCIRepository, so there is nothing to pin here.
+  chartRef:
+    kind: OCIRepository
+    name: vulpes-backend
+    namespace: flux-system
   install:
     remediation:
       retries: 3

--- a/apps/clusters/feathre-core/apps/vulpes-backend-dev/release.yaml
+++ b/apps/clusters/feathre-core/apps/vulpes-backend-dev/release.yaml
@@ -9,32 +9,35 @@ spec:
   install:
     remediation:
       retries: 3
-  chart:
-    spec:
-      chart: ./helm/micronaut
-      sourceRef:
-        kind: GitRepository
-        name: helmcharts
-        namespace: flux-system
+  # Tracks the newest chart release rather than an exact version (see
+  # base-sources/vulpes-backend.yaml), and the chart's appVersion decides the
+  # image tag -- so dev follows both without anything here being bumped. That
+  # is the whole point: this file used to carry a hand-edited tag, and it sat
+  # on 2.3.0 while prod ran 2.4.1.
+  chartRef:
+    kind: OCIRepository
+    name: vulpes-backend-dev
+    namespace: flux-system
   values:
     # Single replica, no PDB -> dev is best-effort and yields to prod under
     # pressure (no priorityClassName). Same logging/JSON setup as prod so the
-    # behaviour matches; only the DB, domain and image tag differ.
+    # behaviour matches; only the DB, the domain and which chart release each
+    # tracks differ.
     replicaCount: 1
-    image:
-      repository: harbor.onelitefeather.dev/onelitefeather/vulpes-backend
-      # Pinned to an immutable version tag instead of "latest": Spegel caches
-      # mutable tags P2P, so "latest" kept resolving to a stale digest. Immutable
-      # tags resolve correctly -> bump this when a new dev build should roll.
-      pullPolicy: IfNotPresent
-      tag: "2.3.0"
+    # The chart is named vulpes-backend, the old shared one was named micronaut,
+    # and .Chart.Name reaches app.kubernetes.io/name -- which is in the
+    # Deployment's selector and immutable. Frozen here so moving to the chart
+    # renames nothing on the cluster; undoing this means deleting the
+    # Deployment, not upgrading it.
+    nameOverride: micronaut
+    fullnameOverride: vulpes-backend-dev-micronaut
+
+    # image, service.port and the Prometheus path now come from the chart. The
+    # tag stays immutable -- it is the chart's appVersion, never "latest",
+    # which Spegel caches P2P and kept resolving to a stale digest.
     imagePullSecrets:
       - name: harbor-pull
-    service:
-      port: 8080
     metrics:
-      enabled: true
-      path: /prometheus
       serviceMonitor:
         enabled: true
     ingress:

--- a/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
+++ b/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
@@ -27,17 +27,19 @@ spec:
     podDisruptionBudget:
       enabled: true
       maxUnavailable: 1
-    image:
-      repository: harbor.onelitefeather.dev/onelitefeather/vulpes-backend
-      pullPolicy: IfNotPresent
-      tag: "2.4.1"
+    # The chart is named vulpes-backend, the old shared one was named micronaut,
+    # and .Chart.Name reaches app.kubernetes.io/name -- which is in the
+    # Deployment's selector and immutable. Frozen here so moving to the chart
+    # renames nothing on the cluster; undoing this means deleting the
+    # Deployment, not upgrading it.
+    nameOverride: micronaut
+    fullnameOverride: vulpes-backend-micronaut
+
+    # image, service.port and the Prometheus path now come from the chart, which
+    # is released from the application's own repository and knows them.
     imagePullSecrets:
       - name: harbor-pull
-    service:
-      port: 8080
     metrics:
-      enabled: true
-      path: /prometheus
       serviceMonitor:
         enabled: true
     ingress:

--- a/infrastructure/clusters/feather-core/base-sources/kustomization.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/kustomization.yaml
@@ -30,6 +30,7 @@ resources:
   - sturnus.yaml
   - pmint93.yml
   - stelaris-ui.yaml
+  - vulpes-backend.yaml
 
 # The OCIRepositories above pull from the private onelitefeather Harbor project,
 # so flux-system needs the same pull credential the workloads use.

--- a/infrastructure/clusters/feather-core/base-sources/vulpes-backend.yaml
+++ b/infrastructure/clusters/feather-core/base-sources/vulpes-backend.yaml
@@ -1,0 +1,51 @@
+---
+# The Vulpes backend ships its chart as an OCI artifact from our own Harbor,
+# versioned together with the image it deploys: the chart leaves image.tag empty
+# and falls back to .Chart.AppVersion, so pinning the chart pins the image. It
+# replaces the shared helm/micronaut chart in this repository, which described
+# no service in particular and had to be paired with a hand-edited image tag in
+# each HelmRelease -- that is how dev came to run 2.3.0 against prod's 2.4.1.
+# otis still uses helm/micronaut.
+#
+# Unlike apus/charts, onelitefeather is a private project - hence secretRef.
+# Two repositories, not one, so dev can run a newer chart than prod: prod is
+# pinned to an exact version and moved deliberately, dev follows the newest
+# release on its own. Same shape as stelaris-ui.yaml beside this file.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: vulpes-backend
+  namespace: flux-system
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://harbor.onelitefeather.dev/onelitefeather/charts/vulpes-backend
+  ref:
+    # 2.6.0 is the first release that publishes a chart: 2.5.0 was cut before
+    # the chart existed and has an image in Harbor but no chart to go with it.
+    # Moving prod onto 2.6.0 is therefore also an application upgrade from the
+    # 2.4.1 it runs today -- the chart and the image share one version by
+    # design, so there is no chart carrying an older image to step through.
+    semver: "=2.6.0"
+  secretRef:
+    name: harbor-pull
+---
+# Floored at 2.6.0 rather than left fully open because that is the first release
+# to carry a chart at all: nothing below it exists in Harbor to resolve to.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: vulpes-backend-dev
+  namespace: flux-system
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://harbor.onelitefeather.dev/onelitefeather/charts/vulpes-backend
+  ref:
+    semver: ">=2.6.0"
+  secretRef:
+    name: harbor-pull


### PR DESCRIPTION
Both environments were rendered from the generic `helm/micronaut` chart in this repository and paired with an image tag edited by hand in each HelmRelease. Nothing tied the two together, so they drifted: dev sat on 2.3.0 while prod ran 2.4.1, because the bump in `acb2a0b` touched prod only.

The backend now publishes a chart alongside its image, versioned from the same release (OneLiteFeatherNET/Vulpes-Backend#179, shipped in 2.6.0). `image.tag` is left empty and falls back to `.Chart.AppVersion`, so the source pin is the only version there is.

Prod stays on an exact pin and is moved deliberately; dev takes an open range and follows the newest release on its own — the same split `stelaris-ui.yaml` uses, and the reason two OCIRepositories point at one URL.

## Verification

Rendered the current manifests against the new chart for both environments before pinning. Nothing changes but the `helm.sh/chart` label and the config checksum that includes it — **no resource name and no selector moves**, so prod sees a single rolling restart rather than a failed upgrade.

That is not free: `.Chart.Name` reaches `app.kubernetes.io/name`, which is in the Deployment's immutable selector, so the rendered names are held in place with `nameOverride`/`fullnameOverride`. Undoing that later means deleting the Deployment, not upgrading it — it is commented as such at both call sites.

Chart 2.6.0 is in Harbor (`Pushed: …/onelitefeather/charts/vulpes-backend:2.6.0`). `./scripts/validate.sh` passes.

## Version note

2.5.0 was cut before the chart existed and has an image but no chart, so 2.6.0 is the first pinnable release. Prod therefore moves from 2.4.1 straight to 2.6.0 — **this PR is an application upgrade, not only an infrastructure change**. The chart and the image share one version by design, so there is no chart carrying an older image to step through.

## Scope

`otis` keeps using `helm/micronaut`, so that chart stays. Moving otis the same way is the remaining step before it can be deleted — it would also fix `otis-dev`, which still runs `tag: "latest"`, the mutable tag Spegel caches P2P and resolves to a stale digest. The three third-party charts (`outline`, `shlink`, `vikunja`) stay here permanently: the charts are ours, the software is not.