### PR TITLE
fix(vulpes): give dev the kubernetes rbac and health config prod has

### DIFF
--- a/apps/clusters/feathre-core/apps/vulpes-backend-dev/release.yaml
+++ b/apps/clusters/feathre-core/apps/vulpes-backend-dev/release.yaml
@@ -55,7 +55,17 @@ spec:
             - path:
                 type: PathPrefix
                 value: /
-    profiles: [ "prod" ]
+    # "k8s" is not optional here even though dev discovers nothing: Micronaut
+    # activates the k8s environment on its own inside a cluster, which brings up
+    # the micronaut-kubernetes beans, and they need both the RBAC below and the
+    # k8s config file this list makes load.
+    profiles: [ "prod", "k8s" ]
+
+    # RBAC for in-namespace service discovery (read services/endpoints). Without
+    # it the discovery client gets a 403 and reports its health indicator DOWN,
+    # which fails /health/readiness and holds the pod at 0/1 forever.
+    rbac:
+      create: true
 
     # Alloy log pipeline: JSON parsing + per-env stream label.
     podLabels:
@@ -155,6 +165,25 @@ spec:
               registerMbeans: true
               leakDetectionThreshold: 20000
               transactionIsolation: TRANSACTION_READ_COMMITTED
+        # Loaded only in the Kubernetes (k8s) environment. k8s is listed in
+        # profiles because MICRONAUT_CONFIG_FILES is built from that list -- it
+        # is what makes this file load at all. It does not switch the k8s
+        # environment on: Micronaut deduces that from running in a cluster
+        # regardless of MICRONAUT_ENVIRONMENTS, which is why the discovery beans
+        # come up here whether or not anything asks for them.
+        k8s: |-
+          # Disable the KubernetesHealthIndicator: the client-java bundled with
+          # micronaut-kubernetes 7.1.1 can't deserialize newer API-server pod
+          # fields (observedGeneration / PodReadyToStartContainers), so every
+          # /health probe logs an ERROR+WARN. Service discovery is unaffected.
+          endpoints:
+            health:
+              kubernetes:
+                enabled: false
+          kubernetes:
+            client:
+              discovery:
+                mode: endpoint
     envFrom:
       - secretRef:
           name: vulpes-dev-app-db

--- a/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
+++ b/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
@@ -164,9 +164,11 @@ spec:
               leakDetectionThreshold: 20000
               transactionIsolation: TRANSACTION_READ_COMMITTED
         # Loaded only in the Kubernetes (k8s) environment. k8s is listed in
-        # profiles so the micronaut-kubernetes discovery beans activate (explicit
-        # MICRONAUT_ENVIRONMENTS disables auto-deduction). The chart requires one
-        # config file per profile, so this file must exist.
+        # profiles because MICRONAUT_CONFIG_FILES is built from that list -- it
+        # is what makes this file load at all. It does not switch the k8s
+        # environment on: Micronaut deduces that from running in a cluster
+        # regardless of MICRONAUT_ENVIRONMENTS, which is why the discovery beans
+        # come up here whether or not anything asks for them.
         k8s: |-
           # Disable the KubernetesHealthIndicator: the client-java bundled with
           # micronaut-kubernetes 7.1.1 can't deserialize newer API-server pod


### PR DESCRIPTION
`vulpes-backend-dev` came up **0/1** after #225 and stayed there. The pod starts fine — Hibernate connects, the server binds — and then every health probe fails:

```
Health indicator [compositeDiscoveryClient(kubernetes)] reported exception: … 403
endpoints is forbidden: User "system:serviceaccount:vulpes-dev:vulpes-backend-dev-micronaut"
cannot list resource "endpoints" in API group "" in the namespace "vulpes-dev"
```

## Cause

Micronaut activates the `k8s` environment **on its own** inside a cluster. The pod runs with `MICRONAUT_ENVIRONMENTS=prod` and still reports `Established active environments: [k8s, cloud, prod]` — so the micronaut-kubernetes discovery beans come up whether or not anything asked for them, and then need permissions dev never had.

prod has carried the fixes for exactly this since `a80fd96` (RBAC) and `ba59b0a` (disable the broken `KubernetesHealthIndicator`). dev never got them: it was frozen on image 2.3.0, which predates both. Moving it onto the newest release is what surfaced the gap — which is what dev tracking releases is for.

| | prod | dev (before) |
|---|---|---|
| Role/RoleBinding | present | **none** |
| `profiles` | `["prod","k8s"]` | `["prod"]` |
| k8s config (health indicator off) | present | **missing** |
| Status | 2/2 ready | **0/1** |

## Fix

Both settings copied across unchanged. `k8s` joins `profiles` because `MICRONAUT_CONFIG_FILES` is built from that list — that is what makes `application-k8s.yml` load; it does **not** switch the environment on.

The comment in prod claiming that an explicit `MICRONAUT_ENVIRONMENTS` disables auto-deduction is corrected in the same commit: this pod disproves it, and leaving it would send the next reader down the same wrong path.

## Verification

Rendered the overlay against the chart: `Role`, `RoleBinding` and `application-k8s.yml` now appear for dev exactly as they do for prod, and `MICRONAUT_CONFIG_FILES` resolves to `/config/application.yml,/config/application-prod.yml,/config/application-k8s.yml`. `./scripts/validate.sh` passes.

`otis-dev` is unaffected — checked, it has been 1/1 for over two days on its older image.