### PR TITLE
feat(vulpes): allow patch in the backend cors configuration

### DIFF
--- a/apps/clusters/feathre-core/apps/vulpes-backend-dev/release.yaml
+++ b/apps/clusters/feathre-core/apps/vulpes-backend-dev/release.yaml
@@ -99,6 +99,15 @@ spec:
                 stelaris-ui:
                   allowed-origins:
                     - https://stelaris-dev.apps.onelite.feather
+                  # Stelaris sends PATCH for partial updates. Listing the set
+                  # explicitly replaces Micronaut's implicit any-method default.
+                  allowed-methods:
+                    - GET
+                    - POST
+                    - PUT
+                    - PATCH
+                    - DELETE
+                    - OPTIONS
             netty:
               access-logger:
                 enabled: true

--- a/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
+++ b/apps/clusters/feathre-core/apps/vulpes-backend/release.yaml
@@ -97,6 +97,15 @@ spec:
                 stelaris-ui:
                   allowed-origins:
                     - https://stelaris.apps.onelite.feather
+                  # Stelaris sends PATCH for partial updates. Listing the set
+                  # explicitly replaces Micronaut's implicit any-method default.
+                  allowed-methods:
+                    - GET
+                    - POST
+                    - PUT
+                    - PATCH
+                    - DELETE
+                    - OPTIONS
             netty:
               access-logger:
                 enabled: true


### PR DESCRIPTION
## What

The `stelaris-ui` CORS configuration on the Vulpes backend pinned `allowed-origins` but left `allowed-methods` unset. Micronaut treats a missing `allowed-methods` as "any method", so this spells the set out — `GET, POST, PUT, PATCH, DELETE, OPTIONS` — making PATCH explicitly covered instead of incidental.

Applied to both overlays:
- `apps/clusters/feathre-core/apps/vulpes-backend/release.yaml`
- `apps/clusters/feathre-core/apps/vulpes-backend-dev/release.yaml`

## Notes

- No behavioural narrowing: the listed set matches what the implicit default already permitted.
- The `micronaut` chart carries a `checksum/config` annotation on the Deployment, so the pods roll on the Helm upgrade — no manual `rollout restart`.
- If a PATCH preflight still fails after this, the cause is elsewhere: most likely `allowed-headers` (a custom header or `Content-Type: application/merge-patch+json`), or a missing `@Patch` route answering 405 before CORS applies.

## Validation

`./scripts/validate.sh` — 0 invalid, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9romuepQH44Gcuae5pH5v